### PR TITLE
WIP: Implement lazy posting list apply mode for ProjectionIndex

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7417,6 +7417,11 @@ Using the text index header cache can significantly reduce latency and increase 
 Whether to use a cache of deserialized text index posting lists.
 Using the text index postings cache can significantly reduce latency and increase throughput when working with a large number of text index queries.
 )", 0) \
+    DECLARE(String, text_index_posting_list_apply_mode, "materialize", R"(
+Controls how posting lists are applied during projection text index queries.
+'materialize' mode (default) eagerly materializes posting lists into Roaring bitmaps before performing set operations.
+'lazy' mode uses lazy-decoding cursors with adaptive intersection/union algorithms (skip-list leapfrog for sparse, brute-force bitmap for dense), which can significantly reduce memory usage and improve performance for selective queries.
+)", 0) \
     DECLARE(Bool, allow_experimental_window_view, false, R"(
 Enable WINDOW VIEW. Not mature enough.
 )", EXPERIMENTAL) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -101,6 +101,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"query_plan_read_in_order_through_join", false, true, "New setting"},
             {"query_plan_max_limit_for_lazy_materialization", 10, 10000, "Increase the limit after performance improvement"},
             {"text_index_hint_max_selectivity", 0.2, 0.2, "New setting"},
+            {"text_index_posting_list_apply_mode", "materialize", "materialize", "New setting to control how posting lists are applied during projection text index queries"},
             {"allow_experimental_time_time64_type", false, true, "Enable Time and Time64 type by default"},
             {"enable_time_time64_type", false, true, "Enable Time and Time64 type by default"},
             {"use_skip_indexes_for_top_k", false, false, "New setting."},

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -1,0 +1,920 @@
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
+#include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/MergeTreeReaderStream.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
+
+#include <turbopfor.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
+}
+
+namespace
+{
+
+/// Prefix-Based Variable-Length Integer Decoding.
+/// This mirrors the encoding used in PostingListData.cpp (VarInt namespace).
+/// Used for reading compressed block sizes in .lpst files.
+///
+/// Encoding thresholds:
+/// - [0 - 176]        : 1 byte
+/// - [177 - 16560]    : 2 bytes
+/// - [16561 - 540848] : 3 bytes
+/// - [540849 - 2^24-1]: 4 bytes (Marker 249)
+/// - [Up to 2^32-1]   : 5 bytes (Marker 250)
+inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
+{
+    static constexpr UInt32 ONE_BYTE_MAX = 176;
+    static constexpr UInt8 TWO_BYTE_MARKER_END = 240;
+    static constexpr UInt8 THREE_BYTE_MARKER_END = 248;
+    static constexpr UInt8 FOUR_BYTE_MARKER = 249;
+
+    static constexpr UInt32 TWO_BYTE_OFFSET = 177;
+    static constexpr UInt32 THREE_BYTE_OFFSET = 16561;
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+
+    const UInt8 first_byte = *istr.position()++;
+
+    if (first_byte <= ONE_BYTE_MAX)
+    {
+        x = first_byte;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 second_byte = *istr.position()++;
+
+    if (first_byte <= TWO_BYTE_MARKER_END)
+    {
+        x = ((first_byte - 177) << 8) + second_byte + TWO_BYTE_OFFSET;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 third_byte = *istr.position()++;
+
+    if (first_byte <= THREE_BYTE_MARKER_END)
+    {
+        x = ((first_byte - 241) << 16) + (second_byte << 8) + third_byte + THREE_BYTE_OFFSET;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 fourth_byte = *istr.position()++;
+
+    if (first_byte == FOUR_BYTE_MARKER)
+    {
+        x = (second_byte << 16) | (third_byte << 8) | fourth_byte;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 fifth_byte = *istr.position()++;
+    x = (UInt32(second_byte) << 24) | (UInt32(third_byte) << 16) | (UInt32(fourth_byte) << 8) | fifth_byte;
+}
+
+} // anonymous namespace
+
+PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t segment)
+    : stream(stream_)
+    , info(info_)
+{
+    current_values.reserve(TURBOPFOR_BLOCK_SIZE);
+    segments.push_back(segment);
+    prepare(segment);
+}
+
+PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_, size_t segment)
+    : PostingListCursor(nullptr, info_, segment)
+{
+}
+
+void PostingListCursor::addSegment(size_t s)
+{
+    auto it = std::find(segments.begin(), segments.end(), s);
+    if (it == segments.end())
+    {
+        segments.push_back(s);
+        is_valid = true;
+    }
+}
+
+void PostingListCursor::prepare(size_t segment)
+{
+    if (current_segment == segment && current_segment != std::numeric_limits<size_t>::max())
+        return;
+
+    current_values.reserve(TURBOPFOR_BLOCK_SIZE);
+
+    if (info.embedded_postings)
+    {
+        /// Embedded postings: already stored as a Roaring Bitmap.
+        /// Decode all doc IDs into current_values at once.
+        chassert(!stream);
+        current_values.resize(info.embedded_postings->cardinality());
+        info.embedded_postings->toUint32Array(current_values.data());
+        current_block = 0;
+        block_count = 1;
+        current_segment = segment;
+        is_valid = true;
+        is_embedded = true;
+
+        if (current_values.size() >= 2)
+            density_val = static_cast<double>(current_values.size()) / static_cast<double>(current_values.back() - current_values.front() + 1);
+        else
+            density_val = 1.0;
+        return;
+    }
+
+    /// Large posting list: read from LargePostingListReaderStream using TurboPFor encoding.
+    /// Each segment corresponds to one LargePostingBlockMeta.
+    chassert(stream);
+    chassert(segment < info.offsets.size());
+
+    const auto & block_meta = info.offsets[segment];
+    segment_doc_count = block_meta.block_doc_count;
+    segment_first_doc_id = static_cast<UInt32>(info.ranges[segment].begin);
+
+    /// The .lpst file stores `segment_doc_count` delta-encoded doc IDs.
+    /// For segment 0: the delta base is `first_doc_id` (= range.begin), and `first_doc_id`
+    ///                itself is NOT in the .lpst stream (it's stored in metadata).
+    /// For segment N>0: the delta base is `range.begin - 1`, and the docs in .lpst start
+    ///                  from `range.begin` (the base itself is NOT a real doc).
+
+    /// Compute block structure for the delta-encoded portion
+    size_t full_blocks = segment_doc_count / TURBOPFOR_BLOCK_SIZE;
+    tail_size = segment_doc_count % TURBOPFOR_BLOCK_SIZE;
+    block_count = full_blocks + (tail_size > 0 ? 1 : 0);
+
+    /// For segment 0, we have one extra doc (first_doc_id) that is not in any block.
+    /// We treat it as: first_doc_id gets prepended to the first decoded block.
+    /// For other segments, all docs come from the .lpst blocks.
+
+    current_block = 0;
+    current_segment = segment;
+
+    /// Set delta base for p4D1Dec
+    if (segment == 0)
+        last_decoded_doc_id = segment_first_doc_id;
+    else
+        last_decoded_doc_id = segment_first_doc_id - 1;
+
+    /// Seek to the data offset in the .lpst file
+    stream->seek(block_meta.offset);
+
+    /// Compute density
+    const auto & range = info.ranges[segment];
+    UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
+    density_val = (range_span > 0) ? static_cast<double>(segment_doc_count + (segment == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
+
+    if (block_count > 0)
+    {
+        decodeNextBlock();
+
+        /// For segment 0, insert first_doc_id at the beginning of the decoded block.
+        /// p4D1Dec uses `last_decoded_doc_id` (= first_doc_id) as delta base, so the
+        /// decoded values start AFTER first_doc_id. We need to prepend it.
+        if (segment == 0)
+        {
+            current_values.insert(current_values.begin(), segment_first_doc_id);
+        }
+        is_valid = true;
+    }
+    else if (segment == 0)
+    {
+        /// Only first_doc_id, no delta-encoded docs
+        current_values.resize(1);
+        current_values[0] = segment_first_doc_id;
+        block_count = 1;
+        index = 0;
+        is_valid = true;
+    }
+    else
+    {
+        is_valid = false;
+    }
+}
+
+bool PostingListCursor::decodeNextBlock()
+{
+    if (current_block >= block_count)
+        return false;
+
+    chassert(stream);
+
+    auto & data_buf = *stream->getDataBuffer();
+
+    /// Read compressed bytes length (Prefix VarInt encoded in .lpst)
+    UInt32 bytes;
+    readPrefixVarUInt32(bytes, data_buf);
+
+    UInt32 count = (current_block + 1 == block_count && tail_size > 0) ? static_cast<UInt32>(tail_size) : 128U;
+
+    uint8_t * src_ptr;
+    if (data_buf.available() >= bytes)
+    {
+        src_ptr = reinterpret_cast<uint8_t *>(data_buf.position());
+        data_buf.position() += bytes;
+    }
+    else
+    {
+        chassert(bytes <= 512);
+        data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
+        src_ptr = stream->packed_buffer;
+    }
+
+    current_values.resize(count);
+    if (count == 128)
+        turbopfor::p4D1Dec128v32(src_ptr, 128, current_values.data(), last_decoded_doc_id);
+    else
+        turbopfor::p4D1Dec32(src_ptr, count, current_values.data(), last_decoded_doc_id);
+
+    last_decoded_doc_id = current_values[count - 1];
+    index = 0;
+
+    return true;
+}
+
+bool PostingListCursor::decodeBlock(size_t block_index)
+{
+    /// To decode a specific block, we need to decode sequentially from the current position.
+    /// Since TurboPFor is delta-encoded, we can't random-access individual blocks without
+    /// decoding from the beginning of the segment.
+    ///
+    /// However, for seek operations, we re-prepare the segment and decode blocks sequentially.
+    /// This is acceptable because:
+    /// 1. Seek typically moves forward within a segment
+    /// 2. Large posting blocks are already 1MB chunks, so sequential decode is fast
+
+    while (current_block < block_index)
+    {
+        ++current_block;
+        if (!decodeNextBlock())
+            return false;
+    }
+    return true;
+}
+
+void PostingListCursor::seek(uint32_t target)
+{
+    if (!seekImpl(target))
+    {
+        int unused_segment_index = -1;
+        bool found = false;
+        for (size_t i = 0; i < segments.size(); ++i)
+        {
+            auto segment = segments[i];
+            if (segment < current_segment)
+            {
+                unused_segment_index = static_cast<int>(i);
+                continue;
+            }
+            const auto & range = info.ranges[segment];
+            if (range.end >= target)
+            {
+                prepare(segment);
+                if (seekImpl(target))
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (unused_segment_index > 0)
+            maybeEraseUnusedSegments(unused_segment_index);
+        is_valid = found;
+    }
+}
+
+bool PostingListCursor::seekImpl(uint32_t target)
+{
+    /// First check current decoded block
+    if (index < current_values.size())
+    {
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
+        if (it != current_values.end() && *it >= target)
+        {
+            index = static_cast<size_t>(it - current_values.begin());
+            return true;
+        }
+        if (is_embedded)
+            return false;
+    }
+
+    /// For TurboPFor encoded data, we need to decode blocks sequentially
+    /// because delta encoding prevents random block access.
+    /// Advance to the next block and keep looking.
+    ++current_block;
+    while (current_block < block_count)
+    {
+        if (!decodeNextBlock())
+            return false;
+
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
+        if (it != current_values.end() && *it >= target)
+        {
+            index = static_cast<size_t>(it - current_values.begin());
+            return true;
+        }
+        ++current_block;
+    }
+    return false;
+}
+
+void PostingListCursor::next()
+{
+    if (!is_valid)
+        return;
+
+    ++index;
+
+    if (index >= current_values.size())
+    {
+        ++current_block;
+        if (current_block >= block_count)
+        {
+            is_valid = false;
+            return;
+        }
+        decodeNextBlock();
+    }
+}
+
+inline void padColumnForOr(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
+{
+    const uint32_t * data = current_values.data();
+    const uint32_t * data_begin = data + begin;
+    const uint32_t * data_end = data + length;
+
+    if (data_begin >= data_end)
+        return;
+
+    const uint32_t * p = data_begin;
+    const size_t count = data_end - data_begin;
+
+    const uint32_t * loop_end = data_begin + (count / 4) * 4;
+
+    for (; p < loop_end; p += 4)
+    {
+        __builtin_prefetch(p + 16, 0, 3);
+        if (p + 4 < data_end)
+            __builtin_prefetch(&out[p[4] - row_begin], 1, 0);
+
+        out[p[0] - row_begin] = 1;
+        out[p[1] - row_begin] = 1;
+        out[p[2] - row_begin] = 1;
+        out[p[3] - row_begin] = 1;
+    }
+
+    switch (data_end - p)
+    {
+        case 3: out[p[2] - row_begin] = 1; [[fallthrough]];
+        case 2: out[p[1] - row_begin] = 1; [[fallthrough]];
+        case 1: out[p[0] - row_begin] = 1; [[fallthrough]];
+        default: break;
+    }
+}
+
+void PostingListCursor::linearOrImpl(size_t segment, UInt8 * __restrict out, size_t row_begin, size_t row_end)
+{
+    chassert(segment < info.ranges.size());
+
+    if (unlikely(is_embedded))
+    {
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
+        if (it == current_values.end())
+            return;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
+        size_t length = it_end - current_values.begin();
+        padColumnForOr(out, current_values, row_begin, idx, length);
+        return;
+    }
+
+    /// Process the current already-decoded block (block 0 decoded in prepare()),
+    /// then decode subsequent blocks sequentially.
+    for (size_t blk = current_block; blk < block_count; ++blk)
+    {
+        /// For the first iteration, current_values already has the decoded block from prepare().
+        /// For subsequent iterations, decode the next block from the stream.
+        if (blk > current_block)
+        {
+            current_block = blk;
+            if (!decodeNextBlock())
+                return;
+        }
+
+        if (current_values.empty())
+            continue;
+
+        /// Skip blocks entirely before row_begin
+        if (current_values.back() < row_begin)
+            continue;
+
+        /// Skip blocks entirely after row_end
+        if (current_values.front() > row_end)
+            return;
+
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
+        if (it == current_values.end())
+            continue;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
+        size_t length = it_end - current_values.begin();
+
+        padColumnForOr(out, current_values, row_begin, idx, length);
+
+        if (length < current_values.size())
+            return;
+    }
+}
+
+void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_rows)
+{
+    int unused_segment_index = -1;
+    for (size_t i = 0; i < segments.size(); ++i)
+    {
+        auto segment = segments[i];
+        size_t begin = info.ranges[segment].begin;
+        size_t end = info.ranges[segment].end;
+
+        if (row_offset > end || (row_offset + num_rows) < begin)
+        {
+            unused_segment_index = static_cast<int>(i);
+            continue;
+        }
+        end = std::min(end, row_offset + num_rows - 1);
+        prepare(segment);
+        linearOrImpl(segment, data, row_offset, end);
+    }
+    if (unused_segment_index > 0)
+        maybeEraseUnusedSegments(unused_segment_index);
+}
+
+inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
+{
+    const uint32_t *p = current_values.data() + begin;
+    const uint32_t *end = current_values.data() + length;
+
+    for (; p + 4 <= end; p += 4)
+    {
+        __builtin_prefetch(p + 16, 0, 3);
+        if (p + 8 < end)
+            __builtin_prefetch(&out[p[8] - row_begin], 1, 0);
+
+        ++out[p[0] - row_begin];
+        ++out[p[1] - row_begin];
+        ++out[p[2] - row_begin];
+        ++out[p[3] - row_begin];
+    }
+
+    switch (end - p)
+    {
+        case 3: ++out[p[2] - row_begin];
+            [[fallthrough]];
+        case 2: ++out[p[1] - row_begin];
+            [[fallthrough]];
+        case 1: ++out[p[0] - row_begin];
+            [[fallthrough]];
+        default: break;
+    }
+}
+
+void PostingListCursor::linearAndImpl(size_t segment, UInt8 * __restrict out, size_t row_begin, size_t row_end)
+{
+    chassert(segment < info.ranges.size());
+
+    if (unlikely(is_embedded))
+    {
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
+        if (it == current_values.end())
+            return;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
+        size_t length = it_end - current_values.begin();
+        padColumnForAnd(out, current_values, row_begin, idx, length);
+        return;
+    }
+
+    /// Process the current already-decoded block, then decode subsequent blocks sequentially.
+    for (size_t blk = current_block; blk < block_count; ++blk)
+    {
+        if (blk > current_block)
+        {
+            current_block = blk;
+            if (!decodeNextBlock())
+                return;
+        }
+
+        if (current_values.empty())
+            continue;
+
+        if (current_values.back() < row_begin)
+            continue;
+
+        if (current_values.front() > row_end)
+            return;
+
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
+        if (it == current_values.end())
+            continue;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
+        size_t length = it_end - current_values.begin();
+
+        padColumnForAnd(out, current_values, row_begin, idx, length);
+
+        if (length < current_values.size())
+            return;
+    }
+}
+
+void PostingListCursor::linearAnd(UInt8 * data, size_t row_offset, size_t num_rows)
+{
+    int unused_segment_index = -1;
+    for (size_t i = 0; i < segments.size(); ++i)
+    {
+        auto segment = segments[i];
+        size_t begin = info.ranges[segment].begin;
+        size_t end = info.ranges[segment].end;
+
+        if (row_offset > end || (row_offset + num_rows) < begin)
+        {
+            unused_segment_index = static_cast<int>(i);
+            continue;
+        }
+        end = std::min(end, row_offset + num_rows - 1);
+        prepare(segments[i]);
+        linearAndImpl(segment, data, row_offset, end);
+    }
+
+    if (unused_segment_index > 0)
+        maybeEraseUnusedSegments(unused_segment_index);
+}
+
+namespace
+{
+
+/// Helper struct for min-heap based intersection algorithm.
+struct HeapItem
+{
+    uint32_t val = 0;
+    uint32_t idx = 0;
+
+    HeapItem() = default;
+    HeapItem(uint32_t val_, uint32_t idx_) : val(val_), idx(idx_) {}
+    bool operator>(const HeapItem & other) const { return val > other.val; }
+};
+
+/// Two-way merge intersection using skip-list style seek.
+void intersectTwo(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, size_t row_offset, size_t effective_end)
+{
+    while (c0->valid() && c1->valid())
+    {
+        uint32_t v0 = c0->value();
+        uint32_t v1 = c1->value();
+        if (v0 >= effective_end || v1 >= effective_end)
+            return;
+
+        if (v0 == v1)
+        {
+            out[v0 - row_offset] = 1;
+            c0->next();
+            c1->next();
+        }
+        else if (v0 < v1)
+        {
+            c0->seek(v1);
+        }
+        else
+        {
+            c1->seek(v0);
+        }
+    }
+}
+
+/// Three-way merge intersection.
+void intersectThree(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, PostingListCursorPtr c2, size_t row_offset, size_t effective_end)
+{
+    uint32_t v0 = 0;
+    uint32_t v1 = 0;
+    uint32_t v2 = 0;
+    while (c0->valid() && c1->valid() && c2->valid())
+    {
+        v0 = c0->value();
+        v1 = c1->value();
+        v2 = c2->value();
+
+        uint32_t max_val = std::max({v0, v1, v2});
+        if (max_val >= effective_end)
+            return;
+
+        if (v0 == v1 && v1 == v2)
+        {
+            out[v0 - row_offset] = 1;
+
+            c0->next();
+            c1->next();
+            c2->next();
+
+        }
+        else
+        {
+            if (v0 < max_val)
+                c0->seek(max_val);
+            if (v1 < max_val)
+                c1->seek(max_val);
+            if (v2 < max_val)
+                c2->seek(max_val);
+        }
+    }
+}
+
+/// Four-way merge intersection.
+void intersectFour(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, PostingListCursorPtr c2, PostingListCursorPtr c3, size_t row_offset, size_t effective_end)
+{
+    uint32_t v0 = 0;
+    uint32_t v1 = 0;
+    uint32_t v2 = 0;
+    uint32_t v3 = 0;
+    while (c0->valid() && c1->valid() && c2->valid() && c3->valid())
+    {
+        v0 = c0->value();
+        v1 = c1->value();
+        v2 = c2->value();
+        v3 = c3->value();
+
+        uint32_t max_val = std::max({v0, v1, v2, v3});
+        if (max_val >= effective_end)
+            return;
+
+        if (v0 == v1 && v1 == v2 && v2 == v3)
+        {
+            out[v0 - row_offset] = 1;
+
+            c0->next();
+            c1->next();
+            c2->next();
+            c3->next();
+        }
+        else
+        {
+            if (v0 < max_val)
+                c0->seek(max_val);
+            if (v1 < max_val)
+                c1->seek(max_val);
+            if (v2 < max_val)
+                c2->seek(max_val);
+            if (v3 < max_val)
+                c3->seek(max_val);
+        }
+    }
+}
+
+/// Leapfrog intersection with linear min/max scan.
+void intersectLeapfrogLinear(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
+{
+    const size_t n = cursors.size();
+    std::vector<uint32_t> vals(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        vals[i] = cursors[i]->value();
+    }
+
+    while (true)
+    {
+        uint32_t min_val = vals[0];
+        uint32_t max_val = vals[0];
+        size_t min_idx = 0;
+
+        for (size_t i = 1; i < n; ++i)
+        {
+            if (vals[i] < min_val)
+            {
+                min_val = vals[i];
+                min_idx = i;
+            }
+            else if (vals[i] > max_val)
+            {
+                max_val = vals[i];
+            }
+        }
+
+        if (max_val >= effective_end)
+            return;
+
+        if (min_val == max_val)
+        {
+            out[min_val - row_offset] = 1;
+            for (size_t i = 0; i < n; ++i)
+            {
+                cursors[i]->next();
+                if (!cursors[i]->valid())
+                    return;
+                vals[i] = cursors[i]->value();
+            }
+        }
+        else
+        {
+            cursors[min_idx]->seek(max_val);
+            if (!cursors[min_idx]->valid())
+                return;
+            vals[min_idx] = cursors[min_idx]->value();
+        }
+    }
+}
+
+/// Leapfrog intersection using min-heap.
+void intersectLeapfrogHeap(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
+{
+    const size_t n = cursors.size();
+
+    std::vector<HeapItem> heap(n);
+    uint32_t max_val = 0;
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        uint32_t val = cursors[i]->value();
+        heap[i] = {val, static_cast<uint32_t>(i)};
+        max_val = std::max(max_val, val);
+    }
+    std::make_heap(heap.begin(), heap.end(), std::greater<>{});
+
+    while (true)
+    {
+        if (max_val >= effective_end)
+            return;
+
+        uint32_t min_val = heap.front().val;
+
+        if (min_val == max_val)
+        {
+            out[min_val - row_offset] = 1;
+
+            max_val = 0;
+            size_t heap_size = n;
+
+            for (size_t i = 0; i < heap_size; ++i)
+            {
+                uint32_t idx = heap[i].idx;
+                cursors[idx]->next();
+
+                if (!cursors[idx]->valid())
+                    return;
+
+                uint32_t val = cursors[idx]->value();
+                if (val >= effective_end)
+                    return;
+
+                heap[i].val = val;
+                max_val = std::max(max_val, val);
+            }
+            std::make_heap(heap.begin(), heap.end(), std::greater<>{});
+        }
+        else
+        {
+            uint32_t min_idx = heap.front().idx;
+            std::pop_heap(heap.begin(), heap.end(), std::greater<>{});
+
+            cursors[min_idx]->seek(max_val);
+            if (!cursors[min_idx]->valid())
+                return;
+
+            uint32_t new_val = cursors[min_idx]->value();
+            if (new_val >= effective_end)
+                return;
+
+            max_val = std::max(max_val, new_val);
+            heap.back() = {new_val, min_idx};
+            std::push_heap(heap.begin(), heap.end(), std::greater<>{});
+        }
+    }
+}
+
+/// Dispatcher for skip-list based intersection algorithms.
+void intersectLeapfrog(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
+{
+    if (cursors.size() == 2)
+        return intersectTwo(out, cursors[0], cursors[1], row_offset, effective_end);
+
+    if (cursors.size() == 3)
+        return intersectThree(out, cursors[0], cursors[1], cursors[2], row_offset, effective_end);
+
+    if (cursors.size() == 4)
+        return intersectFour(out, cursors[0], cursors[1], cursors[2], cursors[3], row_offset, effective_end);
+
+    if (cursors.size() <= 8)
+        return intersectLeapfrogLinear(out, cursors, row_offset, effective_end);
+
+    return intersectLeapfrogHeap(out, cursors, row_offset, effective_end);
+}
+
+/// Brute-force intersection using bitmap counting.
+void intersectBruteForce(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t num_rows)
+{
+    cursors[0]->linearOr(out, row_offset, num_rows);
+
+    for (size_t i = 1; i < cursors.size(); ++i)
+        cursors[i]->linearAnd(out, row_offset, num_rows);
+
+    size_t n = cursors.size();
+    if (n > 1)
+    {
+        UInt8 * p = out;
+        UInt8 * end = out + num_rows;
+        UInt8 * end_loop = out + (num_rows / 4) * 4;
+        UInt8 n8 = static_cast<UInt8>(n);
+
+        for (; p < end_loop; p += 4)
+        {
+            __builtin_prefetch(p + 64, 0, 3);
+            __builtin_prefetch(p + 64, 1, 0);
+
+            p[0] = (p[0] == n8);
+            p[1] = (p[1] == n8);
+            p[2] = (p[2] == n8);
+            p[3] = (p[3] == n8);
+        }
+
+        while (p < end)
+        {
+            *p = (*p == n8);
+            ++p;
+        }
+    }
+}
+
+} // anonymous namespace
+
+void lazyUnionPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool /*brute_force_apply*/, float /*density_threshold*/)
+{
+    auto & data = assert_cast<DB::ColumnUInt8 &>(column).getData();
+    UInt8 * out = data.data() + column_offset;
+
+    std::vector<PostingListCursorPtr> cursors;
+    cursors.reserve(postings.size());
+    for (const auto & token : search_tokens)
+    {
+        auto it = postings.find(token);
+        if (it != postings.end())
+            cursors.emplace_back(it->second);
+    }
+    for (const auto & cursor : cursors)
+        cursor->linearOr(out, row_offset, num_rows);
+}
+
+void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold)
+{
+    auto & data = assert_cast<DB::ColumnUInt8 &>(column).getData();
+    UInt8 * __restrict out = data.data() + column_offset;
+
+    std::vector<PostingListCursorPtr> cursors;
+    cursors.reserve(postings.size());
+    for (const auto & token : search_tokens)
+    {
+        auto it = postings.find(token);
+        if (it != postings.end())
+            cursors.emplace_back(it->second);
+    }
+    const size_t n = cursors.size();
+    const size_t end = row_offset + num_rows;
+
+    if (n == 0)
+        return;
+
+    if (n == 1)
+    {
+        cursors.front()->linearOr(out, row_offset, num_rows);
+        return;
+    }
+
+    double density = 0;
+    for (size_t i = 0; i < n; ++i)
+        density += cursors[i]->density();
+    density = density / static_cast<double>(n);
+
+    if (n < 256 && (density >= density_threshold || brute_force_apply))
+        return intersectBruteForce(out, cursors, row_offset, num_rows);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        cursors[i]->seek(static_cast<uint32_t>(row_offset));
+        if (!cursors[i]->valid() || cursors[i]->value() >= end)
+            return;
+    }
+
+    return intersectLeapfrog(out, cursors, row_offset, end);
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -1,0 +1,178 @@
+#pragma once
+#include <absl/container/flat_hash_map.h>
+
+#include <base/defines.h>
+#include <base/types.h>
+#include <Common/PODArray.h>
+
+#include <limits>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+namespace DB
+{
+
+struct TokenPostingsInfo;
+class WriteBuffer;
+class ReadBuffer;
+class IColumn;
+struct LargePostingListReaderStream;
+
+/// A cursor for lazily iterating over a compressed posting list stored in
+/// ProjectionIndex format (TurboPFor delta-encoded).
+///
+/// Posting list: a sorted list of row IDs where a token appears.
+/// This cursor decodes blocks on-demand, avoiding full decompression upfront.
+///
+/// Supports two access patterns:
+/// 1. Iterator-style: valid() / value() / next() / seek() - for skip-list intersection
+/// 2. Linear scan: linearOr() / linearAnd() - for brute-force bitmap operations
+///
+/// The posting list may span multiple segments (large blocks). Use addSegment()
+/// to register additional segments before iteration.
+class PostingListCursor
+{
+public:
+    /// Construct a cursor for large posting lists backed by a LargePostingListReaderStream.
+    PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t segment);
+
+    /// Construct a cursor for embedded posting lists (no stream needed).
+    PostingListCursor(const TokenPostingsInfo & info_, size_t segment);
+
+    /// Register an additional segment to iterate over.
+    void addSegment(size_t);
+
+    /// Brute-force: set bits for all row IDs in range [row_offset, row_offset + num_rows).
+    void linearOr(UInt8 * data, size_t row_offset, size_t num_rows);
+
+    /// Brute-force: increment counts for all row IDs in range.
+    void linearAnd(UInt8 * data, size_t row_offset, size_t num_rows);
+
+    /// Move to next row ID.
+    void next();
+
+    /// Returns true if cursor points to a valid row ID.
+    bool valid() const { return is_valid; }
+
+    /// Returns current row ID. Requires valid() == true.
+    uint32_t value() const { return current_values[index]; }
+
+    /// Advance to first row ID >= target.
+    void seek(uint32_t target);
+
+    /// Returns posting list density: count / (max - min + 1).
+    /// Used to decide between skip-list vs brute-force algorithm.
+    double density() const { return density_val; }
+
+private:
+    static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
+
+    /// Load and prepare data for the given segment.
+    void prepare(size_t segment);
+
+    void linearOrImpl(size_t segment, UInt8 *, size_t row_begin, size_t row_end);
+    void linearAndImpl(size_t segment, UInt8 *, size_t row_begin, size_t row_end);
+
+    bool seekImpl(uint32_t target);
+
+    /// Decode the next 128-doc (or tail) block from the .lpst stream.
+    /// Returns false if no more blocks remain in the current segment.
+    bool decodeNextBlock();
+
+    /// Decode a specific block by index within the current segment.
+    bool decodeBlock(size_t block_index);
+
+    inline void maybeEraseUnusedSegments(int unused_segment_index)
+    {
+        chassert(static_cast<size_t>(unused_segment_index) < segments.size());
+        if (unused_segment_index >= 0 && segments.size() > 1)
+        {
+            auto end = segments.begin() + unused_segment_index + 1;
+            for (auto it = segments.begin(); it < end; ++it)
+                seen_segments.erase(*it);
+            segments.erase(segments.begin(), segments.begin() + unused_segment_index + 1);
+        }
+    }
+
+    LargePostingListReaderStream * stream = nullptr;
+
+    const TokenPostingsInfo & info;
+
+    /// Decoded row IDs of current block
+    std::vector<uint32_t> current_values;
+    /// Position within current_values
+    size_t index = 0;
+
+    /// Number of 128-doc blocks in the current segment (including tail block)
+    size_t block_count = 0;
+    /// Current block being iterated
+    size_t current_block = 0;
+    /// Size of the tail block (< 128), or 0 if perfectly aligned
+    size_t tail_size = 0;
+    /// Total doc count in the current segment (for large posting: block_doc_count)
+    UInt32 segment_doc_count = 0;
+    /// The first_doc_id for the current large block (used as delta base)
+    UInt32 segment_first_doc_id = 0;
+    /// Last decoded doc_id (for delta decoding continuity)
+    UInt32 last_decoded_doc_id = 0;
+
+    /// Segments (large blocks) this cursor covers
+    std::vector<size_t> segments;
+    std::unordered_set<size_t> seen_segments;
+    size_t current_segment = std::numeric_limits<size_t>::max();
+
+    bool is_valid = true;
+    bool is_embedded = false;
+    double density_val = 0;
+};
+
+using PostingListCursorPtr = std::shared_ptr<PostingListCursor>;
+using PostingListCursorMap = absl::flat_hash_map<std::string_view, PostingListCursorPtr>;
+
+/// Compute union (OR) of multiple posting lists using lazy decoding.
+///
+/// Used for TextSearchMode::Any - a row matches if it contains ANY of the search tokens.
+/// Iterates through each posting list and sets corresponding bits in the output column.
+///
+/// Note: brute_force_apply and density_threshold parameters are unused in union operation
+/// since linear scan is always used (no optimization benefit from skip-list for OR).
+///
+/// @param column         Output column (UInt8), sets bit to 1 for rows matching any token
+/// @param postings       Map from token to its posting list cursor
+/// @param search_tokens  List of tokens to search (determines iteration order)
+/// @param column_offset  Starting position in output column to write results
+/// @param row_offset     First row ID in the processing range
+/// @param num_rows       Number of rows to process
+/// @param brute_force_apply  Unused (kept for API consistency with intersection)
+/// @param density_threshold  Unused (kept for API consistency with intersection)
+void lazyUnionPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold);
+
+/// Compute intersection (AND) of multiple posting lists using lazy decoding.
+///
+/// Used for TextSearchMode::All - a row matches only if it contains ALL search tokens.
+/// Employs adaptive algorithm selection based on posting list density:
+///
+/// Algorithm selection:
+///   - Single list (n=1): direct linear scan, equivalent to union
+///   - Dense lists (density >= threshold) or brute_force_apply=true:
+///     Uses brute-force bitmap counting - each cursor marks its row IDs,
+///     then count rows where all cursors have set bits (sequential memory access)
+///   - Sparse lists: uses skip-list based leapfrog intersection -
+///     cursors advance together, only decode blocks as needed (fewer elements to process)
+///
+/// The density-based switching optimizes for different access patterns:
+///   - Sparse posting lists: skip-list is faster due to fewer elements
+///   - Dense posting lists: brute-force is faster due to sequential memory access
+///
+/// @param column         Output column (UInt8), sets bit to 1 for rows matching all tokens
+/// @param postings       Map from token to its posting list cursor
+/// @param search_tokens  List of tokens to search (determines which cursors to use)
+/// @param column_offset  Starting position in output column to write results
+/// @param row_offset     First row ID in the processing range
+/// @param num_rows       Number of rows to process
+/// @param brute_force_apply  Force brute-force algorithm regardless of density
+/// @param density_threshold  Switch to brute-force if average density >= this value
+void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold);
+
+}

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -1,9 +1,24 @@
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h>
 
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h>
+#include <Storages/MergeTree/MergeTreeIndexConditionText.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
+
+namespace ProfileEvents
+{
+    extern const Event TextIndexReaderTotalMicroseconds;
+}
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsString text_index_posting_list_apply_mode;
+}
 
 MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     const IMergeTreeReader * main_reader_, MergeTreeIndexWithCondition index_, NamesAndTypesList columns_, bool can_skip_mark_)
@@ -21,6 +36,12 @@ MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     };
 
     deserialization_state = std::make_unique<MergeTreeIndexDeserializationState>(std::move(state));
+
+    /// Determine apply mode from query settings.
+    const auto & condition_text = assert_cast<const MergeTreeIndexConditionText &>(*index.condition);
+    const auto & settings = condition_text.getContext()->getSettingsRef();
+    String mode = settings[Setting::text_index_posting_list_apply_mode];
+    use_lazy_mode = (mode == "lazy");
 }
 
 PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
@@ -30,6 +51,167 @@ PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
     auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
     chassert(granule_projection.large_posting_stream);
     return MergeTreeIndexGranuleProjection::materializeFromTokenInfo(*granule_projection.large_posting_stream, token_info, block_idx);
+}
+
+PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
+{
+    chassert(granule);
+    auto & granule_text = dynamic_cast<MergeTreeIndexGranuleText &>(*granule);
+    const auto & remaining_tokens = granule_text.getRemainingTokens();
+    auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
+
+    PostingListCursorMap result;
+
+    for (const auto & [token, token_info] : remaining_tokens)
+    {
+        if (!useful_tokens.contains(token))
+            continue;
+
+        if (token_info.embedded_postings)
+        {
+            /// For embedded postings, create cursor without stream (it reads from embedded data).
+            auto cursor = std::make_shared<PostingListCursor>(token_info, 0);
+            result.emplace(token, std::move(cursor));
+        }
+        else if (!token_info.offsets.empty())
+        {
+            /// For large postings, create cursor with the large posting stream.
+            /// Each LargePostingBlockMeta in offsets is treated as a segment.
+            chassert(granule_projection.large_posting_stream);
+            auto cursor = std::make_shared<PostingListCursor>(
+                granule_projection.large_posting_stream.get(), token_info, 0);
+            for (size_t s = 1; s < token_info.offsets.size(); ++s)
+                cursor->addSegment(s);
+            result.emplace(token, std::move(cursor));
+        }
+    }
+
+    return result;
+}
+
+void MergeTreeReaderProjectionIndex::ensureCursorMap()
+{
+    if (cursor_map_built)
+        return;
+    cursor_map = buildCursorMap();
+    cursor_map_built = true;
+}
+
+void MergeTreeReaderProjectionIndex::fillColumnLazy(
+    IColumn & column,
+    const String & column_name,
+    size_t column_offset,
+    size_t row_offset,
+    size_t num_rows)
+{
+    auto & column_data = assert_cast<ColumnUInt8 &>(column).getData();
+    const auto & condition_text = assert_cast<const MergeTreeIndexConditionText &>(*index.condition);
+    auto search_query = condition_text.getSearchQueryForVirtualColumn(column_name);
+
+    column_data.resize_fill(column_offset + num_rows, 0);
+
+    if (cursor_map.empty() || search_query->tokens.empty())
+        return;
+
+    /// Use default thresholds for adaptive algorithm selection.
+    constexpr bool brute_force_apply = false;
+    constexpr float density_threshold = 0.5f;
+
+    if (search_query->search_mode == TextSearchMode::Any || cursor_map.size() == 1)
+        lazyUnionPostingLists(column, cursor_map, search_query->tokens, column_offset, row_offset, num_rows, brute_force_apply, density_threshold);
+    else if (search_query->search_mode == TextSearchMode::All)
+        lazyIntersectPostingLists(column, cursor_map, search_query->tokens, column_offset, row_offset, num_rows, brute_force_apply, density_threshold);
+}
+
+size_t MergeTreeReaderProjectionIndex::readRows(
+    size_t from_mark,
+    size_t current_task_last_mark,
+    bool continue_reading,
+    size_t max_rows_to_read,
+    size_t rows_offset,
+    Columns & res_columns)
+{
+    /// In materialize mode, delegate to the base class implementation.
+    if (!use_lazy_mode)
+        return MergeTreeReaderTextIndex::readRows(from_mark, current_task_last_mark, continue_reading, max_rows_to_read, rows_offset, res_columns);
+
+    /// Lazy mode: use PostingListCursor-based intersection/union.
+    ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::TextIndexReaderTotalMicroseconds);
+    const auto & index_granularity = data_part_info_for_read->getIndexGranularity();
+
+    size_t from_row;
+    if (continue_reading)
+    {
+        from_mark = current_mark;
+        from_row = current_row + rows_offset;
+    }
+    else
+    {
+        from_row = index_granularity.getMarkStartingRow(from_mark) + rows_offset;
+    }
+
+    size_t total_rows = data_part_info_for_read->getRowCount();
+    if (from_row < total_rows)
+        max_rows_to_read = std::min(max_rows_to_read, total_rows - from_row);
+    else
+        max_rows_to_read = 0;
+
+    if (res_columns.empty())
+    {
+        ++current_mark;
+        current_row += max_rows_to_read;
+        return max_rows_to_read;
+    }
+
+    size_t read_rows = 0;
+    createEmptyColumns(res_columns);
+
+    while (read_rows < max_rows_to_read)
+    {
+        size_t rows_to_read = std::min(index_granularity.getMarkRows(from_mark), max_rows_to_read - read_rows);
+
+        if (!analyzed_granules.contains(static_cast<UInt32>(from_mark)))
+        {
+            canSkipMark(from_mark, current_task_last_mark);
+        }
+
+        if (!may_be_true_granules.contains(static_cast<UInt32>(from_mark)))
+        {
+            for (const auto & column : res_columns)
+            {
+                auto & column_data = assert_cast<ColumnUInt8 &>(column->assumeMutableRef()).getData();
+                column_data.resize_fill(column->size() + rows_to_read, 0);
+            }
+        }
+        else
+        {
+            /// Build cursor map once (lazy), then reuse for all subsequent marks.
+            ensureCursorMap();
+
+            for (size_t i = 0; i < res_columns.size(); ++i)
+            {
+                auto & column_mutable = res_columns[i]->assumeMutableRef();
+
+                if (is_always_true[i])
+                {
+                    auto & column_data = assert_cast<ColumnUInt8 &>(column_mutable).getData();
+                    column_data.resize_fill(column_mutable.size() + rows_to_read, 1);
+                }
+                else
+                {
+                    fillColumnLazy(column_mutable, columns_to_read[i].name, column_mutable.size(), from_row, rows_to_read);
+                }
+            }
+        }
+
+        ++from_mark;
+        from_row += rows_to_read;
+        read_rows += rows_to_read;
+    }
+
+    current_mark = from_mark;
+    current_row = from_row;
+    return read_rows;
 }
 
 }

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Storages/MergeTree/MergeTreeReaderTextIndex.h>
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
 
 namespace DB
 {
@@ -13,9 +14,38 @@ public:
 
     void prefetchBeginOfRange(Priority /* priority */) override { }
 
+    size_t readRows(
+        size_t from_mark,
+        size_t current_task_last_mark,
+        bool continue_reading,
+        size_t max_rows_to_read,
+        size_t offset,
+        Columns & res_columns) override;
+
 private:
     PostingListPtr
     readPostingsBlockForToken(std::string_view token, const TokenPostingsInfo & token_info, size_t block_idx, PostingListCodecPtr) override;
+
+    /// Build PostingListCursorMap from remaining_tokens.
+    PostingListCursorMap buildCursorMap();
+
+    /// Ensure cursor map is built (called once, lazy).
+    void ensureCursorMap();
+
+    /// Fill column using lazy cursor-based intersection/union.
+    void fillColumnLazy(
+        IColumn & column,
+        const String & column_name,
+        size_t column_offset,
+        size_t row_offset,
+        size_t num_rows);
+
+    /// Whether to use lazy posting list apply mode.
+    bool use_lazy_mode = false;
+
+    /// Lazily-built cursor map, shared across all marks in the part.
+    PostingListCursorMap cursor_map;
+    bool cursor_map_built = false;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):

- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add a new text_index_posting_list_apply_mode setting that introduces a lazy cursor-based posting list evaluation path for ProjectionIndex queries. The existing materialize mode eagerly decodes entire posting lists into Roaring Bitmaps; the new lazy mode decodes TurboPFor-compressed blocks on-demand, reducing memory usage and improving performance for selective queries.

Detailed description / Documentation draft:

In the current materialize mode, every posting list is fully decompressed into a Roaring Bitmap before set operations. For large posting lists or highly selective queries, this is wasteful — most decoded doc IDs are never examined. A lazy cursor can skip entire 128-doc blocks and stop early once the result is determined.
