### PR TITLE
WIP: Implement lazy posting list apply mode for ProjectionIndex

### DIFF
--- a/posting-list-layout-v2.md
+++ b/posting-list-layout-v2.md
@@ -1,0 +1,478 @@
+# `.lpst` 流增加 `last_doc_ids` / `offsets` 后置索引数组（v2）
+
+## 1. 背景与动机
+
+### 1.1 当前架构
+
+当前一个 Large Posting List 包含多个 Large Block，每个 Large Block 包含多个 128-doc delta block（TurboPFor 压缩）。
+
+当前 `.lpst` 流中**只存储** TurboPFor 压缩的 128-doc delta block 数据。每个 large block 的元数据（`last_doc_id` 和 `offset`）**仅存储在 `data.bin` 的 dictionary 流中**。
+
+当前 V1 的 `.lpst` 布局：
+
+```
+Large Block 0:                      Large Block 1:
+┌─────────────────────────┐         ┌─────────────────────────┐
+│ [VarInt: bytes] [P4data]│ ×N      │ [VarInt: bytes] [P4data]│ ×M
+│  (128-doc blocks)       │         │  (128-doc blocks)       │
+└─────────────────────────┘         └─────────────────────────┘
+```
+
+Dictionary 流 (`data.bin`) 中存储 Large Block 级别的定位信息：
+
+```
+[doc_count] [first_doc_id] [num_large_blocks]
+[last_doc_id[0], offset[0]]  [last_doc_id[1], offset[1]] ...
+```
+
+### 1.2 存在的问题
+
+要读取某个 token 的 large posting list 中**任意一个 128-doc block**，必须：
+
+1. 从 dictionary 流中解析出全部 `[last_doc_id, offset]` 对，定位到所属的 large block。
+2. 从 large block 的起始位置**顺序扫描**所有 128-doc block 的 `[VarInt: bytes]` 头部，逐个跳过，直到到达目标 block。
+
+这导致：
+- **无法按 128-doc block 粒度做延迟物化**：当前 `ReaderStreamCursor::loadNextBlock` 必须从 large block 头部顺序读取，无法跳转到中间某个 128-doc block。
+- **对高频 token 的查询代价大**：一个高频 token 可能有数百万文档，分布在成千上万个 128-doc block 中。如果查询只需要某个 doc_id 区间内的数据，仍然需要解码不相关的 block。
+
+### 1.3 目标
+
+在 `.lpst` 流中，每个 large block 的 Data Section **之后**，额外写入一组**后置索引数组**（`last_doc_ids[]` 和 `offsets[]`），索引该 large block 内每个 128-doc block 的位置。
+
+写入时，`addBlock` 直接将 sub-block 数据写入输出流并记录其绝对偏移，无需临时缓存。large block 结束后将收集的元数据一次性写出为 Index Section。
+
+对于V2, Dictionary 流中增加一个字段 `index_offset_in_lpst[i]`, 指向这个Large block的 Index Section在lpst文件中的offset; 而`offset_in_lpst[i]` 还是指向Data Section 起始。普通读路径通过 `offset_in_lpst[i]` 定位数据. 如果要支持lazy方式读, 通过`index_offset_in_lpst[i]` 直接 seek 到 Index Section 读取 packed block 索引，再利用 `absolute_offset[]` 实现 sub-block 级随机定位。
+
+V1 和 V2 区别在于, V2 在dictionary流中有指向index section的offset, 在lpst中有index section的数据.
+
+---
+
+## 2. 格式定义
+
+### 2.1 `data.bin`（dictionary 流）
+
+```
+[PrefixVarInt: doc_count]
+[PrefixVarInt: first_doc_id]
+[PrefixVarInt: num_large_blocks]
+for i in range(num_large_blocks):
+    [PrefixVarInt: last_doc_id[i]]
+    [VarUInt64: offset_in_lpst[i]]
+    [VarUInt64: index_offset_in_lpst[i]]   (V2 only)
+```
+
+- **v1**：每个 large block 存储 `(last_doc_id, offset_in_lpst)` 二元组。`offset_in_lpst[i]` 指向对应 large block 在 `.lpst` 中的 **Data Section 起始位置**。
+- **v2**：每个 large block 存储 `(last_doc_id, offset_in_lpst, index_offset_in_lpst)` 三元组。`offset_in_lpst[i]` **仍然指向 Data Section 起始位置**（与 v1 语义相同），`index_offset_in_lpst[i]` 指向该 large block 的 **Index Section 起始位置**（Data Section 之后）。
+
+### 2.2 `.lpst` 流 — v2 格式
+
+每个 large block 在 `.lpst` 中由两部分组成：**Data Section**（压缩数据）+ **Index Section**（后置索引）。
+
+```
+Large Block i (in .lpst):
+┌──────────────────────────────────────────────────────────┐
+│ Data Section (offset_in_lpst[i] 指向此处)                 │
+│ ┌──────────────────────────────────────────────────────┐ │
+│ │ Sub-block 0:                                         │ │
+│ │   [PrefixVarInt: packed_bytes_len]                   │ │
+│ │   [TurboPFor compressed 128-doc delta data]          │ │
+│ ├──────────────────────────────────────────────────────┤ │
+│ │ Sub-block 1:                                         │ │
+│ │   [PrefixVarInt: packed_bytes_len]                   │ │
+│ │   [TurboPFor compressed 128-doc delta data]          │ │
+│ ├──────────────────────────────────────────────────────┤ │
+│ │ ...                                                  │ │
+│ ├──────────────────────────────────────────────────────┤ │
+│ │ Sub-block K (tail, possibly < 128 docs):             │ │
+│ │   [PrefixVarInt: packed_bytes_len]                   │ │
+│ │   [TurboPFor compressed tail delta data]             │ │
+│ └──────────────────────────────────────────────────────┘ │
+├──────────────────────────────────────────────────────────┤
+│ Index Section (index_offset_in_lpst[i] 指向此处)          │
+│ ┌──────────────────────────────────────────────────────┐ │
+│ │ [PrefixVarInt: num_sub_blocks]                       │ │
+│ │ for j in range(num_sub_blocks):                      │ │
+│ │     [PrefixVarInt: last_doc_id[j]]                   │ │
+│ │ for j in range(num_sub_blocks):                      │ │
+│ │     [VarUInt64: absolute_offset[j]]                  │ │
+│ └──────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `num_sub_blocks` | PrefixVarInt | 该 large block 内的 128-doc sub-block 数量（含尾部 tail block） |
+| `last_doc_id[j]` | PrefixVarInt | 第 j 个 sub-block 中最后一个文档的 doc_id |
+| `absolute_offset[j]` | VarUInt64 | 第 j 个 sub-block 的数据起始位置在 `.lpst` 流中的**绝对字节偏移** |
+
+**设计要点**：
+
+1. **Index Section 位于 Data Section 之后**：写入时 `addBlock` 直接将 sub-block 数据写入 `data_out`，同时记录其绝对偏移。large block 结束后，将收集的元数据写出为 Index Section。**无需临时缓存 Data Section，无需预计算 Index Section 大小，无需迭代收敛**。
+2. **双 offset 设计**：dictionary 流中 `offset_in_lpst[i]` 指向 Data Section 起始，`index_offset_in_lpst[i]` 指向 Index Section 起始。普通读路径（v1 风格顺序读取）通过 `offset_in_lpst[i]` 定位数据；lazy 读路径通过 `index_offset_in_lpst[i]` 定位 Index Section，再利用 `absolute_offset[]` 随机定位到目标 sub-block。
+3. **`last_doc_id[]` 和 `absolute_offset[]` 分开存储**而非交错存储 `(last_doc_id, offset)` 对，目的是查询时可以先只读取 `last_doc_id[]` 数组做二分查找，再按需读取对应的 `absolute_offset`，对 CPU cache 更友好。
+4. **使用绝对偏移**：`absolute_offset[j]` 是第 j 个 sub-block 在 `.lpst` 流中的绝对字节位置。读取时可直接 `seek(absolute_offset[j])` 定位到目标 sub-block，无需额外计算。
+5. **`num_sub_blocks` 的计算**：`num_sub_blocks = ceil(large_block_doc_count / 128)`。当 large block 包含的文档数不是 128 的整数倍时，最后一个 sub-block 是 tail block（文档数 < 128）。
+
+### 2.3 v1 与 v2 的布局对比
+
+v1 格式（无 Index Section）：
+```
+Large Block i:
+┌──────────────────────────────────────────────────────────┐
+│ Data Section (offset_in_lpst[i] 指向此处)                 │
+│   Sub-block 0 ... Sub-block K                            │
+└──────────────────────────────────────────────────────────┘
+```
+
+v2 格式（追加 Index Section + 双 offset）：
+```
+Large Block i:
+┌──────────────────────────────────────────────────────────┐
+│ Data Section (offset_in_lpst[i] 指向此处)                 │
+│   Sub-block 0 ... Sub-block K                            │
+├──────────────────────────────────────────────────────────┤
+│ Index Section (index_offset_in_lpst[i] 指向此处)          │
+│   [num_sub_blocks] [last_doc_ids...] [absolute_offsets...]│
+└──────────────────────────────────────────────────────────┘
+```
+
+v1 和 v2 的 `offset_in_lpst[i]` 语义相同（均指向 Data Section 起始），因此 **v1 读路径可以直接兼容 v2 数据**——v1 reader 通过 `offset_in_lpst[i]` seek 到 Data Section 顺序读取即可，Index Section 位于 Data Section 之后不影响顺序读取（通过 `remaining_count` 控制读取边界）。
+
+---
+
+## 3. 写入路径
+
+### 3.1 `LargePostingBlockWriter` 设计
+
+`LargePostingBlockWriter` 通过 `write_block_index` 参数控制 v1/v2 行为：
+
+- **v1** (`write_block_index = false`)：只写 Data Section，不记录 sub-block 元数据，dictionary 中只写 `(last_doc_id, offset_in_lpst)`
+- **v2** (`write_block_index = true`)：写 Data Section 的同时记录元数据，flush 时追加 Index Section，dictionary 中写 `(last_doc_id, offset_in_lpst, index_offset_in_lpst)`
+
+两种模式下，**Data Section 的写入方式完全相同**（直接写 `data_out`），**`offset_in_lpst` 的语义也完全相同**（均指向 Data Section 起始）。
+
+**成员变量**：
+
+```cpp
+WriteBuffer & meta_out;
+WriteBuffer & data_out;
+
+UInt32 docs_per_large_block;
+bool write_block_index;
+UInt32 docs_in_current_block = 0;
+UInt32 current_block_last_doc_id = 0;
+UInt32 num_large_blocks_written = 0;
+UInt64 large_block_start_offset = 0;   /// Data Section 起始偏移（v1/v2 共用）
+
+std::vector<UInt32> packed_block_last_doc_ids;  /// 仅 v2 使用
+std::vector<UInt64> packed_block_offsets;        /// 仅 v2 使用
+```
+
+**`addBlock`**：
+
+```cpp
+void addBlock(UInt32 last_doc_id, const char * data, UInt32 bytes)
+{
+    if (docs_in_current_block == 0)
+        large_block_start_offset = data_out.count();
+
+    if (write_block_index)
+    {
+        /// Record the absolute offset and last_doc_id of this sub-block before writing.
+        packed_block_last_doc_ids.push_back(last_doc_id);
+        packed_block_offsets.push_back(data_out.count());
+    }
+
+    VarInt::writeVarUInt32(bytes, data_out);
+    data_out.write(data, bytes);
+
+    docs_in_current_block += 128;
+    current_block_last_doc_id = last_doc_id;
+
+    if (docs_in_current_block >= docs_per_large_block)
+        flushLargeBlock();
+}
+```
+
+**`flushLargeBlock`**：
+
+```cpp
+void flushLargeBlock()
+{
+    /// v1/v2 共用: offset_in_lpst 始终指向 Data Section 起始
+    VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
+    writeVarUInt(large_block_start_offset, meta_out);
+
+    if (write_block_index)
+    {
+        /// Data Section is already written. Now append the Index Section.
+        /// Record the Index Section start offset for index_offset_in_lpst.
+        UInt64 index_section_offset = data_out.count();
+
+        UInt32 num_packed_blocks = static_cast<UInt32>(packed_block_last_doc_ids.size());
+
+        VarInt::writeVarUInt32(num_packed_blocks, data_out);
+        for (const auto & id : packed_block_last_doc_ids)
+            VarInt::writeVarUInt32(id, data_out);
+        for (const auto & off : packed_block_offsets)
+            writeVarUInt(off, data_out);
+
+        packed_block_last_doc_ids.clear();
+        packed_block_offsets.clear();
+
+        /// Write index_offset_in_lpst to dictionary stream (v2 only).
+        writeVarUInt(index_section_offset, meta_out);
+    }
+
+    docs_in_current_block = 0;
+    ++num_large_blocks_written;
+}
+```
+
+### 3.2 与旧实现对比
+
+| 方面 | 旧 v2 设计（单 offset 指向 Index） | 新 v2 设计（双 offset） |
+|------|-------------------------------------|------------------------|
+| `offset_in_lpst` 语义 | v2 指向 Index Section | **v1/v2 统一指向 Data Section** |
+| dictionary 流每 large block 字段数 | 2 (last_doc_id, offset) | v1: 2, **v2: 3 (last_doc_id, offset, index_offset)** |
+| v1 读路径兼容 v2 数据 | **不兼容** | **兼容** |
+| 需要 `resolveDataSectionOffset` | 是（merge 路径反查 Data Section） | **不需要** |
+| 临时缓存 | 不需要 | **不需要** |
+| `addBlock` 写入目标 | 直接写 `data_out` | **直接写 `data_out`** |
+
+---
+
+## 4. 读取路径
+
+### 4.1 v1 读路径（兼容 v2 数据）
+
+v1 读路径中 dictionary 流的 `offset_in_lpst` 指向 Data Section 起始，`ReaderStreamCursor` 从该位置顺序读取所有 sub-block，通过 `remaining_count` 控制结束。
+
+在新设计中，**v1 读路径可以直接读取 v2 数据**——因为 v2 的 `offset_in_lpst` 仍然指向 Data Section 起始，Data Section 的内部格式与 v1 完全相同。Index Section 位于 Data Section 之后，v1 reader 通过 `remaining_count` 控制读取边界，不会越界读到 Index Section。
+
+v2 dictionary 流中额外的 `index_offset_in_lpst` 字段对 v1 reader 不可见（v1 reader 不读取该字段）。这要求反序列化代码根据 `format_version` 决定是否读取 `index_offset_in_lpst`。
+
+涉及的函数：
+- `materializeLargeBlockIntoBitmap`：seek 到 `offset_in_lpst`，顺序读取
+- `PostingListStream::write`（merge 读路径）：seek 到 `offset_in_lpst`，顺序读取
+- `PostingListStream::collect`：seek 到 `offset_in_lpst`，顺序读取
+
+### 4.2 v2 读路径 — `PostingListCursor`
+
+v2 读路径通过 `PostingListCursor` 实现，利用 Index Section 实现 sub-block 级别的随机定位。
+
+**定位 Index Section 的方式**：dictionary 流中的 `index_offset_in_lpst[i]` 直接指向 Index Section 起始，`PostingListCursor::prepare` 直接 seek 到该位置读取索引。
+
+v2 读路径的查询流程：
+
+```
+1. 从 dictionary 流获取 large block 列表:
+   [(last_doc_id, offset_in_lpst, index_offset_in_lpst)]
+2. 通过 large block 的 last_doc_id 判断目标 doc_id 范围覆盖哪些 large block
+3. 对需要读取的 large block 调用 prepare(large_block):
+   a. seek 到 index_offset_in_lpst
+   b. 读取 Index Section: num_sub_blocks, last_doc_ids[], absolute_offsets[]
+   c. 不解码任何 packed block，延迟到首次 access
+4. seek(target) 时:
+   a. 在 packed_block_last_doc_ids[] 上 lower_bound(target)，O(log N) 定位目标 packed block j
+   b. seek 到 packed_block_offsets[j]，读取并 TurboPFor 解码
+   c. 在解码结果中 lower_bound(target) 定位具体 doc_id
+5. next() / linearOr() / linearAnd() 顺序遍历时:
+   依次解码后续 packed block，无需 seek（流式顺序读取）
+```
+
+### 4.3 读路径选择
+
+对于 v2 数据，有两种读取方式可选：
+
+- **顺序读取**（v1 风格）：通过 `offset_in_lpst` seek 到 Data Section，顺序解码所有 sub-block。适用于需要物化整个 large block 的场景（如 `materializeLargeBlockIntoBitmap`）。
+- **随机定位**（v2 Cursor）：通过 `index_offset_in_lpst` seek 到 Index Section，利用索引做 sub-block 级别的随机访问。适用于只需要特定 doc_id 范围内数据的场景。
+
+两种读路径可以共存——同一份 v2 数据既支持顺序读取也支持随机定位。
+
+---
+
+## 5. Merge 路径
+
+### 5.1 `PostingListStream::write` — 使用新格式
+
+Merge 时 `PostingListStream::write` 通过 `mergePostingCursors` 做多路归并排序后写出。输出路径复用改造后的 `LargePostingBlockWriter`，可选产生 v2 格式（带 Index Section）的 `.lpst` 数据。
+
+由于新设计中 `offset_in_lpst` 始终指向 Data Section 起始（与 v1 语义一致），merge 的读取端**不再需要 `resolveDataSectionOffset` 来反查 Data Section 位置**——直接使用 `offset_in_lpst` 即可 seek 到 Data Section 顺序读取。
+
+### 5.2 `PostingListStream::merge` — 无需修改
+
+`PostingListStream::merge` 操作的是内存中的 `LazyPostingStream` 和 `ReaderStreamVector`，不涉及磁盘格式。merge 路径只在最终 `write` 时才序列化到磁盘，此时由新的 `LargePostingBlockWriter` 处理。
+
+---
+
+## 6. 空间开销分析
+
+### 6.1 Index Section 大小估算
+
+每个 large block 的 Index Section 包含：
+- 1 个 `num_sub_blocks`（PrefixVarInt，通常 1-2 字节）
+- N 个 `last_doc_id`（PrefixVarInt，每个 1-5 字节，通常 3-4 字节）
+- N 个 `absolute_offset`（VarUInt64，每个 1-9 字节，通常 4-6 字节）
+
+其中 N = `docs_per_large_block / 128`。
+
+| `posting_list_block_size` | N (sub-blocks) | Index Section 大小估算 |
+|---------------------------|----------------|----------------------|
+| 1M (默认) | 8192 | ~56-80 KB |
+| 128K | 1024 | ~7-10 KB |
+| 16K | 128 | ~896 B - 1.2 KB |
+
+### 6.2 与 Data Section 的比例
+
+一个包含 1M 文档的 large block，Data Section 大小取决于 TurboPFor 压缩率，通常 1-4 字节/文档，约 1-4 MB。Index Section 约 56-80 KB，**额外开销约 1.5-8%**。
+
+### 6.3 Dictionary 流额外开销
+
+v2 每个 large block 在 dictionary 流中额外存储一个 `index_offset_in_lpst`（VarUInt64，通常 4-6 字节）。对于一个 3M 文档的 token（3 个 large block），额外 12-18 字节，可忽略不计。
+
+### 6.4 与 dictionary 流的冗余
+
+Dictionary 流中每个 large block 存储 `(last_doc_id, offset_in_lpst[, index_offset_in_lpst])` 元组。Index Section 存储 N 个 sub-block 的索引。两者不冗余——dictionary 流提供 large block 级定位，Index Section 提供 sub-block 级定位。
+
+---
+
+## 7. 示例
+
+假设一个 token 有 `doc_count = 3,000,000`，`posting_list_block_size = 1M`（对齐后 1,048,576），则：
+
+- `large_doc_count = 2,999,999`（第一个 doc_id 内联）
+- `num_large_blocks = ceil(2,999,999 / 1,048,576) = 3`
+- Large Block 0: 1,048,576 docs -> `num_sub_blocks = 1,048,576 / 128 = 8,192`
+- Large Block 1: 1,048,576 docs -> `num_sub_blocks = 8,192`
+- Large Block 2: 902,847 docs -> `num_sub_blocks = ceil(902,847 / 128) = 7,054`
+
+**Dictionary 流** (`data.bin`)：
+```
+[VarInt: 3000000]                       // doc_count
+[VarInt: 42]                            // first_doc_id (示例)
+[VarInt: 3]                             // num_large_blocks
+
+// large block 0:
+[VarInt: 1200000]                       // last_doc_id
+[VarUInt64: 0]                          // offset_in_lpst → Data Section 0 起始
+[VarUInt64: ~4.0MB]                     // index_offset_in_lpst → Index Section 0 起始 (V2 only)
+
+// large block 1:
+[VarInt: 2500000]                       // last_doc_id
+[VarUInt64: ~4.08MB]                    // offset_in_lpst → Data Section 1 起始
+[VarUInt64: ~8.1MB]                     // index_offset_in_lpst → Index Section 1 起始 (V2 only)
+
+// large block 2:
+[VarInt: 3500000]                       // last_doc_id
+[VarUInt64: ~8.18MB]                    // offset_in_lpst → Data Section 2 起始
+[VarUInt64: ~12.1MB]                    // index_offset_in_lpst → Index Section 2 起始 (V2 only)
+```
+
+**`.lpst` 流中 Large Block 0 的结构**（v2）：
+```
+offset 0:       === Large Block 0 Data Section === (offset_in_lpst[0] 指向此处)
+                [VarInt: 240] [P4 data: 128-doc block 0]
+                [VarInt: 238] [P4 data: 128-doc block 1]
+                ...
+                [VarInt: 242] [P4 data: 128-doc block 8191]
+offset ~4.0MB:  === Large Block 0 Index Section === (index_offset_in_lpst[0] 指向此处)
+                [VarInt: 8192]                            // num_sub_blocks
+                [VarInt: 170] [VarInt: 298] ... (x8192)   // last_doc_ids
+                [VarUInt64: 0] [VarUInt64: 242] ... (x8192)  // absolute_offsets
+offset ~4.08MB: === Large Block 1 Data Section === (offset_in_lpst[1] 指向此处)
+                ...
+```
+
+**查询示例 1**（v1 风格顺序读取）：物化 Large Block 1 的全部文档
+
+1. Dictionary 流: 获取 `offset_in_lpst[1] = ~4.08MB`
+2. seek 到 `~4.08MB`（Data Section 1 起始）
+3. 顺序读取 8,192 个 sub-block，逐个解码为 bitmap
+
+**查询示例 2**（v2 Cursor 随机定位）：查找 `doc_id = 1,800,000`
+
+1. Dictionary 流: `last_doc_id[0]=1200000 < 1800000 <= last_doc_id[1]=2500000` -> 需要 Large Block 1
+2. seek 到 `index_offset_in_lpst[1]`（Index Section 1 起始）
+3. 读取 Index Section: `num_sub_blocks=8192`, `last_doc_ids[0..8191]`, `absolute_offsets[0..8191]`
+4. 二分查找 `last_doc_ids[]`: 找到 `j` 使得 `last_doc_ids[j-1] < 1800000 <= last_doc_ids[j]`
+5. 直接 seek 到 `absolute_offsets[j]`
+6. 读取并解码该 128-doc block
+7. 在解码结果中查找 `doc_id = 1,800,000`
+
+---
+
+## 8. 关键实现要点
+
+### 8.1 `absolute_offset` 的计算
+
+由于 Index Section 位于 Data Section 之后，`absolute_offset[j]` 在 `addBlock` 写入时就已确定（= `data_out.count()`，即写入前的当前流位置）。**无需预计算 Index Section 大小，无需迭代收敛**。这是将 Index Section 放在 Data Section 之后的核心优势。
+
+读取时拿到 `absolute_offset[j]` 后可直接 `seek(absolute_offset[j])`，无需知道 Data Section 或 Index Section 的起始位置。
+
+### 8.2 delta 解码基准
+
+当从 large block 中间的某个 sub-block 开始读取时，delta 解码需要一个 base doc_id。对于 sub-block j：
+
+- `j == 0` 且是 large block 0：base = `first_doc_id`（来自 dictionary 流），且 `first_doc_id` 本身也包含在结果中。
+- `j == 0` 且不是 large block 0：base = 前一个 large block 的 `last_doc_id`（来自 dictionary 流）。
+- `j > 0`：base = `last_doc_ids[j-1]`（来自 Index Section）。
+
+这是 v2 Index Section 存储 `last_doc_ids[]` 的关键原因——不仅用于二分查找定位，还充当 sub-block 级别的 delta 解码基准。
+
+### 8.3 尾部 sub-block
+
+每个 large block 的最后一个 sub-block 可能是 tail block（包含 < 128 个文档）。Index Section 中它与普通 sub-block 无区别——`last_doc_id` 和 `absolute_offset` 正常记录。读取时通过 `remaining_count` 判断实际文档数。
+
+### 8.4 内存使用
+
+读取 Index Section 时需要在内存中持有 `last_doc_ids[]` 和 `absolute_offsets[]` 数组。对于默认的 `posting_list_block_size = 1M`，N = 8192，内存开销约 8192 * (4 + 8) = 96 KB。这在可接受范围内，且可通过减小 `posting_list_block_size` 进一步控制。
+
+### 8.5 v1 与 v2 的兼容性
+
+新设计中 `offset_in_lpst` 的语义在 v1 和 v2 之间**完全一致**（均指向 Data Section 起始），因此：
+
+- **v1 读路径可以读取 v2 数据**：v1 reader 只使用 `offset_in_lpst` seek 到 Data Section 顺序读取，忽略 `index_offset_in_lpst`。Index Section 位于 Data Section 之后，不影响顺序读取（通过 `remaining_count` 控制边界）。
+- **v2 读路径可以读取 v1 数据**：v1 数据没有 `index_offset_in_lpst` 字段，v2 reader 退化为 v1 风格的顺序读取（不使用 lazy cursor）。
+- **v2 数据反序列化兼容**：反序列化 dictionary 流时，根据 `format_version` 决定是否读取 `index_offset_in_lpst` 字段。v1 格式不包含该字段，v2 格式包含。
+
+这消除了旧设计中的不兼容问题，简化了 merge 路径的实现。
+
+### 8.6 dictionary 流的反序列化
+
+反序列化 dictionary 流中 large block 元信息时，需要根据 `format_version` 区分处理：
+
+```cpp
+for (UInt32 i = 0; i < num_large_blocks; ++i)
+{
+    readPrefixVarUInt32(last_doc_id, buf);
+    readVarUInt(offset_in_lpst, buf);
+
+    if (postingListFormatHasBlockIndex(format_version))
+        readVarUInt(index_offset_in_lpst, buf);
+}
+```
+
+`LargeBlockMeta` 结构需要增加 `index_offset_in_lpst` 字段（v1 数据中该字段为 0 或未设置）。
+
+---
+
+## 9. 与 V1 格式对比总结
+
+| 方面 | V1 | V2 |
+|------|----|----|
+| Large Block 布局 | 仅 Data Section | Data Section + Index Section |
+| Index Section 位置 | 无 | Data Section **之后** |
+| `offset_in_lpst` 指向 | Data Section 起始 | Data Section 起始（**与 v1 相同**） |
+| `index_offset_in_lpst` | 无 | **Index Section 起始** |
+| Dictionary 流每 block 字段 | `(last_doc_id, offset)` | `(last_doc_id, offset, index_offset)` |
+| Sub-block offset 类型 | 无 | 绝对偏移（VarUInt64） |
+| Sub-block 定位 | 顺序扫描 | Index Section 二分查找 + 直接 seek |
+| 写入临时缓存 | 无 | **无**（直接写入） |
+| 额外空间开销 | 无 | ~1.5-8%（Index Section）+ 每 block ~5 字节（dictionary 流） |
+| 读取放大 | 读整个 large block | 可选：读整个 large block **或** 读 Index Section + 目标 sub-block(s) |
+| v1 读路径兼容 v2 数据 | — | **兼容** |
+| v2 读路径兼容 v1 数据 | — | **兼容**（退化为顺序读取） |

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -120,6 +120,12 @@
     M(TextIndexUsedEmbeddedPostings, "Number of times a posting list embedded in the dictionary has been used.", ValueType::Number) \
     M(TextIndexUseHint, "Number of index granules where a direct reading from the text index was added as hint and was used.", ValueType::Number) \
     M(TextIndexDiscardHint, "Number of index granules where a direct reading from the text index was added as hint and was discarded due to low selectivity.", ValueType::Number) \
+    M(TextIndexLazyPackedBlocksDecoded, "Number of packed blocks decoded via TurboPFor in the lazy posting list cursor path.", ValueType::Number) \
+    M(TextIndexLazyPackedBlocksSkipped, "Number of packed blocks skipped (arithmetic sequence) in the lazy posting list cursor path.", ValueType::Number) \
+    M(TextIndexLazySeekCount, "Number of seek calls on lazy posting list cursors.", ValueType::Number) \
+    M(TextIndexLazyLargeBlocksPrepared, "Number of large block Index Sections loaded by lazy posting list cursors.", ValueType::Number) \
+    M(TextIndexLazyBruteForceIntersections, "Number of times the brute-force intersection algorithm was chosen for lazy posting list cursors.", ValueType::Number) \
+    M(TextIndexLazyLeapfrogIntersections, "Number of times the leapfrog intersection algorithm was chosen for lazy posting list cursors.", ValueType::Number) \
     M(QueryConditionCacheHits, "Number of times an entry has been found in the query condition cache (and reading of marks can be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
     M(QueryConditionCacheMisses, "Number of times an entry has not been found in the query condition cache (and reading of mark cannot be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
     M(QueryCacheHits, "Number of times a query result has been found in the query cache (and query computation was avoided). Only updated for SELECT queries with SETTING use_query_cache = 1.", ValueType::Number) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7417,6 +7417,11 @@ Using the text index header cache can significantly reduce latency and increase 
 Whether to use a cache of deserialized text index posting lists.
 Using the text index postings cache can significantly reduce latency and increase throughput when working with a large number of text index queries.
 )", 0) \
+    DECLARE(String, text_index_posting_list_apply_mode, "materialize", R"(
+Controls how posting lists are applied during projection text index queries.
+'materialize' mode (default) eagerly materializes posting lists into Roaring bitmaps before performing set operations.
+'lazy' mode uses lazy-decoding cursors with adaptive intersection/union algorithms (skip-list leapfrog for sparse, brute-force bitmap for dense), which can significantly reduce memory usage and improve performance for selective queries.
+)", 0) \
     DECLARE(Bool, allow_experimental_window_view, false, R"(
 Enable WINDOW VIEW. Not mature enough.
 )", EXPERIMENTAL) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7421,6 +7421,12 @@ Using the text index postings cache can significantly reduce latency and increas
 Controls how posting lists are applied during projection text index queries.
 'materialize' mode (default) eagerly materializes posting lists into Roaring bitmaps before performing set operations.
 'lazy' mode uses lazy-decoding cursors with adaptive intersection/union algorithms (skip-list leapfrog for sparse, brute-force bitmap for dense), which can significantly reduce memory usage and improve performance for selective queries.
+Note: 'lazy' mode requires V2 posting list format (with block index). V1 data always uses 'materialize' regardless of this setting.
+)", 0) \
+    DECLARE(Float, text_index_density_threshold, 0.5, R"(
+Density threshold for adaptive algorithm selection in lazy posting list mode.
+When the minimum posting list density (cardinality / range_span) across all search terms meets or exceeds this threshold, the brute-force bitmap intersection algorithm is used. Below this threshold, the skip-list leapfrog algorithm is used instead.
+Higher values favor leapfrog (better for sparse queries), lower values favor brute-force (better for dense queries).
 )", 0) \
     DECLARE(Bool, allow_experimental_window_view, false, R"(
 Enable WINDOW VIEW. Not mature enough.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -101,6 +101,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"query_plan_read_in_order_through_join", false, true, "New setting"},
             {"query_plan_max_limit_for_lazy_materialization", 10, 10000, "Increase the limit after performance improvement"},
             {"text_index_hint_max_selectivity", 0.2, 0.2, "New setting"},
+            {"text_index_posting_list_apply_mode", "materialize", "materialize", "New setting to control how posting lists are applied during projection text index queries"},
             {"allow_experimental_time_time64_type", false, true, "Enable Time and Time64 type by default"},
             {"enable_time_time64_type", false, true, "Enable Time and Time64 type by default"},
             {"use_skip_indexes_for_top_k", false, false, "New setting."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -102,6 +102,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"query_plan_max_limit_for_lazy_materialization", 10, 10000, "Increase the limit after performance improvement"},
             {"text_index_hint_max_selectivity", 0.2, 0.2, "New setting"},
             {"text_index_posting_list_apply_mode", "materialize", "materialize", "New setting to control how posting lists are applied during projection text index queries"},
+            {"text_index_density_threshold", 0.5, 0.5, "New setting for adaptive algorithm selection threshold in lazy posting list mode"},
             {"allow_experimental_time_time64_type", false, true, "Enable Time and Time64 type by default"},
             {"enable_time_time64_type", false, true, "Enable Time and Time64 type by default"},
             {"use_skip_indexes_for_top_k", false, false, "New setting."},

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -76,7 +76,7 @@ public:
                 "Derived RESERVED_BITS must be greater than parent's");
         }
 
-        return *reinterpret_cast<BitfieldStruct *>(&flags_storage);
+        return *std::launder(reinterpret_cast<BitfieldStruct *>(&flags_storage));
     }
 
     template <typename BitfieldStruct>
@@ -94,7 +94,7 @@ public:
                 "Derived RESERVED_BITS must be greater than parent's");
         }
 
-        return *reinterpret_cast<const BitfieldStruct *>(&flags_storage);
+        return *std::launder(reinterpret_cast<const BitfieldStruct *>(&flags_storage));
     }
 
     UInt32 use_count() const noexcept { return ref_counter.load(std::memory_order_relaxed); }

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1236,6 +1236,7 @@ static const String ARGUMENT_DICTIONARY_BLOCK_SIZE = "dictionary_block_size";
 static const String ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION = "dictionary_block_frontcoding_compression";
 static const String ARGUMENT_POSTING_LIST_BLOCK_SIZE = "posting_list_block_size";
 static const String ARGUMENT_POSTING_LIST_CODEC = "posting_list_codec";
+static const String ARGUMENT_POSTING_LIST_VERSION = "posting_list_version";
 
 namespace
 {
@@ -1381,11 +1382,13 @@ MergeTreeIndexText::parseTextIndexArguments(const String & index_name, const Fie
     };
     auto posting_list_codec = PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, allowed_codecs, index_name);
 
+    UInt64 posting_list_version = extractOption<UInt64>(options, ARGUMENT_POSTING_LIST_VERSION).value_or(2);
+
     if (!options.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));
 
     MergeTreeIndexTextParams index_params{
-        dictionary_block_size, dictionary_block_frontcoding_compression, posting_list_block_size, preprocessor};
+        dictionary_block_size, dictionary_block_frontcoding_compression, posting_list_block_size, preprocessor, posting_list_version};
 
     return {std::move(index_params), std::move(token_extractor), std::move(posting_list_codec)};
 }
@@ -1423,6 +1426,10 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be greater than 0, but got {}", ARGUMENT_POSTING_LIST_BLOCK_SIZE, posting_list_block_size);
 
     extractOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
+
+    UInt64 posting_list_version = extractOption<UInt64>(options, ARGUMENT_POSTING_LIST_VERSION).value_or(2);
+    if (posting_list_version != 1 && posting_list_version != 2)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be 1 or 2, but got {}", ARGUMENT_POSTING_LIST_VERSION, posting_list_version);
 
     auto preprocessor = extractOption<String>(options, ARGUMENT_PREPROCESSOR, false);
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -80,6 +80,7 @@ struct MergeTreeIndexTextParams
     size_t dictionary_block_frontcoding_compression = 1;
     size_t posting_list_block_size = 1024 * 1024;
     String preprocessor;
+    size_t posting_list_version = 2;
 };
 
 using PostingList = roaring::Roaring;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -1,0 +1,920 @@
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
+#include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/MergeTreeReaderStream.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
+
+#include <turbopfor.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
+}
+
+namespace
+{
+
+/// Prefix-Based Variable-Length Integer Decoding.
+/// This mirrors the encoding used in PostingListData.cpp (VarInt namespace).
+/// Used for reading compressed block sizes in .lpst files.
+///
+/// Encoding thresholds:
+/// - [0 - 176]        : 1 byte
+/// - [177 - 16560]    : 2 bytes
+/// - [16561 - 540848] : 3 bytes
+/// - [540849 - 2^24-1]: 4 bytes (Marker 249)
+/// - [Up to 2^32-1]   : 5 bytes (Marker 250)
+inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
+{
+    static constexpr UInt32 ONE_BYTE_MAX = 176;
+    static constexpr UInt8 TWO_BYTE_MARKER_END = 240;
+    static constexpr UInt8 THREE_BYTE_MARKER_END = 248;
+    static constexpr UInt8 FOUR_BYTE_MARKER = 249;
+
+    static constexpr UInt32 TWO_BYTE_OFFSET = 177;
+    static constexpr UInt32 THREE_BYTE_OFFSET = 16561;
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+
+    const UInt8 first_byte = *istr.position()++;
+
+    if (first_byte <= ONE_BYTE_MAX)
+    {
+        x = first_byte;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 second_byte = *istr.position()++;
+
+    if (first_byte <= TWO_BYTE_MARKER_END)
+    {
+        x = ((first_byte - 177) << 8) + second_byte + TWO_BYTE_OFFSET;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 third_byte = *istr.position()++;
+
+    if (first_byte <= THREE_BYTE_MARKER_END)
+    {
+        x = ((first_byte - 241) << 16) + (second_byte << 8) + third_byte + THREE_BYTE_OFFSET;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 fourth_byte = *istr.position()++;
+
+    if (first_byte == FOUR_BYTE_MARKER)
+    {
+        x = (second_byte << 16) | (third_byte << 8) | fourth_byte;
+        return;
+    }
+
+    if (istr.eof()) [[unlikely]]
+        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+    const UInt8 fifth_byte = *istr.position()++;
+    x = (UInt32(second_byte) << 24) | (UInt32(third_byte) << 16) | (UInt32(fourth_byte) << 8) | fifth_byte;
+}
+
+} // anonymous namespace
+
+PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t segment)
+    : stream(stream_)
+    , info(info_)
+{
+    current_values.reserve(TURBOPFOR_BLOCK_SIZE);
+    segments.push_back(segment);
+    prepare(segment);
+}
+
+PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_, size_t segment)
+    : PostingListCursor(nullptr, info_, segment)
+{
+}
+
+void PostingListCursor::addSegment(size_t s)
+{
+    auto it = std::find(segments.begin(), segments.end(), s);
+    if (it == segments.end())
+    {
+        segments.push_back(s);
+        is_valid = true;
+    }
+}
+
+void PostingListCursor::prepare(size_t segment)
+{
+    if (current_segment == segment && current_segment != std::numeric_limits<size_t>::max())
+        return;
+
+    current_values.reserve(TURBOPFOR_BLOCK_SIZE);
+
+    if (info.embedded_postings)
+    {
+        /// Embedded postings: already stored as a Roaring Bitmap.
+        /// Decode all doc IDs into current_values at once.
+        chassert(!stream);
+        current_values.resize(info.embedded_postings->cardinality());
+        info.embedded_postings->toUint32Array(current_values.data());
+        current_block = 0;
+        block_count = 1;
+        current_segment = segment;
+        is_valid = true;
+        is_embedded = true;
+
+        if (current_values.size() >= 2)
+            density_val = static_cast<double>(current_values.size()) / static_cast<double>(current_values.back() - current_values.front() + 1);
+        else
+            density_val = 1.0;
+        return;
+    }
+
+    /// Large posting list: read from LargePostingListReaderStream using TurboPFor encoding.
+    /// Each segment corresponds to one LargePostingBlockMeta.
+    chassert(stream);
+    chassert(segment < info.offsets.size());
+
+    const auto & block_meta = info.offsets[segment];
+    segment_doc_count = block_meta.block_doc_count;
+    segment_first_doc_id = static_cast<UInt32>(info.ranges[segment].begin);
+
+    /// The .lpst file stores `segment_doc_count` delta-encoded doc IDs.
+    /// For segment 0: the delta base is `first_doc_id` (= range.begin), and `first_doc_id`
+    ///                itself is NOT in the .lpst stream (it's stored in metadata).
+    /// For segment N>0: the delta base is `range.begin - 1`, and the docs in .lpst start
+    ///                  from `range.begin` (the base itself is NOT a real doc).
+
+    /// Compute block structure for the delta-encoded portion
+    size_t full_blocks = segment_doc_count / TURBOPFOR_BLOCK_SIZE;
+    tail_size = segment_doc_count % TURBOPFOR_BLOCK_SIZE;
+    block_count = full_blocks + (tail_size > 0 ? 1 : 0);
+
+    /// For segment 0, we have one extra doc (first_doc_id) that is not in any block.
+    /// We treat it as: first_doc_id gets prepended to the first decoded block.
+    /// For other segments, all docs come from the .lpst blocks.
+
+    current_block = 0;
+    current_segment = segment;
+
+    /// Set delta base for p4D1Dec
+    if (segment == 0)
+        last_decoded_doc_id = segment_first_doc_id;
+    else
+        last_decoded_doc_id = segment_first_doc_id - 1;
+
+    /// Seek to the data offset in the .lpst file
+    stream->seek(block_meta.offset);
+
+    /// Compute density
+    const auto & range = info.ranges[segment];
+    UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
+    density_val = (range_span > 0) ? static_cast<double>(segment_doc_count + (segment == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
+
+    if (block_count > 0)
+    {
+        decodeNextBlock();
+
+        /// For segment 0, insert first_doc_id at the beginning of the decoded block.
+        /// p4D1Dec uses `last_decoded_doc_id` (= first_doc_id) as delta base, so the
+        /// decoded values start AFTER first_doc_id. We need to prepend it.
+        if (segment == 0)
+        {
+            current_values.insert(current_values.begin(), segment_first_doc_id);
+        }
+        is_valid = true;
+    }
+    else if (segment == 0)
+    {
+        /// Only first_doc_id, no delta-encoded docs
+        current_values.resize(1);
+        current_values[0] = segment_first_doc_id;
+        block_count = 1;
+        index = 0;
+        is_valid = true;
+    }
+    else
+    {
+        is_valid = false;
+    }
+}
+
+bool PostingListCursor::decodeNextBlock()
+{
+    if (current_block >= block_count)
+        return false;
+
+    chassert(stream);
+
+    auto & data_buf = *stream->getDataBuffer();
+
+    /// Read compressed bytes length (Prefix VarInt encoded in .lpst)
+    UInt32 bytes;
+    readPrefixVarUInt32(bytes, data_buf);
+
+    UInt32 count = (current_block + 1 == block_count && tail_size > 0) ? static_cast<UInt32>(tail_size) : 128U;
+
+    uint8_t * src_ptr;
+    if (data_buf.available() >= bytes)
+    {
+        src_ptr = reinterpret_cast<uint8_t *>(data_buf.position());
+        data_buf.position() += bytes;
+    }
+    else
+    {
+        chassert(bytes <= 512);
+        data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
+        src_ptr = stream->packed_buffer;
+    }
+
+    current_values.resize(count);
+    if (count == 128)
+        turbopfor::p4D1Dec128v32(src_ptr, 128, current_values.data(), last_decoded_doc_id);
+    else
+        turbopfor::p4D1Dec32(src_ptr, count, current_values.data(), last_decoded_doc_id);
+
+    last_decoded_doc_id = current_values[count - 1];
+    index = 0;
+
+    return true;
+}
+
+bool PostingListCursor::decodeBlock(size_t block_index)
+{
+    /// To decode a specific block, we need to decode sequentially from the current position.
+    /// Since TurboPFor is delta-encoded, we can't random-access individual blocks without
+    /// decoding from the beginning of the segment.
+    ///
+    /// However, for seek operations, we re-prepare the segment and decode blocks sequentially.
+    /// This is acceptable because:
+    /// 1. Seek typically moves forward within a segment
+    /// 2. Large posting blocks are already 1MB chunks, so sequential decode is fast
+
+    while (current_block < block_index)
+    {
+        ++current_block;
+        if (!decodeNextBlock())
+            return false;
+    }
+    return true;
+}
+
+void PostingListCursor::seek(uint32_t target)
+{
+    if (!seekImpl(target))
+    {
+        int unused_segment_index = -1;
+        bool found = false;
+        for (size_t i = 0; i < segments.size(); ++i)
+        {
+            auto segment = segments[i];
+            if (segment < current_segment)
+            {
+                unused_segment_index = static_cast<int>(i);
+                continue;
+            }
+            const auto & range = info.ranges[segment];
+            if (range.end >= target)
+            {
+                prepare(segment);
+                if (seekImpl(target))
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (unused_segment_index > 0)
+            maybeEraseUnusedSegments(unused_segment_index);
+        is_valid = found;
+    }
+}
+
+bool PostingListCursor::seekImpl(uint32_t target)
+{
+    /// First check current decoded block
+    if (index < current_values.size())
+    {
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
+        if (it != current_values.end() && *it >= target)
+        {
+            index = static_cast<size_t>(it - current_values.begin());
+            return true;
+        }
+        if (is_embedded)
+            return false;
+    }
+
+    /// For TurboPFor encoded data, we need to decode blocks sequentially
+    /// because delta encoding prevents random block access.
+    /// Advance to the next block and keep looking.
+    ++current_block;
+    while (current_block < block_count)
+    {
+        if (!decodeNextBlock())
+            return false;
+
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
+        if (it != current_values.end() && *it >= target)
+        {
+            index = static_cast<size_t>(it - current_values.begin());
+            return true;
+        }
+        ++current_block;
+    }
+    return false;
+}
+
+void PostingListCursor::next()
+{
+    if (!is_valid)
+        return;
+
+    ++index;
+
+    if (index >= current_values.size())
+    {
+        ++current_block;
+        if (current_block >= block_count)
+        {
+            is_valid = false;
+            return;
+        }
+        decodeNextBlock();
+    }
+}
+
+inline void padColumnForOr(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
+{
+    const uint32_t * data = current_values.data();
+    const uint32_t * data_begin = data + begin;
+    const uint32_t * data_end = data + length;
+
+    if (data_begin >= data_end)
+        return;
+
+    const uint32_t * p = data_begin;
+    const size_t count = data_end - data_begin;
+
+    const uint32_t * loop_end = data_begin + (count / 4) * 4;
+
+    for (; p < loop_end; p += 4)
+    {
+        __builtin_prefetch(p + 16, 0, 3);
+        if (p + 4 < data_end)
+            __builtin_prefetch(&out[p[4] - row_begin], 1, 0);
+
+        out[p[0] - row_begin] = 1;
+        out[p[1] - row_begin] = 1;
+        out[p[2] - row_begin] = 1;
+        out[p[3] - row_begin] = 1;
+    }
+
+    switch (data_end - p)
+    {
+        case 3: out[p[2] - row_begin] = 1; [[fallthrough]];
+        case 2: out[p[1] - row_begin] = 1; [[fallthrough]];
+        case 1: out[p[0] - row_begin] = 1; [[fallthrough]];
+        default: break;
+    }
+}
+
+void PostingListCursor::linearOrImpl(size_t segment, UInt8 * __restrict out, size_t row_begin, size_t row_end)
+{
+    chassert(segment < info.ranges.size());
+
+    if (unlikely(is_embedded))
+    {
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
+        if (it == current_values.end())
+            return;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
+        size_t length = it_end - current_values.begin();
+        padColumnForOr(out, current_values, row_begin, idx, length);
+        return;
+    }
+
+    /// Process the current already-decoded block (block 0 decoded in prepare()),
+    /// then decode subsequent blocks sequentially.
+    for (size_t blk = current_block; blk < block_count; ++blk)
+    {
+        /// For the first iteration, current_values already has the decoded block from prepare().
+        /// For subsequent iterations, decode the next block from the stream.
+        if (blk > current_block)
+        {
+            current_block = blk;
+            if (!decodeNextBlock())
+                return;
+        }
+
+        if (current_values.empty())
+            continue;
+
+        /// Skip blocks entirely before row_begin
+        if (current_values.back() < row_begin)
+            continue;
+
+        /// Skip blocks entirely after row_end
+        if (current_values.front() > row_end)
+            return;
+
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
+        if (it == current_values.end())
+            continue;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
+        size_t length = it_end - current_values.begin();
+
+        padColumnForOr(out, current_values, row_begin, idx, length);
+
+        if (length < current_values.size())
+            return;
+    }
+}
+
+void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_rows)
+{
+    int unused_segment_index = -1;
+    for (size_t i = 0; i < segments.size(); ++i)
+    {
+        auto segment = segments[i];
+        size_t begin = info.ranges[segment].begin;
+        size_t end = info.ranges[segment].end;
+
+        if (row_offset > end || (row_offset + num_rows) < begin)
+        {
+            unused_segment_index = static_cast<int>(i);
+            continue;
+        }
+        end = std::min(end, row_offset + num_rows - 1);
+        prepare(segment);
+        linearOrImpl(segment, data, row_offset, end);
+    }
+    if (unused_segment_index > 0)
+        maybeEraseUnusedSegments(unused_segment_index);
+}
+
+inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
+{
+    const uint32_t *p = current_values.data() + begin;
+    const uint32_t *end = current_values.data() + length;
+
+    for (; p + 4 <= end; p += 4)
+    {
+        __builtin_prefetch(p + 16, 0, 3);
+        if (p + 8 < end)
+            __builtin_prefetch(&out[p[8] - row_begin], 1, 0);
+
+        ++out[p[0] - row_begin];
+        ++out[p[1] - row_begin];
+        ++out[p[2] - row_begin];
+        ++out[p[3] - row_begin];
+    }
+
+    switch (end - p)
+    {
+        case 3: ++out[p[2] - row_begin];
+            [[fallthrough]];
+        case 2: ++out[p[1] - row_begin];
+            [[fallthrough]];
+        case 1: ++out[p[0] - row_begin];
+            [[fallthrough]];
+        default: break;
+    }
+}
+
+void PostingListCursor::linearAndImpl(size_t segment, UInt8 * __restrict out, size_t row_begin, size_t row_end)
+{
+    chassert(segment < info.ranges.size());
+
+    if (unlikely(is_embedded))
+    {
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
+        if (it == current_values.end())
+            return;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
+        size_t length = it_end - current_values.begin();
+        padColumnForAnd(out, current_values, row_begin, idx, length);
+        return;
+    }
+
+    /// Process the current already-decoded block, then decode subsequent blocks sequentially.
+    for (size_t blk = current_block; blk < block_count; ++blk)
+    {
+        if (blk > current_block)
+        {
+            current_block = blk;
+            if (!decodeNextBlock())
+                return;
+        }
+
+        if (current_values.empty())
+            continue;
+
+        if (current_values.back() < row_begin)
+            continue;
+
+        if (current_values.front() > row_end)
+            return;
+
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
+        if (it == current_values.end())
+            continue;
+        size_t idx = static_cast<size_t>(it - current_values.begin());
+        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
+        size_t length = it_end - current_values.begin();
+
+        padColumnForAnd(out, current_values, row_begin, idx, length);
+
+        if (length < current_values.size())
+            return;
+    }
+}
+
+void PostingListCursor::linearAnd(UInt8 * data, size_t row_offset, size_t num_rows)
+{
+    int unused_segment_index = -1;
+    for (size_t i = 0; i < segments.size(); ++i)
+    {
+        auto segment = segments[i];
+        size_t begin = info.ranges[segment].begin;
+        size_t end = info.ranges[segment].end;
+
+        if (row_offset > end || (row_offset + num_rows) < begin)
+        {
+            unused_segment_index = static_cast<int>(i);
+            continue;
+        }
+        end = std::min(end, row_offset + num_rows - 1);
+        prepare(segments[i]);
+        linearAndImpl(segment, data, row_offset, end);
+    }
+
+    if (unused_segment_index > 0)
+        maybeEraseUnusedSegments(unused_segment_index);
+}
+
+namespace
+{
+
+/// Helper struct for min-heap based intersection algorithm.
+struct HeapItem
+{
+    uint32_t val = 0;
+    uint32_t idx = 0;
+
+    HeapItem() = default;
+    HeapItem(uint32_t val_, uint32_t idx_) : val(val_), idx(idx_) {}
+    bool operator>(const HeapItem & other) const { return val > other.val; }
+};
+
+/// Two-way merge intersection using skip-list style seek.
+void intersectTwo(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, size_t row_offset, size_t effective_end)
+{
+    while (c0->valid() && c1->valid())
+    {
+        uint32_t v0 = c0->value();
+        uint32_t v1 = c1->value();
+        if (v0 >= effective_end || v1 >= effective_end)
+            return;
+
+        if (v0 == v1)
+        {
+            out[v0 - row_offset] = 1;
+            c0->next();
+            c1->next();
+        }
+        else if (v0 < v1)
+        {
+            c0->seek(v1);
+        }
+        else
+        {
+            c1->seek(v0);
+        }
+    }
+}
+
+/// Three-way merge intersection.
+void intersectThree(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, PostingListCursorPtr c2, size_t row_offset, size_t effective_end)
+{
+    uint32_t v0 = 0;
+    uint32_t v1 = 0;
+    uint32_t v2 = 0;
+    while (c0->valid() && c1->valid() && c2->valid())
+    {
+        v0 = c0->value();
+        v1 = c1->value();
+        v2 = c2->value();
+
+        uint32_t max_val = std::max({v0, v1, v2});
+        if (max_val >= effective_end)
+            return;
+
+        if (v0 == v1 && v1 == v2)
+        {
+            out[v0 - row_offset] = 1;
+
+            c0->next();
+            c1->next();
+            c2->next();
+
+        }
+        else
+        {
+            if (v0 < max_val)
+                c0->seek(max_val);
+            if (v1 < max_val)
+                c1->seek(max_val);
+            if (v2 < max_val)
+                c2->seek(max_val);
+        }
+    }
+}
+
+/// Four-way merge intersection.
+void intersectFour(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, PostingListCursorPtr c2, PostingListCursorPtr c3, size_t row_offset, size_t effective_end)
+{
+    uint32_t v0 = 0;
+    uint32_t v1 = 0;
+    uint32_t v2 = 0;
+    uint32_t v3 = 0;
+    while (c0->valid() && c1->valid() && c2->valid() && c3->valid())
+    {
+        v0 = c0->value();
+        v1 = c1->value();
+        v2 = c2->value();
+        v3 = c3->value();
+
+        uint32_t max_val = std::max({v0, v1, v2, v3});
+        if (max_val >= effective_end)
+            return;
+
+        if (v0 == v1 && v1 == v2 && v2 == v3)
+        {
+            out[v0 - row_offset] = 1;
+
+            c0->next();
+            c1->next();
+            c2->next();
+            c3->next();
+        }
+        else
+        {
+            if (v0 < max_val)
+                c0->seek(max_val);
+            if (v1 < max_val)
+                c1->seek(max_val);
+            if (v2 < max_val)
+                c2->seek(max_val);
+            if (v3 < max_val)
+                c3->seek(max_val);
+        }
+    }
+}
+
+/// Leapfrog intersection with linear min/max scan.
+void intersectLeapfrogLinear(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
+{
+    const size_t n = cursors.size();
+    std::vector<uint32_t> vals(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+        vals[i] = cursors[i]->value();
+    }
+
+    while (true)
+    {
+        uint32_t min_val = vals[0];
+        uint32_t max_val = vals[0];
+        size_t min_idx = 0;
+
+        for (size_t i = 1; i < n; ++i)
+        {
+            if (vals[i] < min_val)
+            {
+                min_val = vals[i];
+                min_idx = i;
+            }
+            else if (vals[i] > max_val)
+            {
+                max_val = vals[i];
+            }
+        }
+
+        if (max_val >= effective_end)
+            return;
+
+        if (min_val == max_val)
+        {
+            out[min_val - row_offset] = 1;
+            for (size_t i = 0; i < n; ++i)
+            {
+                cursors[i]->next();
+                if (!cursors[i]->valid())
+                    return;
+                vals[i] = cursors[i]->value();
+            }
+        }
+        else
+        {
+            cursors[min_idx]->seek(max_val);
+            if (!cursors[min_idx]->valid())
+                return;
+            vals[min_idx] = cursors[min_idx]->value();
+        }
+    }
+}
+
+/// Leapfrog intersection using min-heap.
+void intersectLeapfrogHeap(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
+{
+    const size_t n = cursors.size();
+
+    std::vector<HeapItem> heap(n);
+    uint32_t max_val = 0;
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        uint32_t val = cursors[i]->value();
+        heap[i] = {val, static_cast<uint32_t>(i)};
+        max_val = std::max(max_val, val);
+    }
+    std::make_heap(heap.begin(), heap.end(), std::greater<>{});
+
+    while (true)
+    {
+        if (max_val >= effective_end)
+            return;
+
+        uint32_t min_val = heap.front().val;
+
+        if (min_val == max_val)
+        {
+            out[min_val - row_offset] = 1;
+
+            max_val = 0;
+            size_t heap_size = n;
+
+            for (size_t i = 0; i < heap_size; ++i)
+            {
+                uint32_t idx = heap[i].idx;
+                cursors[idx]->next();
+
+                if (!cursors[idx]->valid())
+                    return;
+
+                uint32_t val = cursors[idx]->value();
+                if (val >= effective_end)
+                    return;
+
+                heap[i].val = val;
+                max_val = std::max(max_val, val);
+            }
+            std::make_heap(heap.begin(), heap.end(), std::greater<>{});
+        }
+        else
+        {
+            uint32_t min_idx = heap.front().idx;
+            std::pop_heap(heap.begin(), heap.end(), std::greater<>{});
+
+            cursors[min_idx]->seek(max_val);
+            if (!cursors[min_idx]->valid())
+                return;
+
+            uint32_t new_val = cursors[min_idx]->value();
+            if (new_val >= effective_end)
+                return;
+
+            max_val = std::max(max_val, new_val);
+            heap.back() = {new_val, min_idx};
+            std::push_heap(heap.begin(), heap.end(), std::greater<>{});
+        }
+    }
+}
+
+/// Dispatcher for skip-list based intersection algorithms.
+void intersectLeapfrog(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
+{
+    if (cursors.size() == 2)
+        return intersectTwo(out, cursors[0], cursors[1], row_offset, effective_end);
+
+    if (cursors.size() == 3)
+        return intersectThree(out, cursors[0], cursors[1], cursors[2], row_offset, effective_end);
+
+    if (cursors.size() == 4)
+        return intersectFour(out, cursors[0], cursors[1], cursors[2], cursors[3], row_offset, effective_end);
+
+    if (cursors.size() <= 8)
+        return intersectLeapfrogLinear(out, cursors, row_offset, effective_end);
+
+    return intersectLeapfrogHeap(out, cursors, row_offset, effective_end);
+}
+
+/// Brute-force intersection using bitmap counting.
+void intersectBruteForce(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t num_rows)
+{
+    cursors[0]->linearOr(out, row_offset, num_rows);
+
+    for (size_t i = 1; i < cursors.size(); ++i)
+        cursors[i]->linearAnd(out, row_offset, num_rows);
+
+    size_t n = cursors.size();
+    if (n > 1)
+    {
+        UInt8 * p = out;
+        UInt8 * end = out + num_rows;
+        UInt8 * end_loop = out + (num_rows / 4) * 4;
+        UInt8 n8 = static_cast<UInt8>(n);
+
+        for (; p < end_loop; p += 4)
+        {
+            __builtin_prefetch(p + 64, 0, 3);
+            __builtin_prefetch(p + 64, 1, 0);
+
+            p[0] = (p[0] == n8);
+            p[1] = (p[1] == n8);
+            p[2] = (p[2] == n8);
+            p[3] = (p[3] == n8);
+        }
+
+        while (p < end)
+        {
+            *p = (*p == n8);
+            ++p;
+        }
+    }
+}
+
+} // anonymous namespace
+
+void lazyUnionPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool /*brute_force_apply*/, float /*density_threshold*/)
+{
+    auto & data = assert_cast<DB::ColumnUInt8 &>(column).getData();
+    UInt8 * out = data.data() + column_offset;
+
+    std::vector<PostingListCursorPtr> cursors;
+    cursors.reserve(postings.size());
+    for (const auto & token : search_tokens)
+    {
+        auto it = postings.find(token);
+        if (it != postings.end())
+            cursors.emplace_back(it->second);
+    }
+    for (const auto & cursor : cursors)
+        cursor->linearOr(out, row_offset, num_rows);
+}
+
+void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold)
+{
+    auto & data = assert_cast<DB::ColumnUInt8 &>(column).getData();
+    UInt8 * __restrict out = data.data() + column_offset;
+
+    std::vector<PostingListCursorPtr> cursors;
+    cursors.reserve(postings.size());
+    for (const auto & token : search_tokens)
+    {
+        auto it = postings.find(token);
+        if (it != postings.end())
+            cursors.emplace_back(it->second);
+    }
+    const size_t n = cursors.size();
+    const size_t end = row_offset + num_rows;
+
+    if (n == 0)
+        return;
+
+    if (n == 1)
+    {
+        cursors.front()->linearOr(out, row_offset, num_rows);
+        return;
+    }
+
+    double density = 0;
+    for (size_t i = 0; i < n; ++i)
+        density += cursors[i]->density();
+    density = density / static_cast<double>(n);
+
+    if (n < 256 && (density >= density_threshold || brute_force_apply))
+        return intersectBruteForce(out, cursors, row_offset, num_rows);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        cursors[i]->seek(static_cast<uint32_t>(row_offset));
+        if (!cursors[i]->valid() || cursors[i]->value() >= end)
+            return;
+    }
+
+    return intersectLeapfrog(out, cursors, row_offset, end);
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 #include <turbopfor.h>
-
+#pragma clang optimize off
 namespace DB
 {
 
@@ -95,6 +95,13 @@ PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_strea
 {
     if (total_large_blocks > 0)
         prepare(0);
+    else if (info.embedded_postings)
+    {
+        /// Embedded postings with no ranges/offsets — call prepare to decode them.
+        prepare(0);
+    }
+    else
+        is_valid = false;
 }
 
 PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_)
@@ -109,8 +116,6 @@ UInt32 PostingListCursor::cardinality() const
 
 void PostingListCursor::prepare(size_t large_block_idx)
 {
-    if (current_large_block_idx == large_block_idx && has_prepared_first_large_block)
-        return;
     has_prepared_first_large_block = true;
 
     /// Large block 0's packed block 0 needs to prepend `first_doc_id` (which is stored
@@ -129,7 +134,7 @@ void PostingListCursor::prepare(size_t large_block_idx)
         current_block = 0;
         block_count = 1;
         current_large_block_idx = large_block_idx;
-        is_valid = true;
+        is_valid = !current_values.empty();
         is_embedded = true;
 
         if (current_values.size() >= 2)
@@ -259,17 +264,21 @@ bool PostingListCursor::decodeNextBlock()
 
 void PostingListCursor::seek(uint32_t target)
 {
+    /// Fast path: try current already-prepared large block first.
     if (!is_embedded && seekImpl(target))
         return;
 
+    /// Slow path: current large block doesn't contain target.
+    /// Start from next large block (current one already failed in fast path).
+    /// For embedded postings, seekImpl above was skipped, so start from current_large_block_idx.
     bool found = false;
-    for (size_t i = current_large_block_idx; i < total_large_blocks; ++i)
+    size_t start = is_embedded ? current_large_block_idx : current_large_block_idx + 1;
+    for (size_t i = start; i < total_large_blocks; ++i)
     {
-        auto large_block = i;
-        const auto & range = info.ranges[large_block];
+        const auto & range = info.ranges[i];
         if (range.end >= target)
         {
-            prepare(large_block);
+            prepare(i);
             if (seekImpl(target))
             {
                 found = true;
@@ -342,11 +351,23 @@ void PostingListCursor::next()
     if (index >= current_values.size())
     {
         ++current_block;
-        if (current_block >= block_count)
+        if (current_block < block_count)
+        {
+            /// Still within current large block, decode next packed block.
+            /// Sequential read: need_seek_before_decode stays false.
+            decodeNextBlock();
+            return;
+        }
+
+        /// All packed blocks in current large block exhausted, advance to next large block.
+        size_t next_large_block = current_large_block_idx + 1;
+        if (next_large_block >= total_large_blocks)
         {
             is_valid = false;
             return;
         }
+
+        prepare(next_large_block);
         decodeNextBlock();
     }
 }
@@ -442,10 +463,12 @@ void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_row
         size_t begin = info.ranges[large_block].begin;
         size_t end = info.ranges[large_block].end;
 
-        if (row_offset > end || (row_offset + num_rows) < begin)
-        {
+        if (row_offset > end)
             continue;
-        }
+
+        if ((row_offset + num_rows) < begin)
+            break;
+
         end = std::min(end, row_offset + num_rows - 1);
         prepare(large_block);
         linearOrImpl(large_block, data, row_offset, end);
@@ -535,10 +558,12 @@ void PostingListCursor::linearAnd(UInt8 * data, size_t row_offset, size_t num_ro
         size_t begin = info.ranges[large_block].begin;
         size_t end = info.ranges[large_block].end;
 
-        if (row_offset > end || (row_offset + num_rows) < begin)
-        {
+        if (row_offset > end)
             continue;
-        }
+
+        if ((row_offset + num_rows) < begin)
+            break;
+
         end = std::min(end, row_offset + num_rows - 1);
         prepare(large_block);
         linearAndImpl(large_block, data, row_offset, end);

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -366,38 +366,65 @@ void PostingListCursor::next()
     }
 }
 
-/// Scatter-write 1s into `out` for doc_ids in values[begin..length).
-/// 4-wide loop with prefetch for cache-line utilization.
-inline void padColumnForOr(UInt8 * __restrict out, const uint32_t * values, size_t row_begin, size_t begin, size_t length)
-{
-    const uint32_t * data_begin = values + begin;
-    const uint32_t * data_end = values + length;
+enum class PadOp { Or, And };
 
-    if (data_begin >= data_end)
+/// Scatter-write into `out` for doc_ids in values[begin..length).
+/// PadOp::Or assigns 1, PadOp::And increments the counter.
+/// 4-wide loop with prefetch for cache-line utilization.
+template <PadOp op>
+inline void padColumn(UInt8 * __restrict out, const uint32_t * values, size_t row_begin, size_t begin, size_t length)
+{
+    const uint32_t * p = values + begin;
+    const uint32_t * end = values + length;
+
+    if (p >= end)
         return;
 
-    const uint32_t * p = data_begin;
-    const size_t count = data_end - data_begin;
-
-    const uint32_t * loop_end = data_begin + (count / 4) * 4;
+    const size_t count = static_cast<size_t>(end - p);
+    const uint32_t * loop_end = p + (count / 4) * 4;
 
     for (; p < loop_end; p += 4)
     {
         __builtin_prefetch(p + 16, 0, 3);
-        if (p + 4 < data_end)
-            __builtin_prefetch(&out[p[4] - row_begin], 1, 0);
+        if (p + 8 < end)
+            __builtin_prefetch(&out[p[8] - row_begin], 1, 0);
 
-        out[p[0] - row_begin] = 1;
-        out[p[1] - row_begin] = 1;
-        out[p[2] - row_begin] = 1;
-        out[p[3] - row_begin] = 1;
+        if constexpr (op == PadOp::Or)
+        {
+            out[p[0] - row_begin] = 1;
+            out[p[1] - row_begin] = 1;
+            out[p[2] - row_begin] = 1;
+            out[p[3] - row_begin] = 1;
+        }
+        else
+        {
+            ++out[p[0] - row_begin];
+            ++out[p[1] - row_begin];
+            ++out[p[2] - row_begin];
+            ++out[p[3] - row_begin];
+        }
     }
 
-    switch (data_end - p)
+    switch (end - p)
     {
-        case 3: out[p[2] - row_begin] = 1; [[fallthrough]];
-        case 2: out[p[1] - row_begin] = 1; [[fallthrough]];
-        case 1: out[p[0] - row_begin] = 1; [[fallthrough]];
+        case 3:
+            if constexpr (op == PadOp::Or)
+                out[p[2] - row_begin] = 1;
+            else
+                ++out[p[2] - row_begin];
+            [[fallthrough]];
+        case 2:
+            if constexpr (op == PadOp::Or)
+                out[p[1] - row_begin] = 1;
+            else
+                ++out[p[1] - row_begin];
+            [[fallthrough]];
+        case 1:
+            if constexpr (op == PadOp::Or)
+                out[p[0] - row_begin] = 1;
+            else
+                ++out[p[0] - row_begin];
+            [[fallthrough]];
         default: break;
     }
 }
@@ -414,7 +441,7 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         size_t begin_idx = static_cast<size_t>(it - decoded_values);
         auto it_end = std::upper_bound(decoded_values, decoded_values + decoded_count, row_end);
         size_t end_idx = it_end - decoded_values;
-        padColumnForOr(out, decoded_values, row_begin, begin_idx, end_idx);
+        padColumn<PadOp::Or>(out, decoded_values, row_begin, begin_idx, end_idx);
         return;
     }
 
@@ -483,12 +510,12 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
                 end_idx = static_cast<size_t>(it_end - decoded_values);
             }
 
-            padColumnForOr(out, decoded_values, row_begin, begin_idx, end_idx);
+            padColumn<PadOp::Or>(out, decoded_values, row_begin, begin_idx, end_idx);
         }
         else
         {
             /// Entire block is within [row_begin, row_end] — no clipping needed.
-            padColumnForOr(out, decoded_values, row_begin, 0, decoded_count);
+            padColumn<PadOp::Or>(out, decoded_values, row_begin, 0, decoded_count);
         }
     }
 }
@@ -513,37 +540,6 @@ void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_row
     }
 }
 
-/// Scatter-increment counters in `out` for doc_ids in values[begin..length).
-/// 4-wide loop with prefetch for cache-line utilization.
-inline void padColumnForAnd(UInt8 * __restrict out, const uint32_t * values, size_t row_begin, size_t begin, size_t length)
-{
-    const uint32_t *p = values + begin;
-    const uint32_t *end = values + length;
-
-    for (; p + 4 <= end; p += 4)
-    {
-        __builtin_prefetch(p + 16, 0, 3);
-        if (p + 8 < end)
-            __builtin_prefetch(&out[p[8] - row_begin], 1, 0);
-
-        ++out[p[0] - row_begin];
-        ++out[p[1] - row_begin];
-        ++out[p[2] - row_begin];
-        ++out[p[3] - row_begin];
-    }
-
-    switch (end - p)
-    {
-        case 3: ++out[p[2] - row_begin];
-            [[fallthrough]];
-        case 2: ++out[p[1] - row_begin];
-            [[fallthrough]];
-        case 1: ++out[p[0] - row_begin];
-            [[fallthrough]];
-        default: break;
-    }
-}
-
 void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out, size_t row_begin, size_t row_end)
 {
     chassert(large_block < info.ranges.size());
@@ -556,7 +552,7 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
         size_t idx = static_cast<size_t>(it - decoded_values);
         auto it_end = std::upper_bound(decoded_values, decoded_values + decoded_count, row_end);
         size_t length = it_end - decoded_values;
-        padColumnForAnd(out, decoded_values, row_begin, idx, length);
+        padColumn<PadOp::And>(out, decoded_values, row_begin, idx, length);
         return;
     }
 
@@ -609,11 +605,11 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
                 end_idx = static_cast<size_t>(it_end - decoded_values);
             }
 
-            padColumnForAnd(out, decoded_values, row_begin, begin_idx, end_idx);
+            padColumn<PadOp::And>(out, decoded_values, row_begin, begin_idx, end_idx);
         }
         else
         {
-            padColumnForAnd(out, decoded_values, row_begin, 0, decoded_count);
+            padColumn<PadOp::And>(out, decoded_values, row_begin, 0, decoded_count);
         }
     }
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -2,10 +2,22 @@
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h>
+#include <Common/ProfileEvents.h>
 #include <algorithm>
 #include <cstring>
 
 #include <turbopfor.h>
+
+namespace ProfileEvents
+{
+    extern const Event TextIndexLazyPackedBlocksDecoded;
+    extern const Event TextIndexLazyPackedBlocksSkipped;
+    extern const Event TextIndexLazySeekCount;
+    extern const Event TextIndexLazyLargeBlocksPrepared;
+    extern const Event TextIndexLazyBruteForceIntersections;
+    extern const Event TextIndexLazyLeapfrogIntersections;
+}
+
 namespace DB
 {
 
@@ -60,6 +72,11 @@ UInt32 PostingListCursor::cardinality() const
 
 void PostingListCursor::prepare(size_t large_block_idx)
 {
+    /// Skip if this large block is already loaded.
+    if (has_prepared_first_large_block && large_block_idx == current_large_block_idx)
+        return;
+
+    ProfileEvents::increment(ProfileEvents::TextIndexLazyLargeBlocksPrepared);
     has_prepared_first_large_block = true;
 
     decoded_count = 0;
@@ -211,6 +228,7 @@ bool PostingListCursor::probeAndDecodePackedBlock(size_t block_idx)
 
         if (is_arithmetic)
         {
+            ProfileEvents::increment(ProfileEvents::TextIndexLazyPackedBlocksSkipped);
             arithmetic_mode = true;
             arithmetic_step = constant_value + 1;
             arithmetic_first = delta_base + arithmetic_step;
@@ -250,6 +268,7 @@ bool PostingListCursor::probeAndDecodePackedBlock(size_t block_idx)
         last_decoded_doc_id = decoded_values[actual_count - 1];
         index = 0;
 
+        ProfileEvents::increment(ProfileEvents::TextIndexLazyPackedBlocksDecoded);
         return false;
     }
 
@@ -287,12 +306,15 @@ bool PostingListCursor::probeAndDecodePackedBlock(size_t block_idx)
         last_decoded_doc_id = decoded_values[actual_count - 1];
         index = 0;
 
+        ProfileEvents::increment(ProfileEvents::TextIndexLazyPackedBlocksDecoded);
         return false;
     }
 }
 
 void PostingListCursor::seek(uint32_t target)
 {
+    ProfileEvents::increment(ProfileEvents::TextIndexLazySeekCount);
+
     /// Fast path: target may fall within the currently loaded large block.
     if (!is_embedded && seekImpl(target))
         return;
@@ -1134,6 +1156,7 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
 
     if (n < 256 && (min_density >= density_threshold || brute_force_apply))
     {
+        ProfileEvents::increment(ProfileEvents::TextIndexLazyBruteForceIntersections);
         intersectBruteForce(out, cursors, row_offset, num_rows);
         return;
     }
@@ -1152,6 +1175,7 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
             return;
     }
 
+    ProfileEvents::increment(ProfileEvents::TextIndexLazyLeapfrogIntersections);
     intersectLeapfrog(out, cursors, row_offset, end);
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -114,26 +114,24 @@ void PostingListCursor::prepare(size_t large_block_idx)
 {
     has_prepared_first_large_block = true;
 
-    /// Large block 0, packed block 0 needs an extra slot for `first_doc_id`
-    /// (stored in the dictionary, not in TurboPFor data).
-    current_values.reserve(TURBOPFOR_BLOCK_SIZE + (large_block_idx == 0 ? 1 : 0));
-    current_values.clear();
+    decoded_count = 0;
 
     if (info.embedded_postings)
     {
         /// Embedded posting list: already materialized as a Roaring Bitmap.
-        /// Decode all doc_ids into current_values in one shot.
+        /// Decode all doc_ids into decoded_values in one shot (at most 6 entries).
         chassert(!stream);
-        current_values.resize(info.embedded_postings->cardinality());
-        info.embedded_postings->toUint32Array(current_values.data());
+        decoded_count = info.embedded_postings->cardinality();
+        chassert(decoded_count <= TURBOPFOR_BLOCK_SIZE + 1);
+        info.embedded_postings->toUint32Array(decoded_values);
         current_block = 0;
         block_count = 1;
         current_large_block_idx = large_block_idx;
-        is_valid = !current_values.empty();
+        is_valid = decoded_count > 0;
         is_embedded = true;
 
-        if (current_values.size() >= 2)
-            density_val = static_cast<double>(current_values.size()) / static_cast<double>(current_values.back() - current_values.front() + 1);
+        if (decoded_count >= 2)
+            density_val = static_cast<double>(decoded_count) / static_cast<double>(decoded_values[decoded_count - 1] - decoded_values[0] + 1);
         else
             density_val = 1.0;
         return;
@@ -240,8 +238,8 @@ bool PostingListCursor::decodeNextBlock()
     bool prepend_first_doc_id = (current_large_block_idx == 0 && current_block == 0);
     UInt32 actual_count = prepend_first_doc_id ? count + 1 : count;
 
-    current_values.resize(actual_count);
-    uint32_t * decode_dst = current_values.data() + (prepend_first_doc_id ? 1 : 0);
+    decoded_count = actual_count;
+    uint32_t * decode_dst = decoded_values + (prepend_first_doc_id ? 1 : 0);
 
     if (count == 128)
         turbopfor::p4D1Dec128v32(src_ptr, 128, decode_dst, last_decoded_doc_id);
@@ -249,9 +247,9 @@ bool PostingListCursor::decodeNextBlock()
         turbopfor::p4D1Dec32(src_ptr, count, decode_dst, last_decoded_doc_id);
 
     if (prepend_first_doc_id)
-        current_values[0] = static_cast<uint32_t>(info.ranges[0].begin);
+        decoded_values[0] = static_cast<uint32_t>(info.ranges[0].begin);
 
-    last_decoded_doc_id = current_values[actual_count - 1];
+    last_decoded_doc_id = decoded_values[actual_count - 1];
     index = 0;
 
     return true;
@@ -288,23 +286,23 @@ bool PostingListCursor::seekImpl(uint32_t target)
 {
     if (is_embedded)
     {
-        /// Embedded: all doc_ids are in current_values, use binary search.
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
-        if (it != current_values.end())
+        /// Embedded: all doc_ids are in decoded_values, use binary search.
+        auto it = std::lower_bound(decoded_values, decoded_values + decoded_count, target);
+        if (it != decoded_values + decoded_count)
         {
-            index = static_cast<size_t>(it - current_values.begin());
+            index = static_cast<size_t>(it - decoded_values);
             return true;
         }
         return false;
     }
 
     /// Check if target falls within the already-decoded packed block.
-    if (index < current_values.size())
+    if (index < decoded_count)
     {
-        auto it = std::lower_bound(current_values.begin() + index, current_values.end(), target);
-        if (it != current_values.end())
+        auto it = std::lower_bound(decoded_values + index, decoded_values + decoded_count, target);
+        if (it != decoded_values + decoded_count)
         {
-            index = static_cast<size_t>(it - current_values.begin());
+            index = static_cast<size_t>(it - decoded_values);
             return true;
         }
     }
@@ -324,10 +322,10 @@ bool PostingListCursor::seekImpl(uint32_t target)
     decodeNextBlock();
 
     /// Binary search within the decoded packed block.
-    auto found_it = std::lower_bound(current_values.begin(), current_values.end(), target);
-    if (found_it != current_values.end())
+    auto found_it = std::lower_bound(decoded_values, decoded_values + decoded_count, target);
+    if (found_it != decoded_values + decoded_count)
     {
-        index = static_cast<size_t>(found_it - current_values.begin());
+        index = static_cast<size_t>(found_it - decoded_values);
         return true;
     }
 
@@ -341,7 +339,7 @@ void PostingListCursor::next()
 
     ++index;
 
-    if (index >= current_values.size())
+    if (index >= decoded_count)
     {
         ++current_block;
         if (current_block < block_count)
@@ -364,13 +362,12 @@ void PostingListCursor::next()
     }
 }
 
-/// Scatter-write 1s into `out` for doc_ids in current_values[begin..length).
+/// Scatter-write 1s into `out` for doc_ids in values[begin..length).
 /// 4-wide loop with prefetch for cache-line utilization.
-inline void padColumnForOr(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
+inline void padColumnForOr(UInt8 * __restrict out, const uint32_t * values, size_t row_begin, size_t begin, size_t length)
 {
-    const uint32_t * data = current_values.data();
-    const uint32_t * data_begin = data + begin;
-    const uint32_t * data_end = data + length;
+    const uint32_t * data_begin = values + begin;
+    const uint32_t * data_end = values + length;
 
     if (data_begin >= data_end)
         return;
@@ -407,13 +404,13 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
 
     if (unlikely(is_embedded))
     {
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
-        if (it == current_values.end())
+        auto it = std::lower_bound(decoded_values, decoded_values + decoded_count, row_begin);
+        if (it == decoded_values + decoded_count)
             return;
-        size_t begin_idx = static_cast<size_t>(it - current_values.begin());
-        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
-        size_t end_idx = it_end - current_values.begin();
-        padColumnForOr(out, current_values, row_begin, begin_idx, end_idx);
+        size_t begin_idx = static_cast<size_t>(it - decoded_values);
+        auto it_end = std::upper_bound(decoded_values, decoded_values + decoded_count, row_end);
+        size_t end_idx = it_end - decoded_values;
+        padColumnForOr(out, decoded_values, row_begin, begin_idx, end_idx);
         return;
     }
 
@@ -452,7 +449,7 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         if (!decodeNextBlock())
             return;
 
-        if (current_values.empty())
+        if (decoded_count == 0)
             continue;
 
         /// For the first and last blocks in the range, the block may only partially
@@ -461,33 +458,33 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         /// [row_begin, row_end], so skip the binary searches entirely.
         bool is_first_block = (blk == blk_start);
         bool is_last_block = (blk + 1 == blk_end);
-        bool need_clip = (is_first_block && current_values.front() < row_begin)
-                      || (is_last_block && current_values.back() > row_end);
+        bool need_clip = (is_first_block && decoded_values[0] < row_begin)
+                      || (is_last_block && decoded_values[decoded_count - 1] > row_end);
 
         if (need_clip)
         {
             size_t begin_idx = 0;
-            size_t end_idx = current_values.size();
+            size_t end_idx = decoded_count;
 
-            if (is_first_block && current_values.front() < row_begin)
+            if (is_first_block && decoded_values[0] < row_begin)
             {
-                auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
-                if (it == current_values.end())
+                auto it = std::lower_bound(decoded_values, decoded_values + decoded_count, static_cast<uint32_t>(row_begin));
+                if (it == decoded_values + decoded_count)
                     continue;
-                begin_idx = static_cast<size_t>(it - current_values.begin());
+                begin_idx = static_cast<size_t>(it - decoded_values);
             }
-            if (is_last_block && current_values.back() > row_end)
+            if (is_last_block && decoded_values[decoded_count - 1] > row_end)
             {
-                auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
-                end_idx = static_cast<size_t>(it_end - current_values.begin());
+                auto it_end = std::upper_bound(decoded_values, decoded_values + decoded_count, static_cast<uint32_t>(row_end));
+                end_idx = static_cast<size_t>(it_end - decoded_values);
             }
 
-            padColumnForOr(out, current_values, row_begin, begin_idx, end_idx);
+            padColumnForOr(out, decoded_values, row_begin, begin_idx, end_idx);
         }
         else
         {
             /// Entire block is within [row_begin, row_end] — no clipping needed.
-            padColumnForOr(out, current_values, row_begin, 0, current_values.size());
+            padColumnForOr(out, decoded_values, row_begin, 0, decoded_count);
         }
     }
 }
@@ -512,12 +509,12 @@ void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_row
     }
 }
 
-/// Scatter-increment counters in `out` for doc_ids in current_values[begin..length).
+/// Scatter-increment counters in `out` for doc_ids in values[begin..length).
 /// 4-wide loop with prefetch for cache-line utilization.
-inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
+inline void padColumnForAnd(UInt8 * __restrict out, const uint32_t * values, size_t row_begin, size_t begin, size_t length)
 {
-    const uint32_t *p = current_values.data() + begin;
-    const uint32_t *end = current_values.data() + length;
+    const uint32_t *p = values + begin;
+    const uint32_t *end = values + length;
 
     for (; p + 4 <= end; p += 4)
     {
@@ -549,13 +546,13 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
 
     if (unlikely(is_embedded))
     {
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
-        if (it == current_values.end())
+        auto it = std::lower_bound(decoded_values, decoded_values + decoded_count, row_begin);
+        if (it == decoded_values + decoded_count)
             return;
-        size_t idx = static_cast<size_t>(it - current_values.begin());
-        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
-        size_t length = it_end - current_values.begin();
-        padColumnForAnd(out, current_values, row_begin, idx, length);
+        size_t idx = static_cast<size_t>(it - decoded_values);
+        auto it_end = std::upper_bound(decoded_values, decoded_values + decoded_count, row_end);
+        size_t length = it_end - decoded_values;
+        padColumnForAnd(out, decoded_values, row_begin, idx, length);
         return;
     }
 
@@ -582,37 +579,37 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
         if (!decodeNextBlock())
             return;
 
-        if (current_values.empty())
+        if (decoded_count == 0)
             continue;
 
         bool is_first_block = (blk == blk_start);
         bool is_last_block = (blk + 1 == blk_end);
-        bool need_clip = (is_first_block && current_values.front() < row_begin)
-                      || (is_last_block && current_values.back() > row_end);
+        bool need_clip = (is_first_block && decoded_values[0] < row_begin)
+                      || (is_last_block && decoded_values[decoded_count - 1] > row_end);
 
         if (need_clip)
         {
             size_t begin_idx = 0;
-            size_t end_idx = current_values.size();
+            size_t end_idx = decoded_count;
 
-            if (is_first_block && current_values.front() < row_begin)
+            if (is_first_block && decoded_values[0] < row_begin)
             {
-                auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
-                if (it == current_values.end())
+                auto it = std::lower_bound(decoded_values, decoded_values + decoded_count, static_cast<uint32_t>(row_begin));
+                if (it == decoded_values + decoded_count)
                     continue;
-                begin_idx = static_cast<size_t>(it - current_values.begin());
+                begin_idx = static_cast<size_t>(it - decoded_values);
             }
-            if (is_last_block && current_values.back() > row_end)
+            if (is_last_block && decoded_values[decoded_count - 1] > row_end)
             {
-                auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
-                end_idx = static_cast<size_t>(it_end - current_values.begin());
+                auto it_end = std::upper_bound(decoded_values, decoded_values + decoded_count, static_cast<uint32_t>(row_end));
+                end_idx = static_cast<size_t>(it_end - decoded_values);
             }
 
-            padColumnForAnd(out, current_values, row_begin, begin_idx, end_idx);
+            padColumnForAnd(out, decoded_values, row_begin, begin_idx, end_idx);
         }
         else
         {
-            padColumnForAnd(out, current_values, row_begin, 0, current_values.size());
+            padColumnForAnd(out, decoded_values, row_begin, 0, decoded_count);
         }
     }
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -4,6 +4,7 @@
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <IO/ReadHelpers.h>
 
+#pragma clang optimize off
 #include <turbopfor.h>
 
 namespace DB
@@ -162,9 +163,10 @@ void PostingListCursor::prepare(size_t large_block_idx)
     UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
     density_val = (range_span > 0) ? static_cast<double>(large_block_doc_count + (large_block_idx == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
 
-    /// In V2 format, block_meta.offset points directly to the Index Section
-    /// (not the Data Section). Seek there and read the packed block index.
-    stream->seek(block_meta.offset);
+    /// In V2 format, block_meta.index_offset points to the Index Section.
+    /// Seek there and read the packed block index.
+    chassert(block_meta.index_offset != 0);
+    stream->seek(block_meta.index_offset);
     auto & data_buf = *stream->getDataBuffer();
 
     /// Read Index Section: [num_packed_blocks] [last_doc_ids...] [offsets...]

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -1,8 +1,6 @@
 #include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
-#include <Common/ElapsedTimeProfileEventIncrement.h>
-#include <IO/ReadHelpers.h>
 #include <algorithm>
 
 #include <turbopfor.h>
@@ -419,8 +417,36 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         return;
     }
 
-    /// Process the current packed block, then decode and process subsequent blocks.
-    for (size_t blk = current_block; blk < block_count; ++blk)
+    /// Use packed_block_last_doc_ids[] to determine the range of packed blocks
+    /// that overlap [row_begin, row_end], skipping all blocks outside this range
+    /// without any I/O or decoding.
+    ///
+    /// packed_block_last_doc_ids[j] is the last doc_id in packed block j.
+    /// The first doc_id of block j is approximately packed_block_last_doc_ids[j-1]+1
+    /// (or info.ranges[large_block].begin for block 0).
+    ///
+    /// We want the first block whose last_doc_id >= row_begin (it may contain row_begin)
+    /// and the last block whose first doc_id could be <= row_end.
+    auto blk_start_it = std::lower_bound(packed_block_last_doc_ids.begin(), packed_block_last_doc_ids.end(), static_cast<UInt32>(row_begin));
+    if (blk_start_it == packed_block_last_doc_ids.end())
+        return;  /// All blocks end before row_begin.
+    size_t blk_start = static_cast<size_t>(blk_start_it - packed_block_last_doc_ids.begin());
+
+    /// Find the last block that could contain doc_ids in [row_begin, row_end].
+    /// lower_bound(row_end) returns the first block with last_doc_id >= row_end;
+    /// that block is the last one we need (it contains or ends at row_end).
+    auto blk_end_it = std::lower_bound(packed_block_last_doc_ids.begin(), packed_block_last_doc_ids.end(), static_cast<UInt32>(row_end));
+    size_t blk_end;
+    if (blk_end_it == packed_block_last_doc_ids.end())
+        blk_end = block_count;  /// row_end exceeds all blocks — process them all.
+    else
+        blk_end = static_cast<size_t>(blk_end_it - packed_block_last_doc_ids.begin()) + 1;  /// +1 for exclusive upper bound.
+
+    /// Seek directly to the first relevant packed block.
+    current_block = blk_start;
+    need_seek_before_decode = true;
+
+    for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
         current_block = blk;
         if (!decodeNextBlock())
@@ -429,23 +455,40 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         if (current_values.empty())
             continue;
 
-        if (current_values.back() < row_begin)  /// Entire block before range — skip.
-            continue;
+        /// For the first and last blocks in the range, the block may only partially
+        /// overlap [row_begin, row_end] — use binary search to clip.
+        /// For all middle blocks, every doc_id is guaranteed to be within
+        /// [row_begin, row_end], so skip the binary searches entirely.
+        bool is_first_block = (blk == blk_start);
+        bool is_last_block = (blk + 1 == blk_end);
+        bool need_clip = (is_first_block && current_values.front() < row_begin)
+                      || (is_last_block && current_values.back() > row_end);
 
-        if (current_values.front() > row_end)   /// Entire block after range — done.
-            return;
+        if (need_clip)
+        {
+            size_t begin_idx = 0;
+            size_t end_idx = current_values.size();
 
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
-        if (it == current_values.end())
-            continue;
-        size_t begin_idx = static_cast<size_t>(it - current_values.begin());
-        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
-        size_t end_idx = it_end - current_values.begin();
+            if (is_first_block && current_values.front() < row_begin)
+            {
+                auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
+                if (it == current_values.end())
+                    continue;
+                begin_idx = static_cast<size_t>(it - current_values.begin());
+            }
+            if (is_last_block && current_values.back() > row_end)
+            {
+                auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
+                end_idx = static_cast<size_t>(it_end - current_values.begin());
+            }
 
-        padColumnForOr(out, current_values, row_begin, begin_idx, end_idx);
-
-        if (end_idx < current_values.size())
-            return;
+            padColumnForOr(out, current_values, row_begin, begin_idx, end_idx);
+        }
+        else
+        {
+            /// Entire block is within [row_begin, row_end] — no clipping needed.
+            padColumnForOr(out, current_values, row_begin, 0, current_values.size());
+        }
     }
 }
 
@@ -516,8 +559,24 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
         return;
     }
 
-    /// Process the current already-decoded block, then decode subsequent blocks sequentially.
-    for (size_t blk = current_block; blk < block_count; ++blk)
+    /// Use packed_block_last_doc_ids[] to skip blocks outside [row_begin, row_end]
+    /// without decoding.  Same strategy as linearOrImpl.
+    auto blk_start_it = std::lower_bound(packed_block_last_doc_ids.begin(), packed_block_last_doc_ids.end(), static_cast<UInt32>(row_begin));
+    if (blk_start_it == packed_block_last_doc_ids.end())
+        return;
+    size_t blk_start = static_cast<size_t>(blk_start_it - packed_block_last_doc_ids.begin());
+
+    auto blk_end_it = std::lower_bound(packed_block_last_doc_ids.begin(), packed_block_last_doc_ids.end(), static_cast<UInt32>(row_end));
+    size_t blk_end;
+    if (blk_end_it == packed_block_last_doc_ids.end())
+        blk_end = block_count;
+    else
+        blk_end = static_cast<size_t>(blk_end_it - packed_block_last_doc_ids.begin()) + 1;
+
+    current_block = blk_start;
+    need_seek_before_decode = true;
+
+    for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
         current_block = blk;
         if (!decodeNextBlock())
@@ -526,23 +585,35 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
         if (current_values.empty())
             continue;
 
-        if (current_values.back() < row_begin)
-            continue;
+        bool is_first_block = (blk == blk_start);
+        bool is_last_block = (blk + 1 == blk_end);
+        bool need_clip = (is_first_block && current_values.front() < row_begin)
+                      || (is_last_block && current_values.back() > row_end);
 
-        if (current_values.front() > row_end)
-            return;
+        if (need_clip)
+        {
+            size_t begin_idx = 0;
+            size_t end_idx = current_values.size();
 
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
-        if (it == current_values.end())
-            continue;
-        size_t idx = static_cast<size_t>(it - current_values.begin());
-        auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
-        size_t length = it_end - current_values.begin();
+            if (is_first_block && current_values.front() < row_begin)
+            {
+                auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
+                if (it == current_values.end())
+                    continue;
+                begin_idx = static_cast<size_t>(it - current_values.begin());
+            }
+            if (is_last_block && current_values.back() > row_end)
+            {
+                auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
+                end_idx = static_cast<size_t>(it_end - current_values.begin());
+            }
 
-        padColumnForAnd(out, current_values, row_begin, idx, length);
-
-        if (length < current_values.size())
-            return;
+            padColumnForAnd(out, current_values, row_begin, begin_idx, end_idx);
+        }
+        else
+        {
+            padColumnForAnd(out, current_values, row_begin, 0, current_values.size());
+        }
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -3,6 +3,7 @@
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <IO/ReadHelpers.h>
+#include <algorithm>
 
 #include <turbopfor.h>
 
@@ -106,6 +107,11 @@ PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_strea
 PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_, size_t large_block)
     : PostingListCursor(nullptr, info_, large_block)
 {
+}
+
+UInt32 PostingListCursor::cardinality() const
+{
+    return info.cardinality;
 }
 
 void PostingListCursor::addLargeBlock(size_t s)
@@ -920,16 +926,25 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
         return;
     }
 
-    double density = 0;
+    /// Use min density for algorithm selection: brute-force is only beneficial
+    /// when ALL cursors are dense. If any cursor is sparse, leapfrog can skip
+    /// large ranges efficiently, making it the better choice.
+    double min_density = std::numeric_limits<double>::max();
     for (size_t i = 0; i < n; ++i)
-        density += cursors[i]->density();
-    density = density / static_cast<double>(n);
+        min_density = std::min(min_density, cursors[i]->density());
 
-    if (n < 256 && (density >= density_threshold || brute_force_apply))
+    if (n < 256 && (min_density >= density_threshold || brute_force_apply))
     {
         intersectBruteForce(out, cursors, row_offset, num_rows);
         return;
     }
+
+    /// Sort cursors by cardinality ascending so the sparsest cursor leads
+    /// the leapfrog loop. This minimizes total seek count: the sparse leader
+    /// advances in large jumps while dense followers catch up cheaply.
+    std::sort(cursors.begin(), cursors.end(),
+        [](const PostingListCursorPtr & a, const PostingListCursorPtr & b)
+        { return a->cardinality() < b->cardinality(); });
 
     for (size_t i = 0; i < n; ++i)
     {

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -19,17 +19,6 @@ inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 
 } // anonymous namespace
 
-/// Result of probing a TurboPFor packed block header without full decompression.
-/// Valid only for arithmetic-sequence blocks (constant delta or all-zero delta).
-struct PackedBlockProbe
-{
-    bool is_arithmetic = false;  /// True if block is constant-delta or all-zero.
-    uint32_t step = 0;           /// Delta step = constant_value + 1.
-    uint32_t first_doc_id = 0;   /// First doc_id in this block.
-    uint32_t last_doc_id = 0;    /// Last doc_id in this block.
-    uint32_t count = 0;          /// Number of elements in this block.
-};
-
 PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_)
     : stream(owned_stream_.get())
     , owned_stream(std::move(owned_stream_))
@@ -106,7 +95,6 @@ void PostingListCursor::prepare(size_t large_block_idx)
 
     current_block = 0;
     current_large_block_idx = large_block_idx;
-    need_seek_before_decode = true;
 
     /// Seek to the Index Section and read the packed block index.
     chassert(block_meta.index_offset != 0);
@@ -132,85 +120,15 @@ void PostingListCursor::prepare(size_t large_block_idx)
         is_valid = false;
 }
 
-bool PostingListCursor::decodeNextBlock()
-{
-    arithmetic_mode = false;
-
-    if (current_block >= block_count)
-        return false;
-
-    chassert(stream);
-
-    chassert(current_block < packed_block_offsets.size());
-
-    if (need_seek_before_decode)
-    {
-        stream->seek(packed_block_offsets[current_block]);
-        need_seek_before_decode = false;
-    }
-
-    /// Compute the delta base for TurboPFor decoding.
-    /// Block 0 of each large block uses the large block's range.begin as base;
-    /// subsequent blocks use the last doc_id of the previous packed block.
-    if (current_block == 0)
-    {
-        last_decoded_doc_id = static_cast<UInt32>(info.ranges[current_large_block_idx].begin);
-        if (current_large_block_idx > 0)
-            --last_decoded_doc_id;
-    }
-    else
-        last_decoded_doc_id = packed_block_last_doc_ids[current_block - 1];
-
-    auto &data_buf = *stream->getDataBuffer();
-
-    /// Read the compressed payload length (prefix-varint encoded).
-    UInt32 bytes;
-    readPrefixVarUInt32(bytes, data_buf);
-
-    UInt32 count = (current_block + 1 == block_count && tail_size > 0) ? static_cast<UInt32>(tail_size) : static_cast<UInt32>(TURBOPFOR_BLOCK_SIZE);
-
-    uint8_t * src_ptr;
-    if (data_buf.available() >= bytes)
-    {
-        src_ptr = reinterpret_cast<uint8_t *>(data_buf.position());
-        data_buf.position() += bytes;
-    }
-    else
-    {
-        chassert(bytes <= 512);
-        data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
-        src_ptr = stream->packed_buffer;
-    }
-
-    /// `first_doc_id` is stored in the dictionary stream and excluded from TurboPFor encoding.
-    /// For large block 0, packed block 0: allocate an extra slot, decode into offset 1,
-    /// then write `first_doc_id` into slot 0.
-    bool prepend_first_doc_id = (current_large_block_idx == 0 && current_block == 0);
-    UInt32 actual_count = prepend_first_doc_id ? count + 1 : count;
-
-    decoded_count = actual_count;
-    uint32_t * decode_dst = decoded_values + (prepend_first_doc_id ? 1 : 0);
-
-    if (count == TURBOPFOR_BLOCK_SIZE)
-        turbopfor::p4D1Dec128v32(src_ptr, TURBOPFOR_BLOCK_SIZE, decode_dst, last_decoded_doc_id);
-    else
-        turbopfor::p4D1Dec32(src_ptr, count, decode_dst, last_decoded_doc_id);
-
-    if (prepend_first_doc_id)
-        decoded_values[0] = static_cast<uint32_t>(info.ranges[0].begin);
-
-    last_decoded_doc_id = decoded_values[actual_count - 1];
-    index = 0;
-
-    return true;
-}
-
-PackedBlockProbe PostingListCursor::probePackedBlock(size_t block_idx)
+bool PostingListCursor::probeAndDecodePackedBlock(size_t block_idx)
 {
     chassert(stream);
     chassert(block_idx < packed_block_offsets.size());
 
-    /// Compute the delta base — same logic as decodeNextBlock.
+    current_block = block_idx;
+    arithmetic_mode = false;
+
+    /// Compute the delta base for TurboPFor decoding.
     uint32_t delta_base;
     if (block_idx == 0)
     {
@@ -222,103 +140,154 @@ PackedBlockProbe PostingListCursor::probePackedBlock(size_t block_idx)
         delta_base = packed_block_last_doc_ids[block_idx - 1];
 
     /// For large block 0, packed block 0: the first_doc_id is prepended from
-    /// the dictionary.  The arithmetic sequence would be broken by this extra
-    /// element, so we skip the optimization for this single block.
+    /// the dictionary, breaking any arithmetic sequence.  Skip straight to decode.
     bool prepend_first_doc_id = (current_large_block_idx == 0 && block_idx == 0);
-    if (prepend_first_doc_id)
-        return PackedBlockProbe{};
 
-    /// Seek to the packed block and read the length-prefix.
+    /// Seek to the packed block and read the length-prefix (one seek, shared by
+    /// both the probe path and the decode path).
     stream->seek(packed_block_offsets[block_idx]);
     auto & data_buf = *stream->getDataBuffer();
 
     UInt32 bytes;
     readPrefixVarUInt32(bytes, data_buf);
 
-    /// We need at least 1 byte for the header; for constant blocks up to 5 bytes
-    /// (1 header + 4 constant value).  Ensure the buffer has enough data.
-    if (bytes == 0)
-        return PackedBlockProbe{};
+    UInt32 count = (block_idx + 1 == block_count && tail_size > 0)
+                       ? static_cast<UInt32>(tail_size)
+                       : static_cast<UInt32>(TURBOPFOR_BLOCK_SIZE);
 
-    /// Read the header byte.  We need to peek without consuming if this isn't
-    /// an arithmetic block, but since we set need_seek_before_decode = true on
-    /// fallback, the stream position doesn't matter for decodeNextBlock.
-    uint8_t header_byte;
-    if (data_buf.available() >= bytes)
+    /// --- Arithmetic probe (only when first_doc_id prepend is not needed) ---
+    if (!prepend_first_doc_id && bytes > 0)
     {
-        header_byte = static_cast<uint8_t>(*data_buf.position());
-    }
-    else
-    {
-        /// Copy into packed_buffer so we can inspect it.
-        chassert(bytes <= 512);
-        data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
-        header_byte = stream->packed_buffer[0];
-    }
+        uint8_t header_byte;
+        bool data_in_buffer = (data_buf.available() >= bytes);
+        const uint8_t * payload_start;
 
-    uint32_t constant_value = 0;
-
-    if (header_byte == 0x00)
-    {
-        /// All-zero block: b=0, bx=0.  All deltas are 0, step = 1.
-        constant_value = 0;
-    }
-    else if ((header_byte & 0xC0u) == 0xC0u)
-    {
-        /// Constant block: header = 0xC0 | b.
-        unsigned b = header_byte & 0x3Fu;
-        unsigned bytes_stored = (b + 7u) / 8u;
-
-        if (bytes_stored == 0)
+        if (data_in_buffer)
         {
-            /// b=0 constant block means all deltas are 0.
-            constant_value = 0;
+            header_byte = static_cast<uint8_t>(*data_buf.position());
+            payload_start = reinterpret_cast<const uint8_t *>(data_buf.position());
         }
         else
         {
-            /// Read the constant value from the bytes following the header.
-            const uint8_t * payload;
-            if (data_buf.available() >= bytes)
+            /// Copy into packed_buffer so we can inspect header + decode from it.
+            chassert(bytes <= 512);
+            data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
+            header_byte = stream->packed_buffer[0];
+            payload_start = stream->packed_buffer;
+        }
+
+        uint32_t constant_value = 0;
+        bool is_arithmetic = false;
+
+        if (header_byte == 0x00)
+        {
+            /// All-zero block: all deltas are 0, step = 1.
+            constant_value = 0;
+            is_arithmetic = true;
+        }
+        else if ((header_byte & 0xC0u) == 0xC0u)
+        {
+            /// Constant block: header = 0xC0 | b.
+            unsigned b = header_byte & 0x3Fu;
+            unsigned bytes_stored = (b + 7u) / 8u;
+
+            if (bytes_stored == 0)
             {
-                /// Data still in the buffer (we only peeked the header byte above).
-                payload = reinterpret_cast<const uint8_t *>(data_buf.position()) + 1;
+                constant_value = 0;
+                is_arithmetic = true;
             }
             else
             {
-                /// Already copied into packed_buffer.
-                payload = stream->packed_buffer + 1;
+                const uint8_t * cv_payload = payload_start + 1;
+                constant_value = 0;
+                for (unsigned i = 0; i < bytes_stored && i < 4; ++i)
+                    constant_value |= static_cast<uint32_t>(cv_payload[i]) << (8u * i);
+                if (b < 32u)
+                    constant_value &= (1u << b) - 1u;
+                is_arithmetic = true;
             }
-
-            /// Load little-endian value from 1-4 bytes.
-            constant_value = 0;
-            for (unsigned i = 0; i < bytes_stored && i < 4; ++i)
-                constant_value |= static_cast<uint32_t>(payload[i]) << (8u * i);
-
-            if (b < 32u)
-                constant_value &= (1u << b) - 1u;
         }
+
+        if (is_arithmetic)
+        {
+            arithmetic_mode = true;
+            arithmetic_step = constant_value + 1;
+            arithmetic_first = delta_base + arithmetic_step;
+            arithmetic_count = count;
+            decoded_count = count;
+            index = 0;
+
+            return true;
+        }
+
+        /// Non-arithmetic block — continue to decode from current data.
+        /// The stream has already read the length-prefix.  If data was copied
+        /// into packed_buffer (non-inline path), we can decode directly from it.
+        /// If data is still in the read buffer, consume it now.
+        uint8_t * src_ptr;
+        if (data_in_buffer)
+        {
+            src_ptr = reinterpret_cast<uint8_t *>(data_buf.position());
+            data_buf.position() += bytes;
+        }
+        else
+        {
+            /// Already copied into packed_buffer above.
+            src_ptr = stream->packed_buffer;
+        }
+
+        last_decoded_doc_id = delta_base;
+        UInt32 actual_count = count;
+        decoded_count = actual_count;
+        uint32_t * decode_dst = decoded_values;
+
+        if (count == TURBOPFOR_BLOCK_SIZE)
+            turbopfor::p4D1Dec128v32(src_ptr, TURBOPFOR_BLOCK_SIZE, decode_dst, last_decoded_doc_id);
+        else
+            turbopfor::p4D1Dec32(src_ptr, count, decode_dst, last_decoded_doc_id);
+
+        last_decoded_doc_id = decoded_values[actual_count - 1];
+        index = 0;
+
+        return false;
     }
-    else
+
+    /// --- Direct decode path (prepend_first_doc_id or bytes == 0) ---
+    /// Need to read the payload from the current stream position (length-prefix
+    /// already consumed above, so no second seek is needed).
     {
-        /// Not an arithmetic block (simple bitpacking with exceptions, etc.).
-        return PackedBlockProbe{};
+        uint8_t * src_ptr;
+        if (data_buf.available() >= bytes)
+        {
+            src_ptr = reinterpret_cast<uint8_t *>(data_buf.position());
+            data_buf.position() += bytes;
+        }
+        else
+        {
+            chassert(bytes <= 512);
+            data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
+            src_ptr = stream->packed_buffer;
+        }
+
+        UInt32 actual_count = prepend_first_doc_id ? count + 1 : count;
+        decoded_count = actual_count;
+        uint32_t * decode_dst = decoded_values + (prepend_first_doc_id ? 1 : 0);
+
+        last_decoded_doc_id = delta_base;
+
+        if (count == TURBOPFOR_BLOCK_SIZE)
+            turbopfor::p4D1Dec128v32(src_ptr, TURBOPFOR_BLOCK_SIZE, decode_dst, last_decoded_doc_id);
+        else
+            turbopfor::p4D1Dec32(src_ptr, count, decode_dst, last_decoded_doc_id);
+
+        if (prepend_first_doc_id)
+            decoded_values[0] = static_cast<uint32_t>(info.ranges[0].begin);
+
+        last_decoded_doc_id = decoded_values[actual_count - 1];
+        index = 0;
+
+        return false;
     }
-
-    uint32_t step = constant_value + 1;
-    uint32_t count = (block_idx + 1 == block_count && tail_size > 0)
-                         ? static_cast<uint32_t>(tail_size)
-                         : static_cast<uint32_t>(TURBOPFOR_BLOCK_SIZE);
-
-    uint32_t first_doc_id = delta_base + step;
-    uint32_t last_doc_id = delta_base + step * count;
-
-    return PackedBlockProbe{
-        .is_arithmetic = true,
-        .step = step,
-        .first_doc_id = first_doc_id,
-        .last_doc_id = last_doc_id,
-        .count = count,
-    };
 }
 
 void PostingListCursor::seek(uint32_t target)
@@ -411,42 +380,32 @@ bool PostingListCursor::seekImpl(uint32_t target)
     /// land in the same packed block (common in leapfrog intersection).
     if (j != current_block || decoded_count == 0)
     {
-        /// Probe the header to check for arithmetic-sequence block.
-        PackedBlockProbe probe = probePackedBlock(j);
-
-        if (probe.is_arithmetic)
+        /// Probe the header and, if non-arithmetic, decode in one pass
+        /// (avoids a redundant seek + length-prefix re-read).
+        if (probeAndDecodePackedBlock(j))
         {
             /// Direct arithmetic computation — no decompression needed.
-            current_block = j;
-            arithmetic_mode = true;
-            arithmetic_step = probe.step;
-            arithmetic_first = probe.first_doc_id;
-            arithmetic_count = probe.count;
-            decoded_count = probe.count;
+            /// arithmetic_mode / arithmetic_step / arithmetic_first / arithmetic_count
+            /// are already populated by probeAndDecodePackedBlock.
 
-            if (target <= probe.first_doc_id)
+            if (target <= arithmetic_first)
             {
                 index = 0;
             }
             else
             {
-                uint32_t offset_from_first = target - probe.first_doc_id;
-                uint32_t idx = offset_from_first / probe.step;
-                uint32_t actual = probe.first_doc_id + idx * probe.step;
-                if (actual < target && idx + 1 < probe.count)
+                uint32_t offset_from_first = target - arithmetic_first;
+                uint32_t idx = offset_from_first / arithmetic_step;
+                uint32_t actual = arithmetic_first + idx * arithmetic_step;
+                if (actual < target && idx + 1 < arithmetic_count)
                     ++idx;
                 index = idx;
             }
 
             return true;
         }
-        else
-        {
-            /// Non-arithmetic block — fall back to full decode.
-            current_block = j;
-            need_seek_before_decode = true;
-            decodeNextBlock();
-        }
+
+        /// Non-arithmetic block already decoded by probeAndDecodePackedBlock.
     }
 
     /// Binary search within the decoded packed block.
@@ -469,17 +428,11 @@ void PostingListCursor::next()
 
     if (index >= decoded_count)
     {
-        /// If we were in arithmetic mode, the stream position is not at the end
-        /// of the current packed block (we never read the payload), so we need
-        /// to seek before decoding the next block.
-        if (arithmetic_mode)
-            need_seek_before_decode = true;
-
         ++current_block;
         if (current_block < block_count)
         {
-            /// More packed blocks in this large block — decode sequentially.
-            decodeNextBlock();
+            /// More packed blocks in this large block — probe + decode.
+            probeAndDecodePackedBlock(current_block);
             return;
         }
 
@@ -492,7 +445,7 @@ void PostingListCursor::next()
         }
 
         prepare(next_large_block);
-        decodeNextBlock();
+        probeAndDecodePackedBlock(0);
     }
 }
 
@@ -563,18 +516,18 @@ inline void padColumn(UInt8 * __restrict out, const uint32_t * values, size_t ro
 /// Scatter-write arithmetic-sequence doc_ids into `out` for the range [row_begin, row_end].
 /// Avoids full TurboPFor decompression for constant-delta and all-zero blocks.
 template <PadOp op>
-inline void padArithmeticBlock(UInt8 * __restrict out, const PackedBlockProbe & probe, size_t row_begin, size_t row_end)
+inline void padArithmeticBlock(UInt8 * __restrict out, uint32_t first_doc_id, uint32_t last_doc_id, uint32_t step, size_t row_begin, size_t row_end)
 {
-    uint32_t start = std::max(probe.first_doc_id, static_cast<uint32_t>(row_begin));
-    uint32_t end = std::min(probe.last_doc_id, static_cast<uint32_t>(row_end));
+    uint32_t start = std::max(first_doc_id, static_cast<uint32_t>(row_begin));
+    uint32_t end = std::min(last_doc_id, static_cast<uint32_t>(row_end));
 
     if (start > end)
         return;
 
     /// Find the first doc_id >= start in the arithmetic sequence.
-    uint32_t offset = start - probe.first_doc_id;
-    uint32_t idx = (offset + probe.step - 1) / probe.step;  /// ceil division
-    uint32_t doc_id = probe.first_doc_id + idx * probe.step;
+    uint32_t offset = start - first_doc_id;
+    uint32_t idx = (offset + step - 1) / step;  /// ceil division
+    uint32_t doc_id = first_doc_id + idx * step;
 
     while (doc_id <= end)
     {
@@ -582,7 +535,7 @@ inline void padArithmeticBlock(UInt8 * __restrict out, const PackedBlockProbe & 
             out[doc_id - row_begin] = 1;
         else
             ++out[doc_id - row_begin];
-        doc_id += probe.step;
+        doc_id += step;
     }
 }
 
@@ -627,29 +580,18 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
     else
         blk_end = static_cast<size_t>(blk_end_it - packed_block_last_doc_ids.begin()) + 1;  /// +1 for exclusive upper bound.
 
-    /// Seek directly to the first relevant packed block.
-    current_block = blk_start;
-    need_seek_before_decode = true;
-
     for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
-        current_block = blk;
-
-        /// Try probing the header for an arithmetic-sequence block.
-        PackedBlockProbe probe = probePackedBlock(blk);
-        if (probe.is_arithmetic)
+        /// Probe the header; if non-arithmetic, decode in one pass.
+        if (probeAndDecodePackedBlock(blk))
         {
             /// Scatter arithmetic doc_ids directly — no decompression.
-            padArithmeticBlock<PadOp::Or>(out, probe, row_begin, row_end);
-            need_seek_before_decode = true;
+            uint32_t last_doc_id = arithmetic_first + (arithmetic_count - 1) * arithmetic_step;
+            padArithmeticBlock<PadOp::Or>(out, arithmetic_first, last_doc_id, arithmetic_step, row_begin, row_end);
             continue;
         }
 
-        /// Non-arithmetic block — full decode.  probePackedBlock moved the stream,
-        /// so we must seek back.
-        need_seek_before_decode = true;
-        if (!decodeNextBlock())
-            return;
+        /// Non-arithmetic block already decoded by probeAndDecodePackedBlock.
 
         if (decoded_count == 0)
             continue;
@@ -741,26 +683,17 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
     else
         blk_end = static_cast<size_t>(blk_end_it - packed_block_last_doc_ids.begin()) + 1;
 
-    current_block = blk_start;
-    need_seek_before_decode = true;
-
     for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
-        current_block = blk;
-
-        /// Try probing the header for an arithmetic-sequence block.
-        PackedBlockProbe probe = probePackedBlock(blk);
-        if (probe.is_arithmetic)
+        /// Probe the header; if non-arithmetic, decode in one pass.
+        if (probeAndDecodePackedBlock(blk))
         {
-            padArithmeticBlock<PadOp::And>(out, probe, row_begin, row_end);
-            need_seek_before_decode = true;
+            uint32_t last_doc_id = arithmetic_first + (arithmetic_count - 1) * arithmetic_step;
+            padArithmeticBlock<PadOp::And>(out, arithmetic_first, last_doc_id, arithmetic_step, row_begin, row_end);
             continue;
         }
 
-        /// Non-arithmetic block — full decode.
-        need_seek_before_decode = true;
-        if (!decodeNextBlock())
-            return;
+        /// Non-arithmetic block already decoded by probeAndDecodePackedBlock.
 
         if (decoded_count == 0)
             continue;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -3,6 +3,7 @@
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h>
 #include <algorithm>
+#include <cstring>
 
 #include <turbopfor.h>
 namespace DB
@@ -524,7 +525,27 @@ inline void padArithmeticBlock(UInt8 * __restrict out, uint32_t first_doc_id, ui
     if (start > end)
         return;
 
-    /// Find the first doc_id >= start in the arithmetic sequence.
+    /// Fast path for step=1 (zero-delta / consecutive doc_ids) — the most common
+    /// arithmetic block pattern.  Replaces N scalar stores with a single memset
+    /// (Or) or a tight loop that the compiler auto-vectorizes to SIMD paddb (And).
+    if (step == 1)
+    {
+        size_t off = start - row_begin;
+        size_t count = end - start + 1;
+        if constexpr (op == PadOp::Or)
+        {
+            memset(out + off, 1, count);
+        }
+        else
+        {
+            UInt8 * __restrict dst = out + off;
+            for (size_t i = 0; i < count; ++i)
+                ++dst[i];
+        }
+        return;
+    }
+
+    /// General case: non-unit step.
     uint32_t offset = start - first_doc_id;
     uint32_t idx = (offset + step - 1) / step;  /// ceil division
     uint32_t doc_id = first_doc_id + idx * step;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -1,84 +1,20 @@
 #include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
+#include <Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h>
 #include <algorithm>
 
 #include <turbopfor.h>
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int ATTEMPT_TO_READ_AFTER_EOF;
-}
-
 namespace
 {
 
-/// Prefix-based variable-length integer decoding (mirrors PostingListData.cpp VarInt encoding).
-/// Used for reading compressed block sizes and Index Section fields in .lpst files.
-///
-/// Encoding scheme (first byte determines length):
-///   [0, 176]     → 1 byte   (value = first byte)
-///   [177, 240]   → 2 bytes  (value up to 16560)
-///   [241, 248]   → 3 bytes  (value up to 540848)
-///   249          → 4 bytes  (value up to 2^24 - 1)
-///   250          → 5 bytes  (value up to 2^32 - 1)
+/// Convenience alias for the shared prefix-varint codec.
 inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 {
-    static constexpr UInt32 ONE_BYTE_MAX = 176;
-    static constexpr UInt8 TWO_BYTE_MARKER_END = 240;
-    static constexpr UInt8 THREE_BYTE_MARKER_END = 248;
-    static constexpr UInt8 FOUR_BYTE_MARKER = 249;
-
-    static constexpr UInt32 TWO_BYTE_OFFSET = 177;
-    static constexpr UInt32 THREE_BYTE_OFFSET = 16561;
-
-    if (istr.eof()) [[unlikely]]
-        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-
-    const UInt8 first_byte = *istr.position()++;
-
-    if (first_byte <= ONE_BYTE_MAX)
-    {
-        x = first_byte;
-        return;
-    }
-
-    if (istr.eof()) [[unlikely]]
-        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-    const UInt8 second_byte = *istr.position()++;
-
-    if (first_byte <= TWO_BYTE_MARKER_END)
-    {
-        x = ((first_byte - 177) << 8) + second_byte + TWO_BYTE_OFFSET;
-        return;
-    }
-
-    if (istr.eof()) [[unlikely]]
-        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-    const UInt8 third_byte = *istr.position()++;
-
-    if (first_byte <= THREE_BYTE_MARKER_END)
-    {
-        x = ((first_byte - 241) << 16) + (second_byte << 8) + third_byte + THREE_BYTE_OFFSET;
-        return;
-    }
-
-    if (istr.eof()) [[unlikely]]
-        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-    const UInt8 fourth_byte = *istr.position()++;
-
-    if (first_byte == FOUR_BYTE_MARKER)
-    {
-        x = (second_byte << 16) | (third_byte << 8) | fourth_byte;
-        return;
-    }
-
-    if (istr.eof()) [[unlikely]]
-        throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-    const UInt8 fifth_byte = *istr.position()++;
-    x = (UInt32(second_byte) << 24) | (UInt32(third_byte) << 16) | (UInt32(fourth_byte) << 8) | fifth_byte;
+    LengthPrefixedInt::readUInt32(x, istr);
 }
 
 } // anonymous namespace
@@ -89,6 +25,17 @@ PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_strea
     , info(info_)
     , total_large_blocks(info.offsets.size())
 {
+    /// Compute global density once: cardinality / total_range_span.
+    if (!info.ranges.empty())
+    {
+        UInt32 global_begin = static_cast<UInt32>(info.ranges.front().begin);
+        UInt32 global_end = static_cast<UInt32>(info.ranges.back().end);
+        UInt32 range_span = global_end - global_begin + 1;
+        density_val = (range_span > 0) ? static_cast<double>(info.cardinality) / static_cast<double>(range_span) : 1.0;
+    }
+    else
+        density_val = 1.0;
+
     if (total_large_blocks > 0)
         prepare(0);
     else if (info.embedded_postings)
@@ -129,11 +76,6 @@ void PostingListCursor::prepare(size_t large_block_idx)
         current_large_block_idx = large_block_idx;
         is_valid = decoded_count > 0;
         is_embedded = true;
-
-        if (decoded_count >= 2)
-            density_val = static_cast<double>(decoded_count) / static_cast<double>(decoded_values[decoded_count - 1] - decoded_values[0] + 1);
-        else
-            density_val = 1.0;
         return;
     }
 
@@ -154,11 +96,6 @@ void PostingListCursor::prepare(size_t large_block_idx)
     current_block = 0;
     current_large_block_idx = large_block_idx;
     need_seek_before_decode = true;
-
-    /// Density = doc_count / row_id_span.  Used for algorithm selection.
-    const auto & range = info.ranges[large_block_idx];
-    UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
-    density_val = (range_span > 0) ? static_cast<double>(large_block_doc_count + (large_block_idx == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
 
     /// Seek to the Index Section and read the packed block index.
     chassert(block_meta.index_offset != 0);
@@ -370,7 +307,8 @@ enum class PadOp { Or, And };
 
 /// Scatter-write into `out` for doc_ids in values[begin..length).
 /// PadOp::Or assigns 1, PadOp::And increments the counter.
-/// 4-wide loop with prefetch for cache-line utilization.
+/// 4-wide loop with prefetch for cache-line utilization (~5-10% improvement
+/// on dense posting list iteration in real-world benchmarks).
 template <PadOp op>
 inline void padColumn(UInt8 * __restrict out, const uint32_t * values, size_t row_begin, size_t begin, size_t length)
 {
@@ -768,19 +706,13 @@ void intersectLeapfrogLinear(UInt8 * out, const std::vector<PostingListCursorPtr
     {
         uint32_t min_val = vals[0];
         uint32_t max_val = vals[0];
-        size_t min_idx = 0;
 
         for (size_t i = 1; i < n; ++i)
         {
             if (vals[i] < min_val)
-            {
                 min_val = vals[i];
-                min_idx = i;
-            }
             else if (vals[i] > max_val)
-            {
                 max_val = vals[i];
-            }
         }
 
         if (max_val >= effective_end)
@@ -799,10 +731,16 @@ void intersectLeapfrogLinear(UInt8 * out, const std::vector<PostingListCursorPtr
         }
         else
         {
-            cursors[min_idx]->seek(max_val);
-            if (!cursors[min_idx]->valid())
-                return;
-            vals[min_idx] = cursors[min_idx]->value();
+            for (size_t i = 0; i < n; ++i)
+            {
+                if (vals[i] < max_val)
+                {
+                    cursors[i]->seek(max_val);
+                    if (!cursors[i]->valid())
+                        return;
+                    vals[i] = cursors[i]->value();
+                }
+            }
         }
     }
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -165,6 +165,7 @@ void PostingListCursor::prepare(size_t large_block_idx)
 
     current_block = 0;
     current_large_block_idx = large_block_idx;
+    need_seek_before_decode = true;
 
     /// Compute density
     const auto & range = info.ranges[large_block_idx];
@@ -204,7 +205,12 @@ bool PostingListCursor::decodeNextBlock()
     chassert(stream);
 
     chassert(current_block < packed_block_offsets.size());
-    stream->seek(packed_block_offsets[current_block]);
+
+    if (need_seek_before_decode)
+    {
+        stream->seek(packed_block_offsets[current_block]);
+        need_seek_before_decode = false;
+    }
 
     /// Compute delta base for the target packed block.
     if (current_block == 0)
@@ -330,6 +336,7 @@ bool PostingListCursor::seekImpl(uint32_t target)
     /// Random seek to the target packed block via `need_seek_before_decode`.
     /// Delta base and first_doc_id prepend are handled inside `decodeNextBlock`.
     current_block = j;
+    need_seek_before_decode = true;
     decodeNextBlock();
 
     /// Search within the decoded block

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -90,7 +90,6 @@ PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, con
     : stream(stream_)
     , info(info_)
 {
-    current_values.reserve(TURBOPFOR_BLOCK_SIZE);
     large_blocks.push_back(large_block);
     prepare(large_block);
 }
@@ -115,7 +114,11 @@ void PostingListCursor::prepare(size_t large_block_idx)
     if (current_large_block_idx == large_block_idx && current_large_block_idx != std::numeric_limits<size_t>::max())
         return;
 
-    current_values.reserve(TURBOPFOR_BLOCK_SIZE);
+    /// Large block 0's packed block 0 needs to prepend `first_doc_id` (which is stored
+    /// separately in the dictionary stream and not included in TurboPFor encoding), so
+    /// reserve one extra slot to avoid reallocation during decodeNextBlock.
+    current_values.reserve(TURBOPFOR_BLOCK_SIZE + (large_block_idx == 0 ? 1 : 0));
+    current_values.clear();
 
     if (info.embedded_postings)
     {
@@ -145,7 +148,6 @@ void PostingListCursor::prepare(size_t large_block_idx)
 
     const auto & block_meta = info.offsets[large_block_idx];
     large_block_doc_count = block_meta.block_doc_count;
-    last_decoded_doc_id = static_cast<UInt32>(info.ranges[large_block_idx].begin);
 
     /// Compute packed block structure for the delta-encoded portion
     size_t full_blocks = large_block_doc_count / TURBOPFOR_BLOCK_SIZE;
@@ -160,7 +162,6 @@ void PostingListCursor::prepare(size_t large_block_idx)
     UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
     density_val = (range_span > 0) ? static_cast<double>(large_block_doc_count + (large_block_idx == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
 
-    /// --- V2: Load Index Session ---
     /// In V2 format, block_meta.offset points directly to the Index Section
     /// (not the Data Section). Seek there and read the packed block index.
     stream->seek(block_meta.offset);
@@ -197,7 +198,11 @@ bool PostingListCursor::decodeNextBlock()
 
     /// Compute delta base for the target packed block.
     if (current_block == 0)
+    {
         last_decoded_doc_id = static_cast<UInt32>(info.ranges[current_large_block_idx].begin);
+        if (current_large_block_idx > 0)
+            --last_decoded_doc_id;
+    }
     else
         last_decoded_doc_id = packed_block_last_doc_ids[current_block - 1];
 
@@ -222,13 +227,25 @@ bool PostingListCursor::decodeNextBlock()
         src_ptr = stream->packed_buffer;
     }
 
-    current_values.resize(count);
-    if (count == 128)
-        turbopfor::p4D1Dec128v32(src_ptr, 128, current_values.data(), last_decoded_doc_id);
-    else
-        turbopfor::p4D1Dec32(src_ptr, count, current_values.data(), last_decoded_doc_id);
+    /// `first_doc_id` is stored separately in the dictionary stream and is NOT included
+    /// in the TurboPFor-encoded packed blocks. For large block 0's packed block 0, we need
+    /// to prepend it manually: resize to `count + 1`, decode into offset 1, then fill slot 0.
+    /// This mirrors the old `ReaderStreamCursor` logic with `include_first_doc = true`.
+    bool prepend_first_doc_id = (current_large_block_idx == 0 && current_block == 0);
+    UInt32 actual_count = prepend_first_doc_id ? count + 1 : count;
 
-    last_decoded_doc_id = current_values[count - 1];
+    current_values.resize(actual_count);
+    uint32_t * decode_dst = current_values.data() + (prepend_first_doc_id ? 1 : 0);
+
+    if (count == 128)
+        turbopfor::p4D1Dec128v32(src_ptr, 128, decode_dst, last_decoded_doc_id);
+    else
+        turbopfor::p4D1Dec32(src_ptr, count, decode_dst, last_decoded_doc_id);
+
+    if (prepend_first_doc_id)
+        current_values[0] = static_cast<uint32_t>(info.ranges[0].begin);
+
+    last_decoded_doc_id = current_values[actual_count - 1];
     index = 0;
 
     return true;
@@ -280,8 +297,7 @@ bool PostingListCursor::seekImpl(uint32_t target)
         return false;
     }
 
-    /// V2: use packed block index for O(log N) random access within the large block.
-
+    /// Use packed block index for O(log N) random access within the large block.
     /// First check if target is in the current decoded block
     if (index < current_values.size())
     {
@@ -390,14 +406,9 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
     /// Process the current already-decoded block, then decode subsequent blocks sequentially.
     for (size_t blk = current_block; blk < block_count; ++blk)
     {
-        /// For the first iteration, current_values already has the decoded block.
-        /// For subsequent iterations, decode the next block from the stream.
-        if (blk > current_block)
-        {
-            current_block = blk;
-            if (!decodeNextBlock())
-                return;
-        }
+        current_block = blk;
+        if (!decodeNextBlock())
+            return;
 
         if (current_values.empty())
             continue;
@@ -494,12 +505,9 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
     /// Process the current already-decoded block, then decode subsequent blocks sequentially.
     for (size_t blk = current_block; blk < block_count; ++blk)
     {
-        if (blk > current_block)
-        {
-            current_block = blk;
-            if (!decodeNextBlock())
-                return;
-        }
+        current_block = blk;
+        if (!decodeNextBlock())
+            return;
 
         if (current_values.empty())
             continue;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 
 #include <turbopfor.h>
-#pragma clang optimize off
 namespace DB
 {
 
@@ -18,16 +17,15 @@ namespace ErrorCodes
 namespace
 {
 
-/// Prefix-Based Variable-Length Integer Decoding.
-/// This mirrors the encoding used in PostingListData.cpp (VarInt namespace).
+/// Prefix-based variable-length integer decoding (mirrors PostingListData.cpp VarInt encoding).
 /// Used for reading compressed block sizes and Index Section fields in .lpst files.
 ///
-/// Encoding thresholds:
-/// - [0 - 176]        : 1 byte
-/// - [177 - 16560]    : 2 bytes
-/// - [16561 - 540848] : 3 bytes
-/// - [540849 - 2^24-1]: 4 bytes (Marker 249)
-/// - [Up to 2^32-1]   : 5 bytes (Marker 250)
+/// Encoding scheme (first byte determines length):
+///   [0, 176]     → 1 byte   (value = first byte)
+///   [177, 240]   → 2 bytes  (value up to 16560)
+///   [241, 248]   → 3 bytes  (value up to 540848)
+///   249          → 4 bytes  (value up to 2^24 - 1)
+///   250          → 5 bytes  (value up to 2^32 - 1)
 inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 {
     static constexpr UInt32 ONE_BYTE_MAX = 176;
@@ -118,16 +116,15 @@ void PostingListCursor::prepare(size_t large_block_idx)
 {
     has_prepared_first_large_block = true;
 
-    /// Large block 0's packed block 0 needs to prepend `first_doc_id` (which is stored
-    /// separately in the dictionary stream and not included in TurboPFor encoding), so
-    /// reserve one extra slot to avoid reallocation during decodeNextBlock.
+    /// Large block 0, packed block 0 needs an extra slot for `first_doc_id`
+    /// (stored in the dictionary, not in TurboPFor data).
     current_values.reserve(TURBOPFOR_BLOCK_SIZE + (large_block_idx == 0 ? 1 : 0));
     current_values.clear();
 
     if (info.embedded_postings)
     {
-        /// Embedded postings: already stored as a Roaring Bitmap.
-        /// Decode all doc IDs into current_values at once.
+        /// Embedded posting list: already materialized as a Roaring Bitmap.
+        /// Decode all doc_ids into current_values in one shot.
         chassert(!stream);
         current_values.resize(info.embedded_postings->cardinality());
         info.embedded_postings->toUint32Array(current_values.data());
@@ -144,8 +141,8 @@ void PostingListCursor::prepare(size_t large_block_idx)
         return;
     }
 
-    /// Large posting list: read from LargePostingListReaderStream using TurboPFor encoding.
-    /// Each large block corresponds to one LargePostingBlockMeta.
+    /// Large posting list: read from .lpst stream, TurboPFor delta-encoded.
+    /// Each large block has a corresponding `LargePostingBlockMeta`.
     chassert(stream);
     chassert(large_block_idx < info.offsets.size());
     chassert(large_block_idx < info.ranges.size());
@@ -153,7 +150,7 @@ void PostingListCursor::prepare(size_t large_block_idx)
     const auto & block_meta = info.offsets[large_block_idx];
     large_block_doc_count = block_meta.block_doc_count;
 
-    /// Compute packed block structure for the delta-encoded portion
+    /// Compute packed block structure from the total doc count.
     size_t full_blocks = large_block_doc_count / TURBOPFOR_BLOCK_SIZE;
     tail_size = large_block_doc_count % TURBOPFOR_BLOCK_SIZE;
     block_count = full_blocks + (tail_size > 0 ? 1 : 0);
@@ -162,18 +159,17 @@ void PostingListCursor::prepare(size_t large_block_idx)
     current_large_block_idx = large_block_idx;
     need_seek_before_decode = true;
 
-    /// Compute density
+    /// Density = doc_count / row_id_span.  Used for algorithm selection.
     const auto & range = info.ranges[large_block_idx];
     UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
     density_val = (range_span > 0) ? static_cast<double>(large_block_doc_count + (large_block_idx == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
 
-    /// In V2 format, block_meta.index_offset points to the Index Section.
-    /// Seek there and read the packed block index.
+    /// Seek to the Index Section and read the packed block index.
     chassert(block_meta.index_offset != 0);
     stream->seek(block_meta.index_offset);
     auto & data_buf = *stream->getDataBuffer();
 
-    /// Read Index Section: [num_packed_blocks] [last_doc_ids...] [offsets...]
+    /// Index Section layout: [num_packed_blocks] [last_doc_ids...] [offsets...]
     UInt32 num_packed_blocks;
     readPrefixVarUInt32(num_packed_blocks, data_buf);
     chassert(num_packed_blocks == block_count);
@@ -207,7 +203,9 @@ bool PostingListCursor::decodeNextBlock()
         need_seek_before_decode = false;
     }
 
-    /// Compute delta base for the target packed block.
+    /// Compute the delta base for TurboPFor decoding.
+    /// Block 0 of each large block uses the large block's range.begin as base;
+    /// subsequent blocks use the last doc_id of the previous packed block.
     if (current_block == 0)
     {
         last_decoded_doc_id = static_cast<UInt32>(info.ranges[current_large_block_idx].begin);
@@ -219,7 +217,7 @@ bool PostingListCursor::decodeNextBlock()
 
     auto &data_buf = *stream->getDataBuffer();
 
-    /// Read compressed bytes length (Prefix VarInt encoded in .lpst)
+    /// Read the compressed payload length (prefix-varint encoded).
     UInt32 bytes;
     readPrefixVarUInt32(bytes, data_buf);
 
@@ -238,10 +236,9 @@ bool PostingListCursor::decodeNextBlock()
         src_ptr = stream->packed_buffer;
     }
 
-    /// `first_doc_id` is stored separately in the dictionary stream and is NOT included
-    /// in the TurboPFor-encoded packed blocks. For large block 0's packed block 0, we need
-    /// to prepend it manually: resize to `count + 1`, decode into offset 1, then fill slot 0.
-    /// This mirrors the old `ReaderStreamCursor` logic with `include_first_doc = true`.
+    /// `first_doc_id` is stored in the dictionary stream and excluded from TurboPFor encoding.
+    /// For large block 0, packed block 0: allocate an extra slot, decode into offset 1,
+    /// then write `first_doc_id` into slot 0.
     bool prepend_first_doc_id = (current_large_block_idx == 0 && current_block == 0);
     UInt32 actual_count = prepend_first_doc_id ? count + 1 : count;
 
@@ -264,13 +261,12 @@ bool PostingListCursor::decodeNextBlock()
 
 void PostingListCursor::seek(uint32_t target)
 {
-    /// Fast path: try current already-prepared large block first.
+    /// Fast path: target may fall within the currently loaded large block.
     if (!is_embedded && seekImpl(target))
         return;
 
-    /// Slow path: current large block doesn't contain target.
-    /// Start from next large block (current one already failed in fast path).
-    /// For embedded postings, seekImpl above was skipped, so start from current_large_block_idx.
+    /// Slow path: scan subsequent large blocks whose range covers the target.
+    /// For embedded postings, `seekImpl` was skipped above, so start from current index.
     bool found = false;
     size_t start = is_embedded ? current_large_block_idx : current_large_block_idx + 1;
     for (size_t i = start; i < total_large_blocks; ++i)
@@ -294,7 +290,7 @@ bool PostingListCursor::seekImpl(uint32_t target)
 {
     if (is_embedded)
     {
-        /// Embedded: all values in current_values, simple binary search
+        /// Embedded: all doc_ids are in current_values, use binary search.
         auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
         if (it != current_values.end())
         {
@@ -304,8 +300,7 @@ bool PostingListCursor::seekImpl(uint32_t target)
         return false;
     }
 
-    /// Use packed block index for O(log N) random access within the large block.
-    /// First check if target is in the current decoded block
+    /// Check if target falls within the already-decoded packed block.
     if (index < current_values.size())
     {
         auto it = std::lower_bound(current_values.begin() + index, current_values.end(), target);
@@ -316,21 +311,21 @@ bool PostingListCursor::seekImpl(uint32_t target)
         }
     }
 
-    /// Binary search on packed_block_last_doc_ids to find the target packed block.
-    /// Find the first j where last_doc_ids[j] >= target.
+    /// Binary search on packed_block_last_doc_ids: find the first packed block
+    /// whose last doc_id >= target.
     auto it = std::lower_bound(packed_block_last_doc_ids.begin(), packed_block_last_doc_ids.end(), target);
     if (it == packed_block_last_doc_ids.end())
         return false;
 
     size_t j = static_cast<size_t>(it - packed_block_last_doc_ids.begin());
 
-    /// Random seek to the target packed block via `need_seek_before_decode`.
-    /// Delta base and first_doc_id prepend are handled inside `decodeNextBlock`.
+    /// Seek to and decode the target packed block.
+    /// `need_seek_before_decode` tells `decodeNextBlock` to seek to the absolute offset.
     current_block = j;
     need_seek_before_decode = true;
     decodeNextBlock();
 
-    /// Search within the decoded block
+    /// Binary search within the decoded packed block.
     auto found_it = std::lower_bound(current_values.begin(), current_values.end(), target);
     if (found_it != current_values.end())
     {
@@ -353,13 +348,12 @@ void PostingListCursor::next()
         ++current_block;
         if (current_block < block_count)
         {
-            /// Still within current large block, decode next packed block.
-            /// Sequential read: need_seek_before_decode stays false.
+            /// More packed blocks in this large block — decode sequentially.
             decodeNextBlock();
             return;
         }
 
-        /// All packed blocks in current large block exhausted, advance to next large block.
+        /// Current large block exhausted — advance to next one.
         size_t next_large_block = current_large_block_idx + 1;
         if (next_large_block >= total_large_blocks)
         {
@@ -372,6 +366,8 @@ void PostingListCursor::next()
     }
 }
 
+/// Scatter-write 1s into `out` for doc_ids in current_values[begin..length).
+/// 4-wide loop with prefetch for cache-line utilization.
 inline void padColumnForOr(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
 {
     const uint32_t * data = current_values.data();
@@ -423,7 +419,7 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         return;
     }
 
-    /// Process the current already-decoded block, then decode subsequent blocks sequentially.
+    /// Process the current packed block, then decode and process subsequent blocks.
     for (size_t blk = current_block; blk < block_count; ++blk)
     {
         current_block = blk;
@@ -433,12 +429,10 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         if (current_values.empty())
             continue;
 
-        /// Skip blocks entirely before row_begin
-        if (current_values.back() < row_begin)
+        if (current_values.back() < row_begin)  /// Entire block before range — skip.
             continue;
 
-        /// Skip blocks entirely after row_end
-        if (current_values.front() > row_end)
+        if (current_values.front() > row_end)   /// Entire block after range — done.
             return;
 
         auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
@@ -475,6 +469,8 @@ void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_row
     }
 }
 
+/// Scatter-increment counters in `out` for doc_ids in current_values[begin..length).
+/// 4-wide loop with prefetch for cache-line utilization.
 inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
 {
     const uint32_t *p = current_values.data() + begin;
@@ -573,7 +569,7 @@ void PostingListCursor::linearAnd(UInt8 * data, size_t row_offset, size_t num_ro
 namespace
 {
 
-/// Helper struct for min-heap based intersection algorithm.
+/// Element for the min-heap used in N-way intersection.
 struct HeapItem
 {
     uint32_t val = 0;
@@ -584,7 +580,7 @@ struct HeapItem
     bool operator>(const HeapItem & other) const { return val > other.val; }
 };
 
-/// Two-way merge intersection using skip-list style seek.
+/// Two-cursor intersection.  The lagging cursor seeks to the leading cursor's doc_id.
 void intersectTwo(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, size_t row_offset, size_t effective_end)
 {
     while (c0->valid() && c1->valid())
@@ -611,7 +607,7 @@ void intersectTwo(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1,
     }
 }
 
-/// Three-way merge intersection.
+/// Three-cursor intersection.  All cursors behind the maximum seek forward.
 void intersectThree(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, PostingListCursorPtr c2, size_t row_offset, size_t effective_end)
 {
     uint32_t v0 = 0;
@@ -648,7 +644,7 @@ void intersectThree(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c
     }
 }
 
-/// Four-way merge intersection.
+/// Four-cursor intersection.
 void intersectFour(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1, PostingListCursorPtr c2, PostingListCursorPtr c3, size_t row_offset, size_t effective_end)
 {
     uint32_t v0 = 0;
@@ -689,7 +685,8 @@ void intersectFour(UInt8 * out, PostingListCursorPtr c0, PostingListCursorPtr c1
     }
 }
 
-/// Leapfrog intersection with linear min/max scan.
+/// N-way leapfrog intersection (N <= 8).
+/// Uses a linear scan over cursor values to find min/max each round.
 void intersectLeapfrogLinear(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
 {
     const size_t n = cursors.size();
@@ -742,7 +739,8 @@ void intersectLeapfrogLinear(UInt8 * out, const std::vector<PostingListCursorPtr
     }
 }
 
-/// Leapfrog intersection using min-heap.
+/// N-way leapfrog intersection (N > 8).
+/// Uses a min-heap to efficiently extract the minimum cursor each round.
 void intersectLeapfrogHeap(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
 {
     const size_t n = cursors.size();
@@ -809,7 +807,9 @@ void intersectLeapfrogHeap(UInt8 * out, const std::vector<PostingListCursorPtr> 
     }
 }
 
-/// Dispatcher for skip-list based intersection algorithms.
+/// Dispatch to the best leapfrog variant based on cursor count:
+///   2 → unrolled two-cursor,  3 → three-cursor,  4 → four-cursor,
+///   5..8 → linear scan,  >8 → min-heap.
 void intersectLeapfrog(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
 {
     if (cursors.size() == 2)
@@ -839,7 +839,9 @@ void intersectLeapfrog(UInt8 * out, const std::vector<PostingListCursorPtr> & cu
     intersectLeapfrogHeap(out, cursors, row_offset, effective_end);
 }
 
-/// Brute-force intersection using bitmap counting.
+/// Brute-force intersection via bitmap counting.
+/// First cursor sets bits (linearOr), remaining cursors increment counters (linearAnd),
+/// then a final pass converts count == n into 1, everything else into 0.
 void intersectBruteForce(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t num_rows)
 {
     cursors[0]->linearOr(out, row_offset, num_rows);
@@ -918,9 +920,9 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
         return;
     }
 
-    /// Use min density for algorithm selection: brute-force is only beneficial
-    /// when ALL cursors are dense. If any cursor is sparse, leapfrog can skip
-    /// large ranges efficiently, making it the better choice.
+    /// Algorithm selection uses the MINIMUM density across all cursors:
+    /// brute-force only wins when ALL lists are dense.  A single sparse cursor
+    /// makes leapfrog more efficient because it can skip large unused ranges.
     double min_density = std::numeric_limits<double>::max();
     for (size_t i = 0; i < n; ++i)
         min_density = std::min(min_density, cursors[i]->density());
@@ -931,9 +933,9 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
         return;
     }
 
-    /// Sort cursors by cardinality ascending so the sparsest cursor leads
-    /// the leapfrog loop. This minimizes total seek count: the sparse leader
-    /// advances in large jumps while dense followers catch up cheaply.
+    /// Sort cursors by ascending cardinality so the sparsest cursor leads
+    /// the leapfrog.  The sparse leader advances in large jumps while dense
+    /// followers catch up cheaply via seek.
     std::sort(cursors.begin(), cursors.end(),
         [](const PostingListCursorPtr & a, const PostingListCursorPtr & b)
         { return a->cardinality() < b->cardinality(); });

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -4,7 +4,6 @@
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <IO/ReadHelpers.h>
 
-#pragma clang optimize off
 #include <turbopfor.h>
 
 namespace DB
@@ -89,6 +88,15 @@ inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 
 PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t large_block)
     : stream(stream_)
+    , info(info_)
+{
+    large_blocks.push_back(large_block);
+    prepare(large_block);
+}
+
+PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_, size_t large_block)
+    : stream(owned_stream_.get())
+    , owned_stream(std::move(owned_stream_))
     , info(info_)
 {
     large_blocks.push_back(large_block);

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -87,25 +87,18 @@ inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 
 } // anonymous namespace
 
-PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t large_block)
-    : stream(stream_)
-    , info(info_)
-{
-    large_blocks.push_back(large_block);
-    prepare(large_block);
-}
-
-PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_, size_t large_block)
+PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_)
     : stream(owned_stream_.get())
     , owned_stream(std::move(owned_stream_))
     , info(info_)
+    , total_large_blocks(info.offsets.size())
 {
-    large_blocks.push_back(large_block);
-    prepare(large_block);
+    if (total_large_blocks > 0)
+        prepare(0);
 }
 
-PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_, size_t large_block)
-    : PostingListCursor(nullptr, info_, large_block)
+PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_)
+    : PostingListCursor(nullptr, info_)
 {
 }
 
@@ -114,20 +107,11 @@ UInt32 PostingListCursor::cardinality() const
     return info.cardinality;
 }
 
-void PostingListCursor::addLargeBlock(size_t s)
-{
-    auto it = std::find(large_blocks.begin(), large_blocks.end(), s);
-    if (it == large_blocks.end())
-    {
-        large_blocks.push_back(s);
-        is_valid = true;
-    }
-}
-
 void PostingListCursor::prepare(size_t large_block_idx)
 {
-    if (current_large_block_idx == large_block_idx && current_large_block_idx != std::numeric_limits<size_t>::max())
+    if (current_large_block_idx == large_block_idx && has_prepared_first_large_block)
         return;
+    has_prepared_first_large_block = true;
 
     /// Large block 0's packed block 0 needs to prepend `first_doc_id` (which is stored
     /// separately in the dictionary stream and not included in TurboPFor encoding), so
@@ -278,16 +262,10 @@ void PostingListCursor::seek(uint32_t target)
     if (!is_embedded && seekImpl(target))
         return;
 
-    int unused_large_block_index = -1;
     bool found = false;
-    for (size_t i = 0; i < large_blocks.size(); ++i)
+    for (size_t i = current_large_block_idx; i < total_large_blocks; ++i)
     {
-        auto large_block = large_blocks[i];
-        if (large_block < current_large_block_idx)
-        {
-            unused_large_block_index = static_cast<int>(i);
-            continue;
-        }
+        auto large_block = i;
         const auto & range = info.ranges[large_block];
         if (range.end >= target)
         {
@@ -300,8 +278,6 @@ void PostingListCursor::seek(uint32_t target)
         }
     }
 
-    if (unused_large_block_index > 0)
-        maybeEraseUnusedLargeBlocks(unused_large_block_index);
     is_valid = found;
 }
 
@@ -419,10 +395,10 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         auto it = std::lower_bound(current_values.begin(), current_values.end(), row_begin);
         if (it == current_values.end())
             return;
-        size_t idx = static_cast<size_t>(it - current_values.begin());
+        size_t begin_idx = static_cast<size_t>(it - current_values.begin());
         auto it_end = std::upper_bound(current_values.begin(), current_values.end(), row_end);
-        size_t length = it_end - current_values.begin();
-        padColumnForOr(out, current_values, row_begin, idx, length);
+        size_t end_idx = it_end - current_values.begin();
+        padColumnForOr(out, current_values, row_begin, begin_idx, end_idx);
         return;
     }
 
@@ -447,37 +423,33 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
         auto it = std::lower_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_begin));
         if (it == current_values.end())
             continue;
-        size_t idx = static_cast<size_t>(it - current_values.begin());
+        size_t begin_idx = static_cast<size_t>(it - current_values.begin());
         auto it_end = std::upper_bound(current_values.begin(), current_values.end(), static_cast<uint32_t>(row_end));
-        size_t length = it_end - current_values.begin();
+        size_t end_idx = it_end - current_values.begin();
 
-        padColumnForOr(out, current_values, row_begin, idx, length);
+        padColumnForOr(out, current_values, row_begin, begin_idx, end_idx);
 
-        if (length < current_values.size())
+        if (end_idx < current_values.size())
             return;
     }
 }
 
 void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_rows)
 {
-    int unused_large_block_index = -1;
-    for (size_t i = 0; i < large_blocks.size(); ++i)
+    for (size_t i = current_large_block_idx; i < total_large_blocks; ++i)
     {
-        auto large_block = large_blocks[i];
+        auto large_block = i;
         size_t begin = info.ranges[large_block].begin;
         size_t end = info.ranges[large_block].end;
 
         if (row_offset > end || (row_offset + num_rows) < begin)
         {
-            unused_large_block_index = static_cast<int>(i);
             continue;
         }
         end = std::min(end, row_offset + num_rows - 1);
         prepare(large_block);
         linearOrImpl(large_block, data, row_offset, end);
     }
-    if (unused_large_block_index > 0)
-        maybeEraseUnusedLargeBlocks(unused_large_block_index);
 }
 
 inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
@@ -557,25 +529,20 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
 
 void PostingListCursor::linearAnd(UInt8 * data, size_t row_offset, size_t num_rows)
 {
-    int unused_large_block_index = -1;
-    for (size_t i = 0; i < large_blocks.size(); ++i)
+    for (size_t i = current_large_block_idx; i < total_large_blocks; ++i)
     {
-        auto large_block = large_blocks[i];
+        auto large_block = i;
         size_t begin = info.ranges[large_block].begin;
         size_t end = info.ranges[large_block].end;
 
         if (row_offset > end || (row_offset + num_rows) < begin)
         {
-            unused_large_block_index = static_cast<int>(i);
             continue;
         }
         end = std::min(end, row_offset + num_rows - 1);
-        prepare(large_blocks[i]);
+        prepare(large_block);
         linearAndImpl(large_block, data, row_offset, end);
     }
-
-    if (unused_large_block_index > 0)
-        maybeEraseUnusedLargeBlocks(unused_large_block_index);
 }
 
 namespace

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -19,6 +19,17 @@ inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 
 } // anonymous namespace
 
+/// Result of probing a TurboPFor packed block header without full decompression.
+/// Valid only for arithmetic-sequence blocks (constant delta or all-zero delta).
+struct PackedBlockProbe
+{
+    bool is_arithmetic = false;  /// True if block is constant-delta or all-zero.
+    uint32_t step = 0;           /// Delta step = constant_value + 1.
+    uint32_t first_doc_id = 0;   /// First doc_id in this block.
+    uint32_t last_doc_id = 0;    /// Last doc_id in this block.
+    uint32_t count = 0;          /// Number of elements in this block.
+};
+
 PostingListCursor::PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_)
     : stream(owned_stream_.get())
     , owned_stream(std::move(owned_stream_))
@@ -123,6 +134,8 @@ void PostingListCursor::prepare(size_t large_block_idx)
 
 bool PostingListCursor::decodeNextBlock()
 {
+    arithmetic_mode = false;
+
     if (current_block >= block_count)
         return false;
 
@@ -192,6 +205,122 @@ bool PostingListCursor::decodeNextBlock()
     return true;
 }
 
+PackedBlockProbe PostingListCursor::probePackedBlock(size_t block_idx)
+{
+    chassert(stream);
+    chassert(block_idx < packed_block_offsets.size());
+
+    /// Compute the delta base — same logic as decodeNextBlock.
+    uint32_t delta_base;
+    if (block_idx == 0)
+    {
+        delta_base = static_cast<uint32_t>(info.ranges[current_large_block_idx].begin);
+        if (current_large_block_idx > 0)
+            --delta_base;
+    }
+    else
+        delta_base = packed_block_last_doc_ids[block_idx - 1];
+
+    /// For large block 0, packed block 0: the first_doc_id is prepended from
+    /// the dictionary.  The arithmetic sequence would be broken by this extra
+    /// element, so we skip the optimization for this single block.
+    bool prepend_first_doc_id = (current_large_block_idx == 0 && block_idx == 0);
+    if (prepend_first_doc_id)
+        return PackedBlockProbe{};
+
+    /// Seek to the packed block and read the length-prefix.
+    stream->seek(packed_block_offsets[block_idx]);
+    auto & data_buf = *stream->getDataBuffer();
+
+    UInt32 bytes;
+    readPrefixVarUInt32(bytes, data_buf);
+
+    /// We need at least 1 byte for the header; for constant blocks up to 5 bytes
+    /// (1 header + 4 constant value).  Ensure the buffer has enough data.
+    if (bytes == 0)
+        return PackedBlockProbe{};
+
+    /// Read the header byte.  We need to peek without consuming if this isn't
+    /// an arithmetic block, but since we set need_seek_before_decode = true on
+    /// fallback, the stream position doesn't matter for decodeNextBlock.
+    uint8_t header_byte;
+    if (data_buf.available() >= bytes)
+    {
+        header_byte = static_cast<uint8_t>(*data_buf.position());
+    }
+    else
+    {
+        /// Copy into packed_buffer so we can inspect it.
+        chassert(bytes <= 512);
+        data_buf.readStrict(reinterpret_cast<char *>(stream->packed_buffer), bytes);
+        header_byte = stream->packed_buffer[0];
+    }
+
+    uint32_t constant_value = 0;
+
+    if (header_byte == 0x00)
+    {
+        /// All-zero block: b=0, bx=0.  All deltas are 0, step = 1.
+        constant_value = 0;
+    }
+    else if ((header_byte & 0xC0u) == 0xC0u)
+    {
+        /// Constant block: header = 0xC0 | b.
+        unsigned b = header_byte & 0x3Fu;
+        unsigned bytes_stored = (b + 7u) / 8u;
+
+        if (bytes_stored == 0)
+        {
+            /// b=0 constant block means all deltas are 0.
+            constant_value = 0;
+        }
+        else
+        {
+            /// Read the constant value from the bytes following the header.
+            const uint8_t * payload;
+            if (data_buf.available() >= bytes)
+            {
+                /// Data still in the buffer (we only peeked the header byte above).
+                payload = reinterpret_cast<const uint8_t *>(data_buf.position()) + 1;
+            }
+            else
+            {
+                /// Already copied into packed_buffer.
+                payload = stream->packed_buffer + 1;
+            }
+
+            /// Load little-endian value from 1-4 bytes.
+            constant_value = 0;
+            for (unsigned i = 0; i < bytes_stored && i < 4; ++i)
+                constant_value |= static_cast<uint32_t>(payload[i]) << (8u * i);
+
+            if (b < 32u)
+                constant_value &= (1u << b) - 1u;
+        }
+    }
+    else
+    {
+        /// Not an arithmetic block (simple bitpacking with exceptions, etc.).
+        return PackedBlockProbe{};
+    }
+
+    uint32_t step = constant_value + 1;
+    uint32_t count = (block_idx + 1 == block_count && tail_size > 0)
+                         ? static_cast<uint32_t>(tail_size)
+                         : static_cast<uint32_t>(TURBOPFOR_BLOCK_SIZE);
+
+    uint32_t first_doc_id = delta_base + step;
+    uint32_t last_doc_id = delta_base + step * count;
+
+    return PackedBlockProbe{
+        .is_arithmetic = true,
+        .step = step,
+        .first_doc_id = first_doc_id,
+        .last_doc_id = last_doc_id,
+        .count = count,
+    };
+}
+
 void PostingListCursor::seek(uint32_t target)
 {
     /// Fast path: target may fall within the currently loaded large block.
@@ -233,14 +362,39 @@ bool PostingListCursor::seekImpl(uint32_t target)
         return false;
     }
 
-    /// Check if target falls within the already-decoded packed block.
+    /// Check if target falls within the already-decoded/active packed block.
     if (index < decoded_count)
     {
-        auto it = std::lower_bound(decoded_values + index, decoded_values + decoded_count, target);
-        if (it != decoded_values + decoded_count)
+        if (arithmetic_mode)
         {
-            index = static_cast<size_t>(it - decoded_values);
-            return true;
+            /// Arithmetic block: compute position directly.
+            uint32_t last_in_block = arithmetic_first + (static_cast<uint32_t>(decoded_count) - 1) * arithmetic_step;
+            if (target <= last_in_block)
+            {
+                if (target <= arithmetic_first)
+                {
+                    index = 0;
+                    return true;
+                }
+                uint32_t offset_from_first = target - arithmetic_first;
+                uint32_t idx = offset_from_first / arithmetic_step;
+                uint32_t actual = arithmetic_first + idx * arithmetic_step;
+                if (actual < target && idx + 1 < static_cast<uint32_t>(decoded_count))
+                {
+                    ++idx;
+                }
+                index = idx;
+                return true;
+            }
+        }
+        else
+        {
+            auto it = std::lower_bound(decoded_values + index, decoded_values + decoded_count, target);
+            if (it != decoded_values + decoded_count)
+            {
+                index = static_cast<size_t>(it - decoded_values);
+                return true;
+            }
         }
     }
 
@@ -257,9 +411,42 @@ bool PostingListCursor::seekImpl(uint32_t target)
     /// land in the same packed block (common in leapfrog intersection).
     if (j != current_block || decoded_count == 0)
     {
-        current_block = j;
-        need_seek_before_decode = true;
-        decodeNextBlock();
+        /// Probe the header to check for arithmetic-sequence block.
+        PackedBlockProbe probe = probePackedBlock(j);
+
+        if (probe.is_arithmetic)
+        {
+            /// Direct arithmetic computation — no decompression needed.
+            current_block = j;
+            arithmetic_mode = true;
+            arithmetic_step = probe.step;
+            arithmetic_first = probe.first_doc_id;
+            arithmetic_count = probe.count;
+            decoded_count = probe.count;
+
+            if (target <= probe.first_doc_id)
+            {
+                index = 0;
+            }
+            else
+            {
+                uint32_t offset_from_first = target - probe.first_doc_id;
+                uint32_t idx = offset_from_first / probe.step;
+                uint32_t actual = probe.first_doc_id + idx * probe.step;
+                if (actual < target && idx + 1 < probe.count)
+                    ++idx;
+                index = idx;
+            }
+
+            return true;
+        }
+        else
+        {
+            /// Non-arithmetic block — fall back to full decode.
+            current_block = j;
+            need_seek_before_decode = true;
+            decodeNextBlock();
+        }
     }
 
     /// Binary search within the decoded packed block.
@@ -282,6 +469,12 @@ void PostingListCursor::next()
 
     if (index >= decoded_count)
     {
+        /// If we were in arithmetic mode, the stream position is not at the end
+        /// of the current packed block (we never read the payload), so we need
+        /// to seek before decoding the next block.
+        if (arithmetic_mode)
+            need_seek_before_decode = true;
+
         ++current_block;
         if (current_block < block_count)
         {
@@ -367,6 +560,32 @@ inline void padColumn(UInt8 * __restrict out, const uint32_t * values, size_t ro
     }
 }
 
+/// Scatter-write arithmetic-sequence doc_ids into `out` for the range [row_begin, row_end].
+/// Avoids full TurboPFor decompression for constant-delta and all-zero blocks.
+template <PadOp op>
+inline void padArithmeticBlock(UInt8 * __restrict out, const PackedBlockProbe & probe, size_t row_begin, size_t row_end)
+{
+    uint32_t start = std::max(probe.first_doc_id, static_cast<uint32_t>(row_begin));
+    uint32_t end = std::min(probe.last_doc_id, static_cast<uint32_t>(row_end));
+
+    if (start > end)
+        return;
+
+    /// Find the first doc_id >= start in the arithmetic sequence.
+    uint32_t offset = start - probe.first_doc_id;
+    uint32_t idx = (offset + probe.step - 1) / probe.step;  /// ceil division
+    uint32_t doc_id = probe.first_doc_id + idx * probe.step;
+
+    while (doc_id <= end)
+    {
+        if constexpr (op == PadOp::Or)
+            out[doc_id - row_begin] = 1;
+        else
+            ++out[doc_id - row_begin];
+        doc_id += probe.step;
+    }
+}
+
 void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out, size_t row_begin, size_t row_end)
 {
     chassert(large_block < info.ranges.size());
@@ -415,6 +634,20 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
     for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
         current_block = blk;
+
+        /// Try probing the header for an arithmetic-sequence block.
+        PackedBlockProbe probe = probePackedBlock(blk);
+        if (probe.is_arithmetic)
+        {
+            /// Scatter arithmetic doc_ids directly — no decompression.
+            padArithmeticBlock<PadOp::Or>(out, probe, row_begin, row_end);
+            need_seek_before_decode = true;
+            continue;
+        }
+
+        /// Non-arithmetic block — full decode.  probePackedBlock moved the stream,
+        /// so we must seek back.
+        need_seek_before_decode = true;
         if (!decodeNextBlock())
             return;
 
@@ -514,6 +747,18 @@ void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out
     for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
         current_block = blk;
+
+        /// Try probing the header for an arithmetic-sequence block.
+        PackedBlockProbe probe = probePackedBlock(blk);
+        if (probe.is_arithmetic)
+        {
+            padArithmeticBlock<PadOp::And>(out, probe, row_begin, row_end);
+            need_seek_before_decode = true;
+            continue;
+        }
+
+        /// Non-arithmetic block — full decode.
+        need_seek_before_decode = true;
         if (!decodeNextBlock())
             return;
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -217,7 +217,7 @@ bool PostingListCursor::decodeNextBlock()
     UInt32 bytes;
     readPrefixVarUInt32(bytes, data_buf);
 
-    UInt32 count = (current_block + 1 == block_count && tail_size > 0) ? static_cast<UInt32>(tail_size) : 128U;
+    UInt32 count = (current_block + 1 == block_count && tail_size > 0) ? static_cast<UInt32>(tail_size) : static_cast<UInt32>(TURBOPFOR_BLOCK_SIZE);
 
     uint8_t * src_ptr;
     if (data_buf.available() >= bytes)
@@ -241,8 +241,8 @@ bool PostingListCursor::decodeNextBlock()
     decoded_count = actual_count;
     uint32_t * decode_dst = decoded_values + (prepend_first_doc_id ? 1 : 0);
 
-    if (count == 128)
-        turbopfor::p4D1Dec128v32(src_ptr, 128, decode_dst, last_decoded_doc_id);
+    if (count == TURBOPFOR_BLOCK_SIZE)
+        turbopfor::p4D1Dec128v32(src_ptr, TURBOPFOR_BLOCK_SIZE, decode_dst, last_decoded_doc_id);
     else
         turbopfor::p4D1Dec32(src_ptr, count, decode_dst, last_decoded_doc_id);
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -315,11 +315,15 @@ bool PostingListCursor::seekImpl(uint32_t target)
 
     size_t j = static_cast<size_t>(it - packed_block_last_doc_ids.begin());
 
-    /// Seek to and decode the target packed block.
-    /// `need_seek_before_decode` tells `decodeNextBlock` to seek to the absolute offset.
-    current_block = j;
-    need_seek_before_decode = true;
-    decodeNextBlock();
+    /// If the target block is already decoded, search it directly without re-decoding.
+    /// This avoids redundant TurboPFor decode + stream seek when consecutive seeks
+    /// land in the same packed block (common in leapfrog intersection).
+    if (j != current_block || decoded_count == 0)
+    {
+        current_block = j;
+        need_seek_before_decode = true;
+        decodeNextBlock();
+    }
 
     /// Binary search within the decoded packed block.
     auto found_it = std::lower_bound(decoded_values, decoded_values + decoded_count, target);

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -2,6 +2,7 @@
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
+#include <IO/ReadHelpers.h>
 
 #include <turbopfor.h>
 
@@ -18,7 +19,7 @@ namespace
 
 /// Prefix-Based Variable-Length Integer Decoding.
 /// This mirrors the encoding used in PostingListData.cpp (VarInt namespace).
-/// Used for reading compressed block sizes in .lpst files.
+/// Used for reading compressed block sizes and Index Section fields in .lpst files.
 ///
 /// Encoding thresholds:
 /// - [0 - 176]        : 1 byte
@@ -85,33 +86,33 @@ inline void readPrefixVarUInt32(UInt32 & x, ReadBuffer & istr)
 
 } // anonymous namespace
 
-PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t segment)
+PostingListCursor::PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t large_block)
     : stream(stream_)
     , info(info_)
 {
     current_values.reserve(TURBOPFOR_BLOCK_SIZE);
-    segments.push_back(segment);
-    prepare(segment);
+    large_blocks.push_back(large_block);
+    prepare(large_block);
 }
 
-PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_, size_t segment)
-    : PostingListCursor(nullptr, info_, segment)
+PostingListCursor::PostingListCursor(const TokenPostingsInfo & info_, size_t large_block)
+    : PostingListCursor(nullptr, info_, large_block)
 {
 }
 
-void PostingListCursor::addSegment(size_t s)
+void PostingListCursor::addLargeBlock(size_t s)
 {
-    auto it = std::find(segments.begin(), segments.end(), s);
-    if (it == segments.end())
+    auto it = std::find(large_blocks.begin(), large_blocks.end(), s);
+    if (it == large_blocks.end())
     {
-        segments.push_back(s);
+        large_blocks.push_back(s);
         is_valid = true;
     }
 }
 
-void PostingListCursor::prepare(size_t segment)
+void PostingListCursor::prepare(size_t large_block_idx)
 {
-    if (current_segment == segment && current_segment != std::numeric_limits<size_t>::max())
+    if (current_large_block_idx == large_block_idx && current_large_block_idx != std::numeric_limits<size_t>::max())
         return;
 
     current_values.reserve(TURBOPFOR_BLOCK_SIZE);
@@ -125,7 +126,7 @@ void PostingListCursor::prepare(size_t segment)
         info.embedded_postings->toUint32Array(current_values.data());
         current_block = 0;
         block_count = 1;
-        current_segment = segment;
+        current_large_block_idx = large_block_idx;
         is_valid = true;
         is_embedded = true;
 
@@ -137,72 +138,51 @@ void PostingListCursor::prepare(size_t segment)
     }
 
     /// Large posting list: read from LargePostingListReaderStream using TurboPFor encoding.
-    /// Each segment corresponds to one LargePostingBlockMeta.
+    /// Each large block corresponds to one LargePostingBlockMeta.
     chassert(stream);
-    chassert(segment < info.offsets.size());
+    chassert(large_block_idx < info.offsets.size());
+    chassert(large_block_idx < info.ranges.size());
 
-    const auto & block_meta = info.offsets[segment];
-    segment_doc_count = block_meta.block_doc_count;
-    segment_first_doc_id = static_cast<UInt32>(info.ranges[segment].begin);
+    const auto & block_meta = info.offsets[large_block_idx];
+    large_block_doc_count = block_meta.block_doc_count;
+    last_decoded_doc_id = static_cast<UInt32>(info.ranges[large_block_idx].begin);
 
-    /// The .lpst file stores `segment_doc_count` delta-encoded doc IDs.
-    /// For segment 0: the delta base is `first_doc_id` (= range.begin), and `first_doc_id`
-    ///                itself is NOT in the .lpst stream (it's stored in metadata).
-    /// For segment N>0: the delta base is `range.begin - 1`, and the docs in .lpst start
-    ///                  from `range.begin` (the base itself is NOT a real doc).
-
-    /// Compute block structure for the delta-encoded portion
-    size_t full_blocks = segment_doc_count / TURBOPFOR_BLOCK_SIZE;
-    tail_size = segment_doc_count % TURBOPFOR_BLOCK_SIZE;
+    /// Compute packed block structure for the delta-encoded portion
+    size_t full_blocks = large_block_doc_count / TURBOPFOR_BLOCK_SIZE;
+    tail_size = large_block_doc_count % TURBOPFOR_BLOCK_SIZE;
     block_count = full_blocks + (tail_size > 0 ? 1 : 0);
 
-    /// For segment 0, we have one extra doc (first_doc_id) that is not in any block.
-    /// We treat it as: first_doc_id gets prepended to the first decoded block.
-    /// For other segments, all docs come from the .lpst blocks.
-
     current_block = 0;
-    current_segment = segment;
-
-    /// Set delta base for p4D1Dec
-    if (segment == 0)
-        last_decoded_doc_id = segment_first_doc_id;
-    else
-        last_decoded_doc_id = segment_first_doc_id - 1;
-
-    /// Seek to the data offset in the .lpst file
-    stream->seek(block_meta.offset);
+    current_large_block_idx = large_block_idx;
 
     /// Compute density
-    const auto & range = info.ranges[segment];
+    const auto & range = info.ranges[large_block_idx];
     UInt32 range_span = static_cast<UInt32>(range.end) - static_cast<UInt32>(range.begin) + 1;
-    density_val = (range_span > 0) ? static_cast<double>(segment_doc_count + (segment == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
+    density_val = (range_span > 0) ? static_cast<double>(large_block_doc_count + (large_block_idx == 0 ? 1 : 0)) / static_cast<double>(range_span) : 1.0;
 
-    if (block_count > 0)
-    {
-        decodeNextBlock();
+    /// --- V2: Load Index Session ---
+    /// In V2 format, block_meta.offset points directly to the Index Section
+    /// (not the Data Section). Seek there and read the packed block index.
+    stream->seek(block_meta.offset);
+    auto & data_buf = *stream->getDataBuffer();
 
-        /// For segment 0, insert first_doc_id at the beginning of the decoded block.
-        /// p4D1Dec uses `last_decoded_doc_id` (= first_doc_id) as delta base, so the
-        /// decoded values start AFTER first_doc_id. We need to prepend it.
-        if (segment == 0)
-        {
-            current_values.insert(current_values.begin(), segment_first_doc_id);
-        }
+    /// Read Index Section: [num_packed_blocks] [last_doc_ids...] [offsets...]
+    UInt32 num_packed_blocks;
+    readPrefixVarUInt32(num_packed_blocks, data_buf);
+    chassert(num_packed_blocks == block_count);
+
+    packed_block_last_doc_ids.resize(num_packed_blocks);
+    packed_block_offsets.resize(num_packed_blocks);
+
+    for (UInt32 j = 0; j < num_packed_blocks; ++j)
+        readPrefixVarUInt32(packed_block_last_doc_ids[j], data_buf);
+    for (UInt32 j = 0; j < num_packed_blocks; ++j)
+        readVarUInt(packed_block_offsets[j], data_buf);
+
+    if (block_count > 0 || large_block_idx == 0)
         is_valid = true;
-    }
-    else if (segment == 0)
-    {
-        /// Only first_doc_id, no delta-encoded docs
-        current_values.resize(1);
-        current_values[0] = segment_first_doc_id;
-        block_count = 1;
-        index = 0;
-        is_valid = true;
-    }
     else
-    {
         is_valid = false;
-    }
 }
 
 bool PostingListCursor::decodeNextBlock()
@@ -212,7 +192,16 @@ bool PostingListCursor::decodeNextBlock()
 
     chassert(stream);
 
-    auto & data_buf = *stream->getDataBuffer();
+    chassert(current_block < packed_block_offsets.size());
+    stream->seek(packed_block_offsets[current_block]);
+
+    /// Compute delta base for the target packed block.
+    if (current_block == 0)
+        last_decoded_doc_id = static_cast<UInt32>(info.ranges[current_large_block_idx].begin);
+    else
+        last_decoded_doc_id = packed_block_last_doc_ids[current_block - 1];
+
+    auto &data_buf = *stream->getDataBuffer();
 
     /// Read compressed bytes length (Prefix VarInt encoded in .lpst)
     UInt32 bytes;
@@ -245,90 +234,86 @@ bool PostingListCursor::decodeNextBlock()
     return true;
 }
 
-bool PostingListCursor::decodeBlock(size_t block_index)
-{
-    /// To decode a specific block, we need to decode sequentially from the current position.
-    /// Since TurboPFor is delta-encoded, we can't random-access individual blocks without
-    /// decoding from the beginning of the segment.
-    ///
-    /// However, for seek operations, we re-prepare the segment and decode blocks sequentially.
-    /// This is acceptable because:
-    /// 1. Seek typically moves forward within a segment
-    /// 2. Large posting blocks are already 1MB chunks, so sequential decode is fast
-
-    while (current_block < block_index)
-    {
-        ++current_block;
-        if (!decodeNextBlock())
-            return false;
-    }
-    return true;
-}
-
 void PostingListCursor::seek(uint32_t target)
 {
-    if (!seekImpl(target))
+    if (!is_embedded && seekImpl(target))
+        return;
+
+    int unused_large_block_index = -1;
+    bool found = false;
+    for (size_t i = 0; i < large_blocks.size(); ++i)
     {
-        int unused_segment_index = -1;
-        bool found = false;
-        for (size_t i = 0; i < segments.size(); ++i)
+        auto large_block = large_blocks[i];
+        if (large_block < current_large_block_idx)
         {
-            auto segment = segments[i];
-            if (segment < current_segment)
+            unused_large_block_index = static_cast<int>(i);
+            continue;
+        }
+        const auto & range = info.ranges[large_block];
+        if (range.end >= target)
+        {
+            prepare(large_block);
+            if (seekImpl(target))
             {
-                unused_segment_index = static_cast<int>(i);
-                continue;
-            }
-            const auto & range = info.ranges[segment];
-            if (range.end >= target)
-            {
-                prepare(segment);
-                if (seekImpl(target))
-                {
-                    found = true;
-                    break;
-                }
+                found = true;
+                break;
             }
         }
-
-        if (unused_segment_index > 0)
-            maybeEraseUnusedSegments(unused_segment_index);
-        is_valid = found;
     }
+
+    if (unused_large_block_index > 0)
+        maybeEraseUnusedLargeBlocks(unused_large_block_index);
+    is_valid = found;
 }
 
 bool PostingListCursor::seekImpl(uint32_t target)
 {
-    /// First check current decoded block
+    if (is_embedded)
+    {
+        /// Embedded: all values in current_values, simple binary search
+        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
+        if (it != current_values.end())
+        {
+            index = static_cast<size_t>(it - current_values.begin());
+            return true;
+        }
+        return false;
+    }
+
+    /// V2: use packed block index for O(log N) random access within the large block.
+
+    /// First check if target is in the current decoded block
     if (index < current_values.size())
     {
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
-        if (it != current_values.end() && *it >= target)
+        auto it = std::lower_bound(current_values.begin() + index, current_values.end(), target);
+        if (it != current_values.end())
         {
             index = static_cast<size_t>(it - current_values.begin());
             return true;
         }
-        if (is_embedded)
-            return false;
     }
 
-    /// For TurboPFor encoded data, we need to decode blocks sequentially
-    /// because delta encoding prevents random block access.
-    /// Advance to the next block and keep looking.
-    ++current_block;
-    while (current_block < block_count)
+    /// Binary search on packed_block_last_doc_ids to find the target packed block.
+    /// Find the first j where last_doc_ids[j] >= target.
+    auto it = std::lower_bound(packed_block_last_doc_ids.begin(), packed_block_last_doc_ids.end(), target);
+    if (it == packed_block_last_doc_ids.end())
+        return false;
+
+    size_t j = static_cast<size_t>(it - packed_block_last_doc_ids.begin());
+
+    /// Random seek to the target packed block via `need_seek_before_decode`.
+    /// Delta base and first_doc_id prepend are handled inside `decodeNextBlock`.
+    current_block = j;
+    decodeNextBlock();
+
+    /// Search within the decoded block
+    auto found_it = std::lower_bound(current_values.begin(), current_values.end(), target);
+    if (found_it != current_values.end())
     {
-        if (!decodeNextBlock())
-            return false;
-
-        auto it = std::lower_bound(current_values.begin(), current_values.end(), target);
-        if (it != current_values.end() && *it >= target)
-        {
-            index = static_cast<size_t>(it - current_values.begin());
-            return true;
-        }
-        ++current_block;
+        index = static_cast<size_t>(found_it - current_values.begin());
+        return true;
     }
+
     return false;
 }
 
@@ -386,9 +371,9 @@ inline void padColumnForOr(UInt8 * __restrict out, const std::vector<uint32_t> &
     }
 }
 
-void PostingListCursor::linearOrImpl(size_t segment, UInt8 * __restrict out, size_t row_begin, size_t row_end)
+void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out, size_t row_begin, size_t row_end)
 {
-    chassert(segment < info.ranges.size());
+    chassert(large_block < info.ranges.size());
 
     if (unlikely(is_embedded))
     {
@@ -402,11 +387,10 @@ void PostingListCursor::linearOrImpl(size_t segment, UInt8 * __restrict out, siz
         return;
     }
 
-    /// Process the current already-decoded block (block 0 decoded in prepare()),
-    /// then decode subsequent blocks sequentially.
+    /// Process the current already-decoded block, then decode subsequent blocks sequentially.
     for (size_t blk = current_block; blk < block_count; ++blk)
     {
-        /// For the first iteration, current_values already has the decoded block from prepare().
+        /// For the first iteration, current_values already has the decoded block.
         /// For subsequent iterations, decode the next block from the stream.
         if (blk > current_block)
         {
@@ -442,24 +426,24 @@ void PostingListCursor::linearOrImpl(size_t segment, UInt8 * __restrict out, siz
 
 void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_rows)
 {
-    int unused_segment_index = -1;
-    for (size_t i = 0; i < segments.size(); ++i)
+    int unused_large_block_index = -1;
+    for (size_t i = 0; i < large_blocks.size(); ++i)
     {
-        auto segment = segments[i];
-        size_t begin = info.ranges[segment].begin;
-        size_t end = info.ranges[segment].end;
+        auto large_block = large_blocks[i];
+        size_t begin = info.ranges[large_block].begin;
+        size_t end = info.ranges[large_block].end;
 
         if (row_offset > end || (row_offset + num_rows) < begin)
         {
-            unused_segment_index = static_cast<int>(i);
+            unused_large_block_index = static_cast<int>(i);
             continue;
         }
         end = std::min(end, row_offset + num_rows - 1);
-        prepare(segment);
-        linearOrImpl(segment, data, row_offset, end);
+        prepare(large_block);
+        linearOrImpl(large_block, data, row_offset, end);
     }
-    if (unused_segment_index > 0)
-        maybeEraseUnusedSegments(unused_segment_index);
+    if (unused_large_block_index > 0)
+        maybeEraseUnusedLargeBlocks(unused_large_block_index);
 }
 
 inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> & current_values, size_t row_begin, size_t begin, size_t length)
@@ -491,9 +475,9 @@ inline void padColumnForAnd(UInt8 * __restrict out, const std::vector<uint32_t> 
     }
 }
 
-void PostingListCursor::linearAndImpl(size_t segment, UInt8 * __restrict out, size_t row_begin, size_t row_end)
+void PostingListCursor::linearAndImpl(size_t large_block, UInt8 * __restrict out, size_t row_begin, size_t row_end)
 {
-    chassert(segment < info.ranges.size());
+    chassert(large_block < info.ranges.size());
 
     if (unlikely(is_embedded))
     {
@@ -542,25 +526,25 @@ void PostingListCursor::linearAndImpl(size_t segment, UInt8 * __restrict out, si
 
 void PostingListCursor::linearAnd(UInt8 * data, size_t row_offset, size_t num_rows)
 {
-    int unused_segment_index = -1;
-    for (size_t i = 0; i < segments.size(); ++i)
+    int unused_large_block_index = -1;
+    for (size_t i = 0; i < large_blocks.size(); ++i)
     {
-        auto segment = segments[i];
-        size_t begin = info.ranges[segment].begin;
-        size_t end = info.ranges[segment].end;
+        auto large_block = large_blocks[i];
+        size_t begin = info.ranges[large_block].begin;
+        size_t end = info.ranges[large_block].end;
 
         if (row_offset > end || (row_offset + num_rows) < begin)
         {
-            unused_segment_index = static_cast<int>(i);
+            unused_large_block_index = static_cast<int>(i);
             continue;
         }
         end = std::min(end, row_offset + num_rows - 1);
-        prepare(segments[i]);
-        linearAndImpl(segment, data, row_offset, end);
+        prepare(large_blocks[i]);
+        linearAndImpl(large_block, data, row_offset, end);
     }
 
-    if (unused_segment_index > 0)
-        maybeEraseUnusedSegments(unused_segment_index);
+    if (unused_large_block_index > 0)
+        maybeEraseUnusedLargeBlocks(unused_large_block_index);
 }
 
 namespace
@@ -806,18 +790,30 @@ void intersectLeapfrogHeap(UInt8 * out, const std::vector<PostingListCursorPtr> 
 void intersectLeapfrog(UInt8 * out, const std::vector<PostingListCursorPtr> & cursors, size_t row_offset, size_t effective_end)
 {
     if (cursors.size() == 2)
-        return intersectTwo(out, cursors[0], cursors[1], row_offset, effective_end);
+    {
+        intersectTwo(out, cursors[0], cursors[1], row_offset, effective_end);
+        return;
+    }
 
     if (cursors.size() == 3)
-        return intersectThree(out, cursors[0], cursors[1], cursors[2], row_offset, effective_end);
+    {
+        intersectThree(out, cursors[0], cursors[1], cursors[2], row_offset, effective_end);
+        return;
+    }
 
     if (cursors.size() == 4)
-        return intersectFour(out, cursors[0], cursors[1], cursors[2], cursors[3], row_offset, effective_end);
+    {
+        intersectFour(out, cursors[0], cursors[1], cursors[2], cursors[3], row_offset, effective_end);
+        return;
+    }
 
     if (cursors.size() <= 8)
-        return intersectLeapfrogLinear(out, cursors, row_offset, effective_end);
+    {
+        intersectLeapfrogLinear(out, cursors, row_offset, effective_end);
+        return;
+    }
 
-    return intersectLeapfrogHeap(out, cursors, row_offset, effective_end);
+    intersectLeapfrogHeap(out, cursors, row_offset, effective_end);
 }
 
 /// Brute-force intersection using bitmap counting.
@@ -905,7 +901,10 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
     density = density / static_cast<double>(n);
 
     if (n < 256 && (density >= density_threshold || brute_force_apply))
-        return intersectBruteForce(out, cursors, row_offset, num_rows);
+    {
+        intersectBruteForce(out, cursors, row_offset, num_rows);
+        return;
+    }
 
     for (size_t i = 0; i < n; ++i)
     {
@@ -914,7 +913,7 @@ void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & po
             return;
     }
 
-    return intersectLeapfrog(out, cursors, row_offset, end);
+    intersectLeapfrog(out, cursors, row_offset, end);
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -1,0 +1,178 @@
+#pragma once
+#include <absl/container/flat_hash_map.h>
+
+#include <base/defines.h>
+#include <base/types.h>
+#include <Common/PODArray.h>
+
+#include <limits>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+namespace DB
+{
+
+struct TokenPostingsInfo;
+class WriteBuffer;
+class ReadBuffer;
+class IColumn;
+struct LargePostingListReaderStream;
+
+/// A cursor for lazily iterating over a compressed posting list stored in
+/// ProjectionIndex format (TurboPFor delta-encoded).
+///
+/// Posting list: a sorted list of row IDs where a token appears.
+/// This cursor decodes blocks on-demand, avoiding full decompression upfront.
+///
+/// Supports two access patterns:
+/// 1. Iterator-style: valid() / value() / next() / seek() - for skip-list intersection
+/// 2. Linear scan: linearOr() / linearAnd() - for brute-force bitmap operations
+///
+/// The posting list may span multiple segments (large blocks). Use addSegment()
+/// to register additional segments before iteration.
+class PostingListCursor
+{
+public:
+    /// Construct a cursor for large posting lists backed by a LargePostingListReaderStream.
+    PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t segment);
+
+    /// Construct a cursor for embedded posting lists (no stream needed).
+    PostingListCursor(const TokenPostingsInfo & info_, size_t segment);
+
+    /// Register an additional segment to iterate over.
+    void addSegment(size_t);
+
+    /// Brute-force: set bits for all row IDs in range [row_offset, row_offset + num_rows).
+    void linearOr(UInt8 * data, size_t row_offset, size_t num_rows);
+
+    /// Brute-force: increment counts for all row IDs in range.
+    void linearAnd(UInt8 * data, size_t row_offset, size_t num_rows);
+
+    /// Move to next row ID.
+    void next();
+
+    /// Returns true if cursor points to a valid row ID.
+    bool valid() const { return is_valid; }
+
+    /// Returns current row ID. Requires valid() == true.
+    uint32_t value() const { return current_values[index]; }
+
+    /// Advance to first row ID >= target.
+    void seek(uint32_t target);
+
+    /// Returns posting list density: count / (max - min + 1).
+    /// Used to decide between skip-list vs brute-force algorithm.
+    double density() const { return density_val; }
+
+private:
+    static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
+
+    /// Load and prepare data for the given segment.
+    void prepare(size_t segment);
+
+    void linearOrImpl(size_t segment, UInt8 *, size_t row_begin, size_t row_end);
+    void linearAndImpl(size_t segment, UInt8 *, size_t row_begin, size_t row_end);
+
+    bool seekImpl(uint32_t target);
+
+    /// Decode the next 128-doc (or tail) block from the .lpst stream.
+    /// Returns false if no more blocks remain in the current segment.
+    bool decodeNextBlock();
+
+    /// Decode a specific block by index within the current segment.
+    bool decodeBlock(size_t block_index);
+
+    inline void maybeEraseUnusedSegments(int unused_segment_index)
+    {
+        chassert(static_cast<size_t>(unused_segment_index) < segments.size());
+        if (unused_segment_index >= 0 && segments.size() > 1)
+        {
+            auto end = segments.begin() + unused_segment_index + 1;
+            for (auto it = segments.begin(); it < end; ++it)
+                seen_segments.erase(*it);
+            segments.erase(segments.begin(), segments.begin() + unused_segment_index + 1);
+        }
+    }
+
+    LargePostingListReaderStream * stream = nullptr;
+
+    const TokenPostingsInfo & info;
+
+    /// Decoded row IDs of current block
+    std::vector<uint32_t> current_values;
+    /// Position within current_values
+    size_t index = 0;
+
+    /// Number of 128-doc blocks in the current segment (including tail block)
+    size_t block_count = 0;
+    /// Current block being iterated
+    size_t current_block = 0;
+    /// Size of the tail block (< 128), or 0 if perfectly aligned
+    size_t tail_size = 0;
+    /// Total doc count in the current segment (for large posting: block_doc_count)
+    UInt32 segment_doc_count = 0;
+    /// The first_doc_id for the current large block (used as delta base)
+    UInt32 segment_first_doc_id = 0;
+    /// Last decoded doc_id (for delta decoding continuity)
+    UInt32 last_decoded_doc_id = 0;
+
+    /// Segments (large blocks) this cursor covers
+    std::vector<size_t> segments;
+    std::unordered_set<size_t> seen_segments;
+    size_t current_segment = std::numeric_limits<size_t>::max();
+
+    bool is_valid = true;
+    bool is_embedded = false;
+    double density_val = 0;
+};
+
+using PostingListCursorPtr = std::shared_ptr<PostingListCursor>;
+using PostingListCursorMap = absl::flat_hash_map<std::string_view, PostingListCursorPtr>;
+
+/// Compute union (OR) of multiple posting lists using lazy decoding.
+///
+/// Used for TextSearchMode::Any - a row matches if it contains ANY of the search tokens.
+/// Iterates through each posting list and sets corresponding bits in the output column.
+///
+/// Note: brute_force_apply and density_threshold parameters are unused in union operation
+/// since linear scan is always used (no optimization benefit from skip-list for OR).
+///
+/// @param column         Output column (UInt8), sets bit to 1 for rows matching any token
+/// @param postings       Map from token to its posting list cursor
+/// @param search_tokens  List of tokens to search (determines iteration order)
+/// @param column_offset  Starting position in output column to write results
+/// @param row_offset     First row ID in the processing range
+/// @param num_rows       Number of rows to process
+/// @param brute_force_apply  Unused (kept for API consistency with intersection)
+/// @param density_threshold  Unused (kept for API consistency with intersection)
+void lazyUnionPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold);
+
+/// Compute intersection (AND) of multiple posting lists using lazy decoding.
+///
+/// Used for TextSearchMode::All - a row matches only if it contains ALL search tokens.
+/// Employs adaptive algorithm selection based on posting list density:
+///
+/// Algorithm selection:
+///   - Single list (n=1): direct linear scan, equivalent to union
+///   - Dense lists (density >= threshold) or brute_force_apply=true:
+///     Uses brute-force bitmap counting - each cursor marks its row IDs,
+///     then count rows where all cursors have set bits (sequential memory access)
+///   - Sparse lists: uses skip-list based leapfrog intersection -
+///     cursors advance together, only decode blocks as needed (fewer elements to process)
+///
+/// The density-based switching optimizes for different access patterns:
+///   - Sparse posting lists: skip-list is faster due to fewer elements
+///   - Dense posting lists: brute-force is faster due to sequential memory access
+///
+/// @param column         Output column (UInt8), sets bit to 1 for rows matching all tokens
+/// @param postings       Map from token to its posting list cursor
+/// @param search_tokens  List of tokens to search (determines which cursors to use)
+/// @param column_offset  Starting position in output column to write results
+/// @param row_offset     First row ID in the processing range
+/// @param num_rows       Number of rows to process
+/// @param brute_force_apply  Force brute-force algorithm regardless of density
+/// @param density_threshold  Switch to brute-force if average density >= this value
+void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold);
+
+}

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -34,7 +34,7 @@ using LargePostingListReaderStreamPtr = std::shared_ptr<LargePostingListReaderSt
 ///   `packed_block_offsets[j]`      — absolute byte offset of packed block j in .lpst
 /// These enable O(log N) seek via binary search + random file access.
 ///
-/// Embedded postings (small cardinality tokens) are stored inline as a Roaring Bitmap
+/// Embedded postings (small cardinality tokens) are stored inline as a array
 /// in the dictionary stream and decoded entirely in `prepare`; no .lpst stream is used.
 ///
 /// Two access patterns:
@@ -62,7 +62,7 @@ public:
     bool valid() const { return is_valid; }
 
     /// Current doc_id.  Undefined when `valid` returns false.
-    uint32_t value() const { return current_values[index]; }
+    uint32_t value() const { return decoded_values[index]; }
 
     /// Advance to the first doc_id >= target.
     void seek(uint32_t target);
@@ -81,7 +81,7 @@ private:
     /// Load metadata for `large_block_idx`-th large block.
     /// For large postings: reads the Index Section from .lpst (packed block index),
     /// but does NOT decode any packed block data yet.
-    /// For embedded postings: decodes the entire Roaring Bitmap into `current_values`.
+    /// For embedded postings: decodes the entire array into `decoded_values`.
     void prepare(size_t large_block);
 
     void linearOrImpl(size_t large_block, UInt8 *, size_t row_begin, size_t row_end);
@@ -104,8 +104,11 @@ private:
 
     const TokenPostingsInfo & info;
 
-    std::vector<uint32_t> current_values;  /// Decoded doc_ids of the current packed block.
-    size_t index = 0;                      /// Read position within current_values.
+    /// Decoded doc_ids of the current packed block (large postings) or all doc_ids (embedded postings).
+    /// Fixed-size: 128 packed + 1 for first_doc_id prepend.  Embedded postings have at most 6 entries.
+    alignas(16) uint32_t decoded_values[TURBOPFOR_BLOCK_SIZE + 1]{};
+    size_t decoded_count = 0;              /// Number of valid entries in decoded_values.
+    size_t index = 0;                      /// Read position within decoded_values.
 
     /// Per-large-block packed block layout (recomputed in `prepare`).
     size_t block_count = 0;              /// Total packed blocks, including the tail block.

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -16,7 +16,6 @@ namespace DB
 {
 
 struct TokenPostingsInfo;
-struct PackedBlockProbe;
 class WriteBuffer;
 class ReadBuffer;
 class IColumn;
@@ -98,21 +97,17 @@ private:
     /// Returns false if target exceeds this large block's range.
     bool seekImpl(uint32_t target);
 
-    /// Decode the next packed block (TURBOPFOR_BLOCK_SIZE doc_ids, or fewer for the tail block).
-    /// When `need_seek_before_decode` is set, seeks to the absolute stream offset
-    /// from the packed block index before reading.  For large block 0's packed
-    /// block 0, prepends `first_doc_id` which is stored separately in the dictionary.
-    /// Returns false when no more packed blocks remain in the current large block.
-    bool decodeNextBlock();
-
-    /// Probe the TurboPFor header of packed block `block_idx` to check if it's
-    /// an arithmetic-sequence block (constant or zero delta).  If so, compute
-    /// the block's [first, last] doc_id range without decompressing.
+    /// Probe the TurboPFor header of packed block `block_idx` and, if non-arithmetic,
+    /// decode it in one pass — avoiding a double seek that would occur with
+    /// separate probe + decode calls.
     ///
-    /// Reads the length-prefix and header bytes from the stream, advancing the
-    /// read position.  Caller must set `need_seek_before_decode = true` before
-    /// falling back to `decodeNextBlock` after a non-arithmetic probe.
-    PackedBlockProbe probePackedBlock(size_t block_idx);
+    /// On return:
+    ///   - If the block is arithmetic: returns true, `arithmetic_mode` is set with
+    ///     `arithmetic_first` / `arithmetic_step` / `arithmetic_count` populated.
+    ///     `decoded_values` / `decoded_count` are NOT updated.
+    ///   - If the block is non-arithmetic: returns false, `arithmetic_mode` is cleared,
+    ///     `decoded_values` / `decoded_count` are populated.
+    bool probeAndDecodePackedBlock(size_t block_idx);
 
     LargePostingListReaderStream * stream = nullptr;   /// Non-owning pointer (may alias owned_stream).
     LargePostingListReaderStreamPtr owned_stream;      /// Owning handle; nullptr for embedded postings.
@@ -144,12 +139,6 @@ private:
 
     bool is_valid = true;
     bool is_embedded = false;
-
-    /// When true, `decodeNextBlock` seeks to the packed block offset before reading.
-    /// Set after `prepare` (Index Section read moves the stream position) and after
-    /// `seekImpl` (random jump).  Cleared after the first seek-based decode so that
-    /// sequential packed-block reads can proceed without redundant seeks.
-    bool need_seek_before_decode = true;
 
     /// Arithmetic sequence mode: when the current packed block is a constant-delta
     /// or all-zero TurboPFor block, we skip decompression and compute doc_ids on the fly.

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -139,6 +139,11 @@ private:
 
     bool is_valid = true;
     bool is_embedded = false;
+    /// When true, decodeNextBlock will seek to the packed block offset before reading.
+    /// Set after prepare (Index Section read leaves stream at wrong position) and after
+    /// seekImpl (random jump). Cleared after the first seek so that sequential block
+    /// reads skip the redundant seek — the stream is already at the next block's start.
+    bool need_seek_before_decode = true;
     double density_val = 0;
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -20,172 +20,139 @@ class IColumn;
 struct LargePostingListReaderStream;
 using LargePostingListReaderStreamPtr = std::shared_ptr<LargePostingListReaderStream>;
 
-/// A cursor for lazily iterating over a compressed posting list stored in
-/// ProjectionIndex V2 format (TurboPFor delta-encoded with per-large-block
-/// packed block index).
+/// Lazy cursor over a compressed posting list (sorted row IDs for a token).
 ///
-/// Posting list: a sorted list of row IDs where a token appears.
-/// This cursor decodes blocks on-demand, avoiding full decompression upfront.
-/// The V2 Index Session (loaded in `prepare`) enables O(log N) seek to any
-/// 128-doc packed block within a large block via binary search on `packed_block_last_doc_ids`
-/// and random seek using `packed_block_offsets`.
+/// Storage layout (two-level hierarchy):
+///   Large blocks  — variable-size segments of the posting list, each stored as a
+///                   contiguous region in the .lpst stream with its own Index Section.
+///   Packed blocks — fixed-size 128-element groups within a large block, delta-encoded
+///                   and compressed with TurboPFor.  The last packed block in a large
+///                   block may be shorter (the "tail block").
 ///
-/// Supports two access patterns:
-/// 1. Iterator-style: valid() / value() / next() / seek() - for skip-list intersection
-/// 2. Linear scan: linearOr() / linearAnd() - for brute-force bitmap operations
+/// Each large block's Index Section (read in `prepare`) stores two parallel arrays:
+///   `packed_block_last_doc_ids[j]` — last doc_id of packed block j
+///   `packed_block_offsets[j]`      — absolute byte offset of packed block j in .lpst
+/// These enable O(log N) seek via binary search + random file access.
 ///
-/// The posting list may span multiple large blocks. Use addLargeBlock()
-/// to register additional large blocks before iteration.
+/// Embedded postings (small cardinality tokens) are stored inline as a Roaring Bitmap
+/// in the dictionary stream and decoded entirely in `prepare`; no .lpst stream is used.
+///
+/// Two access patterns:
+///   1. Iterator: `valid` / `value` / `next` / `seek` — for leapfrog intersection.
+///   2. Linear scan: `linearOr` / `linearAnd` — for brute-force bitmap operations.
 class PostingListCursor
 {
 public:
-    /// Construct a cursor that owns an independent LargePostingListReaderStream.
-    /// Used in lazy apply mode to give each cursor its own stream, avoiding seek contention.
+    /// Construct a cursor with its own .lpst reader stream (large posting lists).
     PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_);
 
-    /// Construct a cursor for embedded posting lists (no stream needed).
+    /// Construct a cursor without a stream (embedded posting lists only).
     PostingListCursor(const TokenPostingsInfo & info_);
 
-    /// Register an additional large block to iterate over.
-    void addLargeBlock(size_t);
-
-    /// Brute-force: set bits for all row IDs in range [row_offset, row_offset + num_rows).
+    /// Set bits in `data` for all doc_ids in [row_offset, row_offset + num_rows).
     void linearOr(UInt8 * data, size_t row_offset, size_t num_rows);
 
-    /// Brute-force: increment counts for all row IDs in range.
+    /// Increment counters in `data` for all doc_ids in [row_offset, row_offset + num_rows).
     void linearAnd(UInt8 * data, size_t row_offset, size_t num_rows);
 
-    /// Move to next row ID.
+    /// Move to the next doc_id.
     void next();
 
-    /// Returns true if cursor points to a valid row ID.
+    /// True if cursor points to a valid doc_id.
     bool valid() const { return is_valid; }
 
-    /// Returns current row ID. Requires valid() == true.
+    /// Current doc_id.  Undefined when `valid` returns false.
     uint32_t value() const { return current_values[index]; }
 
-    /// Advance to first row ID >= target.
+    /// Advance to the first doc_id >= target.
     void seek(uint32_t target);
 
-    /// Returns posting list density: count / (max - min + 1).
-    /// Used to decide between skip-list vs brute-force algorithm.
+    /// Posting list density: cardinality / (max_doc_id - min_doc_id + 1).
+    /// Used to choose between leapfrog and brute-force algorithms.
     double density() const { return density_val; }
 
-    /// Returns total cardinality of the posting list.
+    /// Total number of doc_ids in the posting list.
     /// Used to sort cursors by selectivity for leapfrog intersection.
     UInt32 cardinality() const;
 
 private:
     static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
 
-    /// Load and prepare data for the given large block.
-    /// For large postings: loads the V2 Index Session (reads Index Section
-    /// from .lpst), but does NOT decode any packed block.
+    /// Load metadata for `large_block_idx`-th large block.
+    /// For large postings: reads the Index Section from .lpst (packed block index),
+    /// but does NOT decode any packed block data yet.
+    /// For embedded postings: decodes the entire Roaring Bitmap into `current_values`.
     void prepare(size_t large_block);
 
     void linearOrImpl(size_t large_block, UInt8 *, size_t row_begin, size_t row_end);
     void linearAndImpl(size_t large_block, UInt8 *, size_t row_begin, size_t row_end);
 
-    /// Seek to the first doc_id >= target within the current large block
-    /// using the V2 packed block index for O(log N) random access.
+    /// Seek to the first doc_id >= target within the current large block.
+    /// Uses binary search on `packed_block_last_doc_ids` for O(log N) access.
+    /// Returns false if target exceeds this large block's range.
     bool seekImpl(uint32_t target);
 
-    /// Decode the next 128-doc (or tail) packed block from the .lpst stream.
-    /// When `need_seek_before_decode` is set (after `prepare` or `seek`), seeks to
-    /// the absolute offset from the packed block index, computes the correct delta
-    /// base, and for the first large block's packed block 0, prepends `first_doc_id`.
-    /// Returns false if no more packed blocks remain in the current large block.
+    /// Decode the next packed block (128 doc_ids, or fewer for the tail block).
+    /// When `need_seek_before_decode` is set, seeks to the absolute stream offset
+    /// from the packed block index before reading.  For large block 0's packed
+    /// block 0, prepends `first_doc_id` which is stored separately in the dictionary.
+    /// Returns false when no more packed blocks remain in the current large block.
     bool decodeNextBlock();
 
-    LargePostingListReaderStream * stream = nullptr;
-    LargePostingListReaderStreamPtr owned_stream;
+    LargePostingListReaderStream * stream = nullptr;   /// Non-owning pointer (may alias owned_stream).
+    LargePostingListReaderStreamPtr owned_stream;      /// Owning handle; nullptr for embedded postings.
 
     const TokenPostingsInfo & info;
 
-    /// Decoded row IDs of current packed block
-    std::vector<uint32_t> current_values;
-    /// Position within current_values
-    size_t index = 0;
+    std::vector<uint32_t> current_values;  /// Decoded doc_ids of the current packed block.
+    size_t index = 0;                      /// Read position within current_values.
 
-    /// Number of 128-doc packed blocks in the current large block (including tail block)
-    size_t block_count = 0;
-    /// Current packed block being iterated
-    size_t current_block = 0;
-    /// Size of the tail packed block (< 128), or 0 if perfectly aligned
-    size_t tail_size = 0;
-    /// Total doc count in the current large block (block_doc_count from LargePostingBlockMeta)
-    UInt32 large_block_doc_count = 0;
-    /// Last decoded doc_id (for delta decoding continuity)
-    UInt32 last_decoded_doc_id = 0;
+    /// Per-large-block packed block layout (recomputed in `prepare`).
+    size_t block_count = 0;              /// Total packed blocks, including the tail block.
+    size_t current_block = 0;            /// Index of the packed block being iterated.
+    size_t tail_size = 0;                /// Element count of the tail block (< 128), 0 if aligned.
+    UInt32 large_block_doc_count = 0;    /// Total doc count in the current large block.
+    UInt32 last_decoded_doc_id = 0;      /// Last doc_id decoded (delta base for next block).
 
-    /// V2 Index section for the current large block: packed block level index
-    /// loaded in `prepare`, enables O(log N) seek within a large block.
-    /// `packed_block_last_doc_ids[j]` is the last doc_id of the j-th 128-doc packed block.
-    /// `packed_block_offsets[j]` is the absolute byte offset of the j-th packed block in .lpst.
-    std::vector<UInt32> packed_block_last_doc_ids;
-    std::vector<UInt64> packed_block_offsets;
+    /// Packed block index loaded from Index Section in `prepare`.
+    /// Enables O(log N) seek within a large block.
+    std::vector<UInt32> packed_block_last_doc_ids;  /// packed_block_last_doc_ids[j] = last doc_id of packed block j.
+    std::vector<UInt64> packed_block_offsets;        /// packed_block_offsets[j] = absolute byte offset in .lpst.
 
-    /// Large blocks this cursor covers (indexes into info.offsets / info.ranges)
-    size_t total_large_blocks = 0;
-    size_t current_large_block_idx = 0;
+    /// Large block iteration state.
+    size_t total_large_blocks = 0;             /// Number of large blocks for this token.
+    size_t current_large_block_idx = 0;        /// Index of the large block currently loaded.
     bool has_prepared_first_large_block = false;
 
     bool is_valid = true;
     bool is_embedded = false;
-    /// When true, decodeNextBlock will seek to the packed block offset before reading.
-    /// Set after prepare (Index Section read leaves stream at wrong position) and after
-    /// seekImpl (random jump). Cleared after the first seek so that sequential block
-    /// reads skip the redundant seek — the stream is already at the next block's start.
+
+    /// When true, `decodeNextBlock` seeks to the packed block offset before reading.
+    /// Set after `prepare` (Index Section read moves the stream position) and after
+    /// `seekImpl` (random jump).  Cleared after the first seek-based decode so that
+    /// sequential packed-block reads can proceed without redundant seeks.
     bool need_seek_before_decode = true;
+
     double density_val = 0;
 };
 
 using PostingListCursorPtr = std::shared_ptr<PostingListCursor>;
 using PostingListCursorMap = absl::flat_hash_map<std::string_view, PostingListCursorPtr>;
 
-/// Compute union (OR) of multiple posting lists using lazy decoding.
-///
-/// Used for TextSearchMode::Any - a row matches if it contains ANY of the search tokens.
-/// Iterates through each posting list and sets corresponding bits in the output column.
-///
-/// Note: brute_force_apply and density_threshold parameters are unused in union operation
-/// since linear scan is always used (no optimization benefit from skip-list for OR).
-///
-/// @param column         Output column (UInt8), sets bit to 1 for rows matching any token
-/// @param postings       Map from token to its posting list cursor
-/// @param search_tokens  List of tokens to search (determines iteration order)
-/// @param column_offset  Starting position in output column to write results
-/// @param row_offset     First row ID in the processing range
-/// @param num_rows       Number of rows to process
-/// @param brute_force_apply  Unused (kept for API consistency with intersection)
-/// @param density_threshold  Unused (kept for API consistency with intersection)
+/// Union (OR) of posting lists: set output[row] = 1 if the row appears in ANY posting list.
+/// Each cursor performs a linear scan over its doc_ids.
+/// `brute_force_apply` and `density_threshold` are unused (kept for API symmetry with intersection).
 void lazyUnionPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold);
 
-/// Compute intersection (AND) of multiple posting lists using lazy decoding.
+/// Intersection (AND) of posting lists: set output[row] = 1 only if the row appears in ALL posting lists.
 ///
-/// Used for TextSearchMode::All - a row matches only if it contains ALL search tokens.
-/// Employs adaptive algorithm selection based on posting list density:
-///
-/// Algorithm selection:
-///   - Single list (n=1): direct linear scan, equivalent to union
-///   - Dense lists (density >= threshold) or brute_force_apply=true:
-///     Uses brute-force bitmap counting - each cursor marks its row IDs,
-///     then count rows where all cursors have set bits (sequential memory access)
-///   - Sparse lists: uses skip-list based leapfrog intersection -
-///     cursors advance together, only decode blocks as needed (fewer elements to process)
-///
-/// The density-based switching optimizes for different access patterns:
-///   - Sparse posting lists: skip-list is faster due to fewer elements
-///   - Dense posting lists: brute-force is faster due to sequential memory access
-///
-/// @param column         Output column (UInt8), sets bit to 1 for rows matching all tokens
-/// @param postings       Map from token to its posting list cursor
-/// @param search_tokens  List of tokens to search (determines which cursors to use)
-/// @param column_offset  Starting position in output column to write results
-/// @param row_offset     First row ID in the processing range
-/// @param num_rows       Number of rows to process
-/// @param brute_force_apply  Force brute-force algorithm regardless of density
-/// @param density_threshold  Switch to brute-force if average density >= this value
+/// Adaptive algorithm selection based on posting list density:
+///   - n == 1:  direct linear scan (degenerate case, same as union).
+///   - Dense (min density >= threshold) or `brute_force_apply`:
+///     Brute-force bitmap counting — first cursor sets bits, remaining cursors increment counters,
+///     then a final pass keeps only rows where count == n.  Favors sequential memory access.
+///   - Sparse:  leapfrog intersection — cursors sorted by ascending cardinality, the sparsest
+///     cursor leads and others seek forward.  Favors skipping large unused ranges.
 void lazyIntersectPostingLists(IColumn & column, const PostingListCursorMap & postings, const std::vector<String> & search_tokens, size_t column_offset, size_t row_offset, size_t num_rows, bool brute_force_apply, float density_threshold);
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -96,9 +96,6 @@ private:
         chassert(static_cast<size_t>(unused_large_block_index) < large_blocks.size());
         if (unused_large_block_index >= 0 && large_blocks.size() > 1)
         {
-            auto end = large_blocks.begin() + unused_large_block_index + 1;
-            for (auto it = large_blocks.begin(); it < end; ++it)
-                seen_large_blocks.erase(*it);
             large_blocks.erase(large_blocks.begin(), large_blocks.begin() + unused_large_block_index + 1);
         }
     }
@@ -123,7 +120,7 @@ private:
     /// Last decoded doc_id (for delta decoding continuity)
     UInt32 last_decoded_doc_id = 0;
 
-    /// V2 Index Session for the current large block: packed block level index
+    /// V2 Index section for the current large block: packed block level index
     /// loaded in `prepare`, enables O(log N) seek within a large block.
     /// `packed_block_last_doc_ids[j]` is the last doc_id of the j-th 128-doc packed block.
     /// `packed_block_offsets[j]` is the absolute byte offset of the j-th packed block in .lpst.
@@ -132,7 +129,6 @@ private:
 
     /// Large blocks this cursor covers (indexes into info.offsets / info.ranges)
     std::vector<size_t> large_blocks;
-    std::unordered_set<size_t> seen_large_blocks;
     size_t current_large_block_idx = std::numeric_limits<size_t>::max();
 
     bool is_valid = true;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -18,6 +18,7 @@ class WriteBuffer;
 class ReadBuffer;
 class IColumn;
 struct LargePostingListReaderStream;
+using LargePostingListReaderStreamPtr = std::shared_ptr<LargePostingListReaderStream>;
 
 /// A cursor for lazily iterating over a compressed posting list stored in
 /// ProjectionIndex V2 format (TurboPFor delta-encoded with per-large-block
@@ -40,6 +41,10 @@ class PostingListCursor
 public:
     /// Construct a cursor for large posting lists backed by a LargePostingListReaderStream.
     PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t large_block);
+
+    /// Construct a cursor that owns an independent LargePostingListReaderStream.
+    /// Used in lazy apply mode to give each cursor its own stream, avoiding seek contention.
+    PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_, size_t large_block);
 
     /// Construct a cursor for embedded posting lists (no stream needed).
     PostingListCursor(const TokenPostingsInfo & info_, size_t large_block);
@@ -101,6 +106,7 @@ private:
     }
 
     LargePostingListReaderStream * stream = nullptr;
+    LargePostingListReaderStreamPtr owned_stream;
 
     const TokenPostingsInfo & info;
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -5,6 +5,8 @@
 #include <base/types.h>
 #include <Common/PODArray.h>
 
+#include <Storages/MergeTree/ProjectionIndex/PostingListData.h>
+
 #include <limits>
 #include <memory>
 #include <unordered_set>
@@ -25,7 +27,7 @@ using LargePostingListReaderStreamPtr = std::shared_ptr<LargePostingListReaderSt
 /// Storage layout (two-level hierarchy):
 ///   Large blocks  — variable-size segments of the posting list, each stored as a
 ///                   contiguous region in the .lpst stream with its own Index Section.
-///   Packed blocks — fixed-size 128-element groups within a large block, delta-encoded
+///   Packed blocks — fixed-size TURBOPFOR_BLOCK_SIZE-element groups within a large block, delta-encoded
 ///                   and compressed with TurboPFor.  The last packed block in a large
 ///                   block may be shorter (the "tail block").
 ///
@@ -76,8 +78,6 @@ public:
     UInt32 cardinality() const;
 
 private:
-    static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
-
     /// Load metadata for `large_block_idx`-th large block.
     /// For large postings: reads the Index Section from .lpst (packed block index),
     /// but does NOT decode any packed block data yet.
@@ -92,7 +92,7 @@ private:
     /// Returns false if target exceeds this large block's range.
     bool seekImpl(uint32_t target);
 
-    /// Decode the next packed block (128 doc_ids, or fewer for the tail block).
+    /// Decode the next packed block (TURBOPFOR_BLOCK_SIZE doc_ids, or fewer for the tail block).
     /// When `need_seek_before_decode` is set, seeks to the absolute stream offset
     /// from the packed block index before reading.  For large block 0's packed
     /// block 0, prepends `first_doc_id` which is stored separately in the dictionary.
@@ -105,7 +105,7 @@ private:
     const TokenPostingsInfo & info;
 
     /// Decoded doc_ids of the current packed block (large postings) or all doc_ids (embedded postings).
-    /// Fixed-size: 128 packed + 1 for first_doc_id prepend.  Embedded postings have at most 6 entries.
+    /// Fixed-size: TURBOPFOR_BLOCK_SIZE packed + 1 for first_doc_id prepend.  Embedded postings have at most 6 entries.
     alignas(16) uint32_t decoded_values[TURBOPFOR_BLOCK_SIZE + 1]{};
     size_t decoded_count = 0;              /// Number of valid entries in decoded_values.
     size_t index = 0;                      /// Read position within decoded_values.
@@ -113,7 +113,7 @@ private:
     /// Per-large-block packed block layout (recomputed in `prepare`).
     size_t block_count = 0;              /// Total packed blocks, including the tail block.
     size_t current_block = 0;            /// Index of the packed block being iterated.
-    size_t tail_size = 0;                /// Element count of the tail block (< 128), 0 if aligned.
+    size_t tail_size = 0;                /// Element count of the tail block (< TURBOPFOR_BLOCK_SIZE), 0 if aligned.
     UInt32 large_block_doc_count = 0;    /// Total doc count in the current large block.
     UInt32 last_decoded_doc_id = 0;      /// Last doc_id decoded (delta base for next block).
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -74,6 +74,10 @@ public:
     /// Used to decide between skip-list vs brute-force algorithm.
     double density() const { return density_val; }
 
+    /// Returns total cardinality of the posting list.
+    /// Used to sort cursors by selectivity for leapfrog intersection.
+    UInt32 cardinality() const;
+
 private:
     static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
 

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -39,15 +39,12 @@ using LargePostingListReaderStreamPtr = std::shared_ptr<LargePostingListReaderSt
 class PostingListCursor
 {
 public:
-    /// Construct a cursor for large posting lists backed by a LargePostingListReaderStream.
-    PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t large_block);
-
     /// Construct a cursor that owns an independent LargePostingListReaderStream.
     /// Used in lazy apply mode to give each cursor its own stream, avoiding seek contention.
-    PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_, size_t large_block);
+    PostingListCursor(LargePostingListReaderStreamPtr owned_stream_, const TokenPostingsInfo & info_);
 
     /// Construct a cursor for embedded posting lists (no stream needed).
-    PostingListCursor(const TokenPostingsInfo & info_, size_t large_block);
+    PostingListCursor(const TokenPostingsInfo & info_);
 
     /// Register an additional large block to iterate over.
     void addLargeBlock(size_t);
@@ -100,15 +97,6 @@ private:
     /// Returns false if no more packed blocks remain in the current large block.
     bool decodeNextBlock();
 
-    inline void maybeEraseUnusedLargeBlocks(int unused_large_block_index)
-    {
-        chassert(static_cast<size_t>(unused_large_block_index) < large_blocks.size());
-        if (unused_large_block_index >= 0 && large_blocks.size() > 1)
-        {
-            large_blocks.erase(large_blocks.begin(), large_blocks.begin() + unused_large_block_index + 1);
-        }
-    }
-
     LargePostingListReaderStream * stream = nullptr;
     LargePostingListReaderStreamPtr owned_stream;
 
@@ -138,8 +126,9 @@ private:
     std::vector<UInt64> packed_block_offsets;
 
     /// Large blocks this cursor covers (indexes into info.offsets / info.ranges)
-    std::vector<size_t> large_blocks;
-    size_t current_large_block_idx = std::numeric_limits<size_t>::max();
+    size_t total_large_blocks = 0;
+    size_t current_large_block_idx = 0;
+    bool has_prepared_first_large_block = false;
 
     bool is_valid = true;
     bool is_embedded = false;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -16,6 +16,7 @@ namespace DB
 {
 
 struct TokenPostingsInfo;
+struct PackedBlockProbe;
 class WriteBuffer;
 class ReadBuffer;
 class IColumn;
@@ -64,7 +65,12 @@ public:
     bool valid() const { return is_valid; }
 
     /// Current doc_id.  Undefined when `valid` returns false.
-    uint32_t value() const { return decoded_values[index]; }
+    uint32_t value() const
+    {
+        if (arithmetic_mode) [[unlikely]]
+            return arithmetic_first + static_cast<uint32_t>(index) * arithmetic_step;
+        return decoded_values[index];
+    }
 
     /// Advance to the first doc_id >= target.
     void seek(uint32_t target);
@@ -98,6 +104,15 @@ private:
     /// block 0, prepends `first_doc_id` which is stored separately in the dictionary.
     /// Returns false when no more packed blocks remain in the current large block.
     bool decodeNextBlock();
+
+    /// Probe the TurboPFor header of packed block `block_idx` to check if it's
+    /// an arithmetic-sequence block (constant or zero delta).  If so, compute
+    /// the block's [first, last] doc_id range without decompressing.
+    ///
+    /// Reads the length-prefix and header bytes from the stream, advancing the
+    /// read position.  Caller must set `need_seek_before_decode = true` before
+    /// falling back to `decodeNextBlock` after a non-arithmetic probe.
+    PackedBlockProbe probePackedBlock(size_t block_idx);
 
     LargePostingListReaderStream * stream = nullptr;   /// Non-owning pointer (may alias owned_stream).
     LargePostingListReaderStreamPtr owned_stream;      /// Owning handle; nullptr for embedded postings.
@@ -135,6 +150,13 @@ private:
     /// `seekImpl` (random jump).  Cleared after the first seek-based decode so that
     /// sequential packed-block reads can proceed without redundant seeks.
     bool need_seek_before_decode = true;
+
+    /// Arithmetic sequence mode: when the current packed block is a constant-delta
+    /// or all-zero TurboPFor block, we skip decompression and compute doc_ids on the fly.
+    bool arithmetic_mode = false;
+    uint32_t arithmetic_step = 0;     /// Delta step (constant_value + 1).
+    uint32_t arithmetic_first = 0;    /// First doc_id of the arithmetic block.
+    uint32_t arithmetic_count = 0;    /// Total elements in the arithmetic block.
 
     double density_val = 0;
 };

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h
@@ -20,28 +20,32 @@ class IColumn;
 struct LargePostingListReaderStream;
 
 /// A cursor for lazily iterating over a compressed posting list stored in
-/// ProjectionIndex format (TurboPFor delta-encoded).
+/// ProjectionIndex V2 format (TurboPFor delta-encoded with per-large-block
+/// packed block index).
 ///
 /// Posting list: a sorted list of row IDs where a token appears.
 /// This cursor decodes blocks on-demand, avoiding full decompression upfront.
+/// The V2 Index Session (loaded in `prepare`) enables O(log N) seek to any
+/// 128-doc packed block within a large block via binary search on `packed_block_last_doc_ids`
+/// and random seek using `packed_block_offsets`.
 ///
 /// Supports two access patterns:
 /// 1. Iterator-style: valid() / value() / next() / seek() - for skip-list intersection
 /// 2. Linear scan: linearOr() / linearAnd() - for brute-force bitmap operations
 ///
-/// The posting list may span multiple segments (large blocks). Use addSegment()
-/// to register additional segments before iteration.
+/// The posting list may span multiple large blocks. Use addLargeBlock()
+/// to register additional large blocks before iteration.
 class PostingListCursor
 {
 public:
     /// Construct a cursor for large posting lists backed by a LargePostingListReaderStream.
-    PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t segment);
+    PostingListCursor(LargePostingListReaderStream * stream_, const TokenPostingsInfo & info_, size_t large_block);
 
     /// Construct a cursor for embedded posting lists (no stream needed).
-    PostingListCursor(const TokenPostingsInfo & info_, size_t segment);
+    PostingListCursor(const TokenPostingsInfo & info_, size_t large_block);
 
-    /// Register an additional segment to iterate over.
-    void addSegment(size_t);
+    /// Register an additional large block to iterate over.
+    void addLargeBlock(size_t);
 
     /// Brute-force: set bits for all row IDs in range [row_offset, row_offset + num_rows).
     void linearOr(UInt8 * data, size_t row_offset, size_t num_rows);
@@ -68,30 +72,34 @@ public:
 private:
     static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
 
-    /// Load and prepare data for the given segment.
-    void prepare(size_t segment);
+    /// Load and prepare data for the given large block.
+    /// For large postings: loads the V2 Index Session (reads Index Section
+    /// from .lpst), but does NOT decode any packed block.
+    void prepare(size_t large_block);
 
-    void linearOrImpl(size_t segment, UInt8 *, size_t row_begin, size_t row_end);
-    void linearAndImpl(size_t segment, UInt8 *, size_t row_begin, size_t row_end);
+    void linearOrImpl(size_t large_block, UInt8 *, size_t row_begin, size_t row_end);
+    void linearAndImpl(size_t large_block, UInt8 *, size_t row_begin, size_t row_end);
 
+    /// Seek to the first doc_id >= target within the current large block
+    /// using the V2 packed block index for O(log N) random access.
     bool seekImpl(uint32_t target);
 
-    /// Decode the next 128-doc (or tail) block from the .lpst stream.
-    /// Returns false if no more blocks remain in the current segment.
+    /// Decode the next 128-doc (or tail) packed block from the .lpst stream.
+    /// When `need_seek_before_decode` is set (after `prepare` or `seek`), seeks to
+    /// the absolute offset from the packed block index, computes the correct delta
+    /// base, and for the first large block's packed block 0, prepends `first_doc_id`.
+    /// Returns false if no more packed blocks remain in the current large block.
     bool decodeNextBlock();
 
-    /// Decode a specific block by index within the current segment.
-    bool decodeBlock(size_t block_index);
-
-    inline void maybeEraseUnusedSegments(int unused_segment_index)
+    inline void maybeEraseUnusedLargeBlocks(int unused_large_block_index)
     {
-        chassert(static_cast<size_t>(unused_segment_index) < segments.size());
-        if (unused_segment_index >= 0 && segments.size() > 1)
+        chassert(static_cast<size_t>(unused_large_block_index) < large_blocks.size());
+        if (unused_large_block_index >= 0 && large_blocks.size() > 1)
         {
-            auto end = segments.begin() + unused_segment_index + 1;
-            for (auto it = segments.begin(); it < end; ++it)
-                seen_segments.erase(*it);
-            segments.erase(segments.begin(), segments.begin() + unused_segment_index + 1);
+            auto end = large_blocks.begin() + unused_large_block_index + 1;
+            for (auto it = large_blocks.begin(); it < end; ++it)
+                seen_large_blocks.erase(*it);
+            large_blocks.erase(large_blocks.begin(), large_blocks.begin() + unused_large_block_index + 1);
         }
     }
 
@@ -99,28 +107,33 @@ private:
 
     const TokenPostingsInfo & info;
 
-    /// Decoded row IDs of current block
+    /// Decoded row IDs of current packed block
     std::vector<uint32_t> current_values;
     /// Position within current_values
     size_t index = 0;
 
-    /// Number of 128-doc blocks in the current segment (including tail block)
+    /// Number of 128-doc packed blocks in the current large block (including tail block)
     size_t block_count = 0;
-    /// Current block being iterated
+    /// Current packed block being iterated
     size_t current_block = 0;
-    /// Size of the tail block (< 128), or 0 if perfectly aligned
+    /// Size of the tail packed block (< 128), or 0 if perfectly aligned
     size_t tail_size = 0;
-    /// Total doc count in the current segment (for large posting: block_doc_count)
-    UInt32 segment_doc_count = 0;
-    /// The first_doc_id for the current large block (used as delta base)
-    UInt32 segment_first_doc_id = 0;
+    /// Total doc count in the current large block (block_doc_count from LargePostingBlockMeta)
+    UInt32 large_block_doc_count = 0;
     /// Last decoded doc_id (for delta decoding continuity)
     UInt32 last_decoded_doc_id = 0;
 
-    /// Segments (large blocks) this cursor covers
-    std::vector<size_t> segments;
-    std::unordered_set<size_t> seen_segments;
-    size_t current_segment = std::numeric_limits<size_t>::max();
+    /// V2 Index Session for the current large block: packed block level index
+    /// loaded in `prepare`, enables O(log N) seek within a large block.
+    /// `packed_block_last_doc_ids[j]` is the last doc_id of the j-th 128-doc packed block.
+    /// `packed_block_offsets[j]` is the absolute byte offset of the j-th packed block in .lpst.
+    std::vector<UInt32> packed_block_last_doc_ids;
+    std::vector<UInt64> packed_block_offsets;
+
+    /// Large blocks this cursor covers (indexes into info.offsets / info.ranges)
+    std::vector<size_t> large_blocks;
+    std::unordered_set<size_t> seen_large_blocks;
+    size_t current_large_block_idx = std::numeric_limits<size_t>::max();
 
     bool is_valid = true;
     bool is_embedded = false;

--- a/src/Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h
+++ b/src/Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h
@@ -1,0 +1,227 @@
+#pragma once
+
+#include <base/types.h>
+#include <IO/ReadBuffer.h>
+#include <IO/WriteBuffer.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
+}
+
+/// Prefix-Based Variable-Length Integer Encoding (Prefix VarInt).
+///
+/// This encoding is a variation of the "Length-Descriptor" VarInt,
+/// originating from the SQLite 4 design and widely utilized in systems
+/// like ClickHouse for high-performance serialization.
+///
+/// ### Key Advantages:
+/// 1. **Instruction-Level Parallelism (ILP)**: Unlike LEB128 (Protobuf) which
+///    has a serial data dependency on the continuation bit, this format
+///    determines the total length solely from the first byte. This allows
+///    the CPU to load and process payload bytes in parallel.
+/// 2. **Branch-Prediction Friendly**: The implementation is loop-less and
+///    unrolled, reducing CPU pipeline stalls during decoding.
+/// 3. **Lexicographical Comparison**: The big-endian-like prefix structure
+///    is designed to be more compatible with memcmp-based sorting and indexing
+///    compared to little-endian VarInts.
+///
+/// ### Encoding Thresholds:
+/// - [0 - 176]        : 1 byte  (Value = B0)
+/// - [177 - 16560]    : 2 bytes (Value = (B0-177) * 256 + B1 + 177)
+/// - [16561 - 540848] : 3 bytes (Value = (B0-241) * 65536 + (B1<<8) + B2 + 16561)
+/// - [540849 - 2^24-1]: 4 bytes (Marker 249 + 3 bytes raw payload)
+/// - [Up to 2^32-1]   : 5 bytes (Marker 250 + 4 bytes raw payload)
+namespace LengthPrefixedInt
+{
+
+/// Encoding thresholds
+static constexpr UInt32 ONE_BYTE_MAX = 176;
+static constexpr UInt32 TWO_BYTE_MAX = 16560;
+static constexpr UInt32 THREE_BYTE_MAX = 540848;
+static constexpr UInt32 FOUR_BYTE_MAX = 16777215;  /// 2^24 - 1
+
+/// Marker byte boundaries
+static constexpr UInt8 TWO_BYTE_MARKER_START = 177;
+static constexpr UInt8 TWO_BYTE_MARKER_END = 240;
+static constexpr UInt8 THREE_BYTE_MARKER_START = 241;
+static constexpr UInt8 THREE_BYTE_MARKER_END = 248;
+static constexpr UInt8 FOUR_BYTE_MARKER = 249;
+static constexpr UInt8 FIVE_BYTE_MARKER = 250;
+
+/// Offsets for compact encodings (1-3 bytes only)
+static constexpr UInt32 TWO_BYTE_OFFSET = 177;
+static constexpr UInt32 THREE_BYTE_OFFSET = 16561;
+
+inline void throwReadAfterEOF()
+{
+    throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
+}
+
+template <bool check_eof>
+inline void readUInt32Impl(UInt32 & x, ReadBuffer & istr)
+{
+    if constexpr (check_eof)
+        if (istr.eof()) [[unlikely]]
+            throwReadAfterEOF();
+
+    const UInt8 first_byte = *istr.position()++;
+
+    if (first_byte <= ONE_BYTE_MAX)
+    {
+        x = first_byte;
+        return;
+    }
+
+    if constexpr (check_eof)
+        if (istr.eof()) [[unlikely]]
+            throwReadAfterEOF();
+
+    const UInt8 second_byte = *istr.position()++;
+
+    if (first_byte <= TWO_BYTE_MARKER_END)
+    {
+        x = ((first_byte - TWO_BYTE_MARKER_START) << 8) + second_byte + TWO_BYTE_OFFSET;
+        return;
+    }
+
+    if constexpr (check_eof)
+        if (istr.eof()) [[unlikely]]
+            throwReadAfterEOF();
+
+    const UInt8 third_byte = *istr.position()++;
+
+    if (first_byte <= THREE_BYTE_MARKER_END)
+    {
+        x = ((first_byte - THREE_BYTE_MARKER_START) << 16) + (second_byte << 8) + third_byte + THREE_BYTE_OFFSET;
+        return;
+    }
+
+    if constexpr (check_eof)
+        if (istr.eof()) [[unlikely]]
+            throwReadAfterEOF();
+
+    const UInt8 fourth_byte = *istr.position()++;
+
+    if (first_byte == FOUR_BYTE_MARKER)
+    {
+        x = (second_byte << 16) | (third_byte << 8) | fourth_byte;
+        return;
+    }
+
+    if constexpr (check_eof)
+        if (istr.eof()) [[unlikely]]
+            throwReadAfterEOF();
+
+    const UInt8 fifth_byte = *istr.position()++;
+    x = (UInt32(second_byte) << 24) | (UInt32(third_byte) << 16) | (UInt32(fourth_byte) << 8) | fifth_byte;
+}
+
+template <bool check_eof>
+inline void writeUInt32Impl(UInt32 x, WriteBuffer & ostr)
+{
+    if (x <= ONE_BYTE_MAX)
+    {
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>(x);
+        return;
+    }
+
+    if (x <= TWO_BYTE_MAX)
+    {
+        const UInt32 adjusted = x - TWO_BYTE_OFFSET;
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>(TWO_BYTE_MARKER_START + (adjusted >> 8));
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>(adjusted & 0xFF);
+        return;
+    }
+
+    if (x <= THREE_BYTE_MAX)
+    {
+        const UInt32 adjusted = x - THREE_BYTE_OFFSET;
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>(THREE_BYTE_MARKER_START + (adjusted >> 16));
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>((adjusted >> 8) & 0xFF);
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>(adjusted & 0xFF);
+        return;
+    }
+
+    if (x <= FOUR_BYTE_MAX)
+    {
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = FOUR_BYTE_MARKER;
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>((x >> 16) & 0xFF);
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>((x >> 8) & 0xFF);
+        if constexpr (check_eof)
+            ostr.nextIfAtEnd();
+        *ostr.position()++ = static_cast<UInt8>(x & 0xFF);
+        return;
+    }
+
+    if constexpr (check_eof)
+        ostr.nextIfAtEnd();
+    *ostr.position()++ = FIVE_BYTE_MARKER;
+    if constexpr (check_eof)
+        ostr.nextIfAtEnd();
+    *ostr.position()++ = static_cast<UInt8>((x >> 24) & 0xFF);
+    if constexpr (check_eof)
+        ostr.nextIfAtEnd();
+    *ostr.position()++ = static_cast<UInt8>((x >> 16) & 0xFF);
+    if constexpr (check_eof)
+        ostr.nextIfAtEnd();
+    *ostr.position()++ = static_cast<UInt8>((x >> 8) & 0xFF);
+    if constexpr (check_eof)
+        ostr.nextIfAtEnd();
+    *ostr.position()++ = static_cast<UInt8>(x & 0xFF);
+}
+
+inline void readUInt32(UInt32 & x, ReadBuffer & istr)
+{
+    if (istr.available() >= 5)
+        readUInt32Impl<false>(x, istr);
+    else
+        readUInt32Impl<true>(x, istr);
+}
+
+inline void writeUInt32(UInt32 x, WriteBuffer & ostr)
+{
+    if (ostr.available() >= 5)
+        writeUInt32Impl<false>(x, ostr);
+    else
+        writeUInt32Impl<true>(x, ostr);
+}
+
+inline size_t getLengthOfUInt32(UInt32 x)
+{
+    if (x <= ONE_BYTE_MAX)
+        return 1;
+    if (x <= TWO_BYTE_MAX)
+        return 2;
+    if (x <= THREE_BYTE_MAX)
+        return 3;
+    if (x <= FOUR_BYTE_MAX)
+        return 4;
+    return 5;
+}
+
+}
+
+}

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
@@ -276,10 +276,6 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
 PostingListPtr MergeTreeIndexGranuleProjection::materializeFromTokenInfo(
     LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx, size_t /*format_version*/)
 {
-    /// In the new V2 design, offset always points to Data Section start (same as V1).
-    /// No need to call resolveDataSectionOffset.
-    UInt64 offset = token_info.offsets[block_idx].offset;
-
     /// For delta-decoding:
     /// - First block: 'begin' is the first doc_id (include it).
     /// - Other blocks: 'begin - 1' is the baseline to reconstruct 'begin' (exclude it).
@@ -291,7 +287,7 @@ PostingListPtr MergeTreeIndexGranuleProjection::materializeFromTokenInfo(
         stream,
         last_doc_id,
         token_info.offsets[block_idx].block_doc_count,
-        offset,
+        token_info.offsets[block_idx].offset,
         block_idx == 0 /* include_first_doc */);
 }
 

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
@@ -42,17 +42,16 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
 {
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::TextIndexReadGranulesMicroseconds);
 
-    MergeTreeDataPartPtr part;
-    for (const auto & [name, projection_part] : state.part.getProjectionParts())
+    for (const auto & [name, proj_part] : state.part.getProjectionParts())
     {
         if (name == projection_name)
         {
-            part = projection_part;
+            projection_part = proj_part;
             break;
         }
     }
 
-    if (!part)
+    if (!projection_part)
     {
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
@@ -61,7 +60,7 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
             state.part.name);
     }
 
-    DictionaryBlockBase sparse_index(part->getIndex()->at(0));
+    DictionaryBlockBase sparse_index(projection_part->getIndex()->at(0));
     if (sparse_index.empty())
         return;
 
@@ -106,7 +105,7 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
                 /// Special handling for the last mark:
                 /// upperBound() lands past the end, but the matching granule
                 /// is the one before the final mark.
-                if (part->index_granularity->hasFinalMark())
+                if (projection_part->index_granularity->hasFinalMark())
                     --mark;
             }
             else
@@ -123,20 +122,20 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
     if (mark_to_tokens.empty())
         return;
 
-    StorageMetadataPtr metadata_ptr = part->storage.getInMemoryMetadataPtr();
-    StorageSnapshotPtr storage_snapshot_ptr = std::make_shared<StorageSnapshot>(part->storage, metadata_ptr);
+    StorageMetadataPtr metadata_ptr = projection_part->storage.getInMemoryMetadataPtr();
+    StorageSnapshotPtr storage_snapshot_ptr = std::make_shared<StorageSnapshot>(projection_part->storage, metadata_ptr);
     auto alter_conversions = std::make_shared<AlterConversions>();
-    auto part_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(part, alter_conversions);
-    auto cols = part->getColumns();
+    auto part_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(projection_part, alter_conversions);
+    auto cols = projection_part->getColumns();
     MergeTreeReaderPtr reader = createMergeTreeReader(
         part_info,
         cols,
         storage_snapshot_ptr,
-        part->storage.getSettings(),
+        projection_part->storage.getSettings(),
         MarkRanges{MarkRange(mark_to_tokens.begin()->first, mark_to_tokens.rbegin()->first + 1)},
         /*virtual_fields=*/{},
         /*uncompressed_cache=*/{},
-        part->storage.getContext()->getMarkCache().get(),
+        projection_part->storage.getContext()->getMarkCache().get(),
         nullptr,
         MergeTreeReaderSettings::createFromSettings(),
         ValueSizeMap{},
@@ -148,7 +147,7 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
         const auto load_dictionary_block = [&] -> TextIndexDictionaryBlockCacheEntryPtr
         {
             ProfileEvents::increment(ProfileEvents::TextIndexReadDictionaryBlocks);
-            const size_t rows_to_read = part->index_granularity->getMarkRows(mark);
+            const size_t rows_to_read = projection_part->index_granularity->getMarkRows(mark);
             Columns result;
             result.resize(cols.size());
             size_t rows_read = reader->readRows(
@@ -222,7 +221,7 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
             return std::make_shared<TextIndexDictionaryBlockCacheEntry>(DictionaryBlock(std::move(result[0]), std::move(token_infos)));
         };
 
-        auto hash = TextIndexDictionaryBlockCache::hash(state.part.getDataPartStorage().getFullPath(), part->name, mark);
+        auto hash = TextIndexDictionaryBlockCache::hash(state.part.getDataPartStorage().getFullPath(), projection_part->name, mark);
         return condition_text.dictionaryBlockCache()->getOrSet(hash, load_dictionary_block);
     };
 
@@ -267,7 +266,7 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
                 return materializeFromTokenInfo(*large_posting_stream, token_info, 0, posting_list_format_version);
             };
 
-            auto hash = TextIndexPostingsCache::hash(data_path, part->name, token_info.offsets[0].offset);
+            auto hash = TextIndexPostingsCache::hash(data_path, projection_part->name, token_info.offsets[0].offset);
             auto p = condition_text.postingsCache()->getOrSet(hash, load_postings);
             rare_tokens_postings.emplace(token, std::move(p));
         }

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
@@ -8,6 +8,7 @@
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
 #include <Storages/MergeTree/ProjectionIndex/PostingListData.h>
+#include <Storages/MergeTree/ProjectionIndex/PostingListState.h>
 #include <Storages/MergeTree/ProjectionIndex/ProjectionIndexText.h>
 #include <Storages/MergeTree/TextIndexCache.h>
 #include <Storages/ProjectionsDescription.h>
@@ -163,6 +164,13 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
 
             assert_cast<const ColumnString &>(*result[0]);
             const ColumnAggregateFunction & posting_column = assert_cast<const ColumnAggregateFunction &>(*result[1]);
+
+            /// Extract format version from the aggregate function type.
+            const auto * agg_func = dynamic_cast<const AggregateFunctionPostingList *>(
+                posting_column.getAggregateFunction().get());
+            if (agg_func)
+                posting_list_format_version = agg_func->version;
+
             const auto & data = posting_column.getData();
             const size_t rows = data.size();
             chassert(rows_read == rows);
@@ -256,7 +264,7 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
             const auto load_postings = [&]() -> PostingListPtr
             {
                 ProfileEvents::increment(ProfileEvents::TextIndexReadPostings);
-                return materializeFromTokenInfo(*large_posting_stream, token_info, 0);
+                return materializeFromTokenInfo(*large_posting_stream, token_info, 0, posting_list_format_version);
             };
 
             auto hash = TextIndexPostingsCache::hash(data_path, part->name, token_info.offsets[0].offset);
@@ -267,8 +275,10 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
 }
 
 PostingListPtr MergeTreeIndexGranuleProjection::materializeFromTokenInfo(
-    LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx)
+    LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx, size_t format_version)
 {
+    UInt64 offset = resolveDataSectionOffset(stream, token_info.offsets[block_idx].offset, format_version);
+
     /// For delta-decoding:
     /// - First block: 'begin' is the first doc_id (include it).
     /// - Other blocks: 'begin - 1' is the baseline to reconstruct 'begin' (exclude it).
@@ -280,7 +290,7 @@ PostingListPtr MergeTreeIndexGranuleProjection::materializeFromTokenInfo(
         stream,
         last_doc_id,
         token_info.offsets[block_idx].block_doc_count,
-        token_info.offsets[block_idx].offset,
+        offset,
         block_idx == 0 /* include_first_doc */);
 }
 

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.cpp
@@ -275,9 +275,11 @@ void MergeTreeIndexGranuleProjection::deserializeBinaryWithMultipleStreams(
 }
 
 PostingListPtr MergeTreeIndexGranuleProjection::materializeFromTokenInfo(
-    LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx, size_t format_version)
+    LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx, size_t /*format_version*/)
 {
-    UInt64 offset = resolveDataSectionOffset(stream, token_info.offsets[block_idx].offset, format_version);
+    /// In the new V2 design, offset always points to Data Section start (same as V1).
+    /// No need to call resolveDataSectionOffset.
+    UInt64 offset = token_info.offsets[block_idx].offset;
 
     /// For delta-decoding:
     /// - First block: 'begin' is the first doc_id (include it).

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h
@@ -15,9 +15,10 @@ struct MergeTreeIndexGranuleProjection final : public MergeTreeIndexGranuleText
     void deserializeBinaryWithMultipleStreams(MergeTreeIndexInputStreams & streams, MergeTreeIndexDeserializationState & state) override;
 
     static PostingListPtr
-    materializeFromTokenInfo(LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx);
+    materializeFromTokenInfo(LargePostingListReaderStream & stream, const TokenPostingsInfo & token_info, size_t block_idx, size_t format_version);
 
     String projection_name;
+    size_t posting_list_format_version = 0;
 
     /// TODO(amos): Do we need per-token stream to reduce seek?
     LargePostingListReaderStreamPtr large_posting_stream;

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
 
 namespace DB
 {
@@ -22,6 +23,11 @@ struct MergeTreeIndexGranuleProjection final : public MergeTreeIndexGranuleText
 
     /// TODO(amos): Do we need per-token stream to reduce seek?
     LargePostingListReaderStreamPtr large_posting_stream;
+
+    /// The projection part that stores the `.lpst` file.
+    /// Saved during deserialization so that `MergeTreeReaderProjectionIndex`
+    /// can create independent posting streams from the correct storage.
+    MergeTreeDataPartPtr projection_part;
 };
 
 class MergeTreeIndexProjection final : public IMergeTreeIndex

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -1,9 +1,24 @@
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h>
 
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h>
+#include <Storages/MergeTree/MergeTreeIndexConditionText.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
+
+namespace ProfileEvents
+{
+    extern const Event TextIndexReaderTotalMicroseconds;
+}
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsString text_index_posting_list_apply_mode;
+}
 
 MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     const IMergeTreeReader * main_reader_, MergeTreeIndexWithCondition index_, NamesAndTypesList columns_, bool can_skip_mark_)
@@ -21,6 +36,12 @@ MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     };
 
     deserialization_state = std::make_unique<MergeTreeIndexDeserializationState>(std::move(state));
+
+    /// Determine apply mode from query settings.
+    const auto & condition_text = assert_cast<const MergeTreeIndexConditionText &>(*index.condition);
+    const auto & settings = condition_text.getContext()->getSettingsRef();
+    String mode = settings[Setting::text_index_posting_list_apply_mode];
+    use_lazy_mode = (mode == "lazy");
 }
 
 PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
@@ -30,6 +51,167 @@ PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
     auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
     chassert(granule_projection.large_posting_stream);
     return MergeTreeIndexGranuleProjection::materializeFromTokenInfo(*granule_projection.large_posting_stream, token_info, block_idx);
+}
+
+PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
+{
+    chassert(granule);
+    auto & granule_text = dynamic_cast<MergeTreeIndexGranuleText &>(*granule);
+    const auto & remaining_tokens = granule_text.getRemainingTokens();
+    auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
+
+    PostingListCursorMap result;
+
+    for (const auto & [token, token_info] : remaining_tokens)
+    {
+        if (!useful_tokens.contains(token))
+            continue;
+
+        if (token_info.embedded_postings)
+        {
+            /// For embedded postings, create cursor without stream (it reads from embedded data).
+            auto cursor = std::make_shared<PostingListCursor>(token_info, 0);
+            result.emplace(token, std::move(cursor));
+        }
+        else if (!token_info.offsets.empty())
+        {
+            /// For large postings, create cursor with the large posting stream.
+            /// Each LargePostingBlockMeta in offsets is treated as a segment.
+            chassert(granule_projection.large_posting_stream);
+            auto cursor = std::make_shared<PostingListCursor>(
+                granule_projection.large_posting_stream.get(), token_info, 0);
+            for (size_t s = 1; s < token_info.offsets.size(); ++s)
+                cursor->addSegment(s);
+            result.emplace(token, std::move(cursor));
+        }
+    }
+
+    return result;
+}
+
+void MergeTreeReaderProjectionIndex::ensureCursorMap()
+{
+    if (cursor_map_built)
+        return;
+    cursor_map = buildCursorMap();
+    cursor_map_built = true;
+}
+
+void MergeTreeReaderProjectionIndex::fillColumnLazy(
+    IColumn & column,
+    const String & column_name,
+    size_t column_offset,
+    size_t row_offset,
+    size_t num_rows)
+{
+    auto & column_data = assert_cast<ColumnUInt8 &>(column).getData();
+    const auto & condition_text = assert_cast<const MergeTreeIndexConditionText &>(*index.condition);
+    auto search_query = condition_text.getSearchQueryForVirtualColumn(column_name);
+
+    column_data.resize_fill(column_offset + num_rows, 0);
+
+    if (cursor_map.empty() || search_query->tokens.empty())
+        return;
+
+    /// Use default thresholds for adaptive algorithm selection.
+    constexpr bool brute_force_apply = false;
+    constexpr float density_threshold = 0.5f;
+
+    if (search_query->search_mode == TextSearchMode::Any || cursor_map.size() == 1)
+        lazyUnionPostingLists(column, cursor_map, search_query->tokens, column_offset, row_offset, num_rows, brute_force_apply, density_threshold);
+    else if (search_query->search_mode == TextSearchMode::All)
+        lazyIntersectPostingLists(column, cursor_map, search_query->tokens, column_offset, row_offset, num_rows, brute_force_apply, density_threshold);
+}
+
+size_t MergeTreeReaderProjectionIndex::readRows(
+    size_t from_mark,
+    size_t current_task_last_mark,
+    bool continue_reading,
+    size_t max_rows_to_read,
+    size_t rows_offset,
+    Columns & res_columns)
+{
+    /// In materialize mode, delegate to the base class implementation.
+    if (!use_lazy_mode)
+        return MergeTreeReaderTextIndex::readRows(from_mark, current_task_last_mark, continue_reading, max_rows_to_read, rows_offset, res_columns);
+
+    /// Lazy mode: use PostingListCursor-based intersection/union.
+    ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::TextIndexReaderTotalMicroseconds);
+    const auto & index_granularity = data_part_info_for_read->getIndexGranularity();
+
+    size_t from_row;
+    if (continue_reading)
+    {
+        from_mark = current_mark;
+        from_row = current_row + rows_offset;
+    }
+    else
+    {
+        from_row = index_granularity.getMarkStartingRow(from_mark) + rows_offset;
+    }
+
+    size_t total_rows = data_part_info_for_read->getRowCount();
+    if (from_row < total_rows)
+        max_rows_to_read = std::min(max_rows_to_read, total_rows - from_row);
+    else
+        max_rows_to_read = 0;
+
+    if (res_columns.empty())
+    {
+        ++current_mark;
+        current_row += max_rows_to_read;
+        return max_rows_to_read;
+    }
+
+    size_t read_rows = 0;
+    createEmptyColumns(res_columns);
+
+    while (read_rows < max_rows_to_read)
+    {
+        size_t rows_to_read = std::min(index_granularity.getMarkRows(from_mark), max_rows_to_read - read_rows);
+
+        if (!analyzed_granules.contains(static_cast<UInt32>(from_mark)))
+        {
+            canSkipMark(from_mark, current_task_last_mark);
+        }
+
+        if (!may_be_true_granules.contains(static_cast<UInt32>(from_mark)))
+        {
+            for (const auto & column : res_columns)
+            {
+                auto & column_data = assert_cast<ColumnUInt8 &>(column->assumeMutableRef()).getData();
+                column_data.resize_fill(column->size() + rows_to_read, 0);
+            }
+        }
+        else
+        {
+            /// Build cursor map once (lazy), then reuse for all subsequent marks.
+            ensureCursorMap();
+
+            for (size_t i = 0; i < res_columns.size(); ++i)
+            {
+                auto & column_mutable = res_columns[i]->assumeMutableRef();
+
+                if (is_always_true[i])
+                {
+                    auto & column_data = assert_cast<ColumnUInt8 &>(column_mutable).getData();
+                    column_data.resize_fill(column_mutable.size() + rows_to_read, 1);
+                }
+                else
+                {
+                    fillColumnLazy(column_mutable, columns_to_read[i].name, column_mutable.size(), from_row, rows_to_read);
+                }
+            }
+        }
+
+        ++from_mark;
+        from_row += rows_to_read;
+        read_rows += rows_to_read;
+    }
+
+    current_mark = from_mark;
+    current_row = from_row;
+    return read_rows;
 }
 
 }

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -6,6 +6,8 @@
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 
 namespace ProfileEvents
 {
@@ -14,6 +16,12 @@ namespace ProfileEvents
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsString text_index_posting_list_apply_mode;
+    extern const SettingsFloat text_index_density_threshold;
+}
 
 MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     const IMergeTreeReader * main_reader_, MergeTreeIndexWithCondition index_, NamesAndTypesList columns_, bool can_skip_mark_)
@@ -139,9 +147,9 @@ void MergeTreeReaderProjectionIndex::fillColumnLazy(
     if (cursor_map.empty() || search_query->tokens.empty())
         return;
 
-    /// Use default thresholds for adaptive algorithm selection.
     constexpr bool brute_force_apply = false;
-    constexpr float density_threshold = 0.5f;
+    const auto & query_settings = condition_text.getContext()->getSettingsRef();
+    float density_threshold = static_cast<float>(double(query_settings[Setting::text_index_density_threshold]));
 
     if (search_query->search_mode == TextSearchMode::Any || cursor_map.size() == 1)
         lazyUnionPostingLists(column, cursor_map, search_query->tokens, column_offset, row_offset, num_rows, brute_force_apply, density_threshold);
@@ -157,14 +165,17 @@ size_t MergeTreeReaderProjectionIndex::readRows(
     size_t rows_offset,
     Columns & res_columns)
 {
-    /// Determine apply mode from the on-disk posting list format version:
-    /// - V1 (no block index): use materialize mode (base class)
-    /// - V2 (with block index): use lazy cursor-based mode
+    /// Determine apply mode:
+    /// - V1 (no block index): always use materialize mode (base class)
+    /// - V2 (with block index): use lazy mode if setting allows
     bool use_lazy = false;
     if (granule)
     {
         auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
-        use_lazy = postingListFormatHasBlockIndex(granule_projection.posting_list_format_version);
+        const auto & condition_text = assert_cast<const MergeTreeIndexConditionText &>(*index.condition);
+        const auto & query_settings = condition_text.getContext()->getSettingsRef();
+        use_lazy = postingListFormatHasBlockIndex(granule_projection.posting_list_format_version)
+            && String(query_settings[Setting::text_index_posting_list_apply_mode]) == "lazy";
     }
 
     if (!use_lazy)

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -97,7 +97,7 @@ PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
         if (token_info.embedded_postings)
         {
             /// For embedded postings, create cursor without stream (it reads from embedded data).
-            auto cursor = std::make_shared<PostingListCursor>(token_info, 0);
+            auto cursor = std::make_shared<PostingListCursor>(token_info);
             result.emplace(token, std::move(cursor));
         }
         else if (!token_info.offsets.empty())
@@ -107,9 +107,7 @@ PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
             /// when multiple cursors share a ReadBuffer in leapfrog intersection.
             auto independent_stream = createIndependentPostingStream();
             auto cursor = std::make_shared<PostingListCursor>(
-                std::move(independent_stream), token_info, 0);
-            for (size_t s = 1; s < token_info.offsets.size(); ++s)
-                cursor->addLargeBlock(s);
+                std::move(independent_stream), token_info);
             result.emplace(token, std::move(cursor));
         }
     }

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -1,10 +1,9 @@
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h>
 
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h>
+#include <Storages/MergeTree/ProjectionIndex/PostingListState.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Columns/ColumnsNumber.h>
-#include <Core/Settings.h>
-#include <Interpreters/Context.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 
 namespace ProfileEvents
@@ -14,11 +13,6 @@ namespace ProfileEvents
 
 namespace DB
 {
-
-namespace Setting
-{
-    extern const SettingsString text_index_posting_list_apply_mode;
-}
 
 MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     const IMergeTreeReader * main_reader_, MergeTreeIndexWithCondition index_, NamesAndTypesList columns_, bool can_skip_mark_)
@@ -36,12 +30,6 @@ MergeTreeReaderProjectionIndex::MergeTreeReaderProjectionIndex(
     };
 
     deserialization_state = std::make_unique<MergeTreeIndexDeserializationState>(std::move(state));
-
-    /// Determine apply mode from query settings.
-    const auto & condition_text = assert_cast<const MergeTreeIndexConditionText &>(*index.condition);
-    const auto & settings = condition_text.getContext()->getSettingsRef();
-    String mode = settings[Setting::text_index_posting_list_apply_mode];
-    use_lazy_mode = (mode == "lazy");
 }
 
 PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
@@ -50,7 +38,8 @@ PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
     chassert(granule);
     auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
     chassert(granule_projection.large_posting_stream);
-    return MergeTreeIndexGranuleProjection::materializeFromTokenInfo(*granule_projection.large_posting_stream, token_info, block_idx);
+    return MergeTreeIndexGranuleProjection::materializeFromTokenInfo(
+        *granule_projection.large_posting_stream, token_info, block_idx, granule_projection.posting_list_format_version);
 }
 
 PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
@@ -131,8 +120,17 @@ size_t MergeTreeReaderProjectionIndex::readRows(
     size_t rows_offset,
     Columns & res_columns)
 {
-    /// In materialize mode, delegate to the base class implementation.
-    if (!use_lazy_mode)
+    /// Determine apply mode from the on-disk posting list format version:
+    /// - V1 (no block index): use materialize mode (base class)
+    /// - V2 (with block index): use lazy cursor-based mode
+    bool use_lazy = false;
+    if (granule)
+    {
+        auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
+        use_lazy = postingListFormatHasBlockIndex(granule_projection.posting_list_format_version);
+    }
+
+    if (!use_lazy)
         return MergeTreeReaderTextIndex::readRows(from_mark, current_task_last_mark, continue_reading, max_rows_to_read, rows_offset, res_columns);
 
     /// Lazy mode: use PostingListCursor-based intersection/union.

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -2,6 +2,7 @@
 
 #include <Storages/MergeTree/ProjectionIndex/MergeTreeIndexProjection.h>
 #include <Storages/MergeTree/ProjectionIndex/PostingListState.h>
+#include <Storages/MergeTree/ProjectionIndex/ProjectionIndexSerializationContext.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
@@ -42,12 +43,19 @@ PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
         *granule_projection.large_posting_stream, token_info, block_idx, granule_projection.posting_list_format_version);
 }
 
+LargePostingListReaderStreamPtr MergeTreeReaderProjectionIndex::createIndependentPostingStream() const
+{
+    auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+        "posting", {}, PROJECTION_INDEX_LARGE_POSTING_SUFFIX, data_part_info_for_read->getChecksums(), storage_settings);
+    chassert(stream_name);
+    return createLargePostingStream(*stream_name, {}, CLOCK_MONOTONIC_COARSE);
+}
+
 PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
 {
     chassert(granule);
     auto & granule_text = dynamic_cast<MergeTreeIndexGranuleText &>(*granule);
     const auto & remaining_tokens = granule_text.getRemainingTokens();
-    auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
 
     PostingListCursorMap result;
 
@@ -64,11 +72,12 @@ PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
         }
         else if (!token_info.offsets.empty())
         {
-            /// For large postings, create cursor with the large posting stream.
-            /// Each LargePostingBlockMeta in offsets corresponds to one large block.
-            chassert(granule_projection.large_posting_stream);
+            /// For large postings, create cursor with an independent stream.
+            /// Each cursor owns its own stream to avoid seek contention
+            /// when multiple cursors share a ReadBuffer in leapfrog intersection.
+            auto independent_stream = createIndependentPostingStream();
             auto cursor = std::make_shared<PostingListCursor>(
-                granule_projection.large_posting_stream.get(), token_info, 0);
+                std::move(independent_stream), token_info, 0);
             for (size_t s = 1; s < token_info.offsets.size(); ++s)
                 cursor->addLargeBlock(s);
             result.emplace(token, std::move(cursor));

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -45,10 +45,40 @@ PostingListPtr MergeTreeReaderProjectionIndex::readPostingsBlockForToken(
 
 LargePostingListReaderStreamPtr MergeTreeReaderProjectionIndex::createIndependentPostingStream() const
 {
+    chassert(granule);
+    auto & granule_projection = assert_cast<MergeTreeIndexGranuleProjection &>(*granule);
+    chassert(granule_projection.projection_part);
+
+    /// Use the projection part's checksums and storage, not the main part's.
+    /// `data_part_info_for_read` refers to the main part, but the `.lpst` file
+    /// is written into the projection part's directory.
+    const auto & proj_part = granule_projection.projection_part;
     auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
-        "posting", {}, PROJECTION_INDEX_LARGE_POSTING_SUFFIX, data_part_info_for_read->getChecksums(), storage_settings);
+        "posting", {}, PROJECTION_INDEX_LARGE_POSTING_SUFFIX, proj_part->checksums, storage_settings);
     chassert(stream_name);
-    return createLargePostingStream(*stream_name, {}, CLOCK_MONOTONIC_COARSE);
+
+    auto proj_storage = proj_part->getDataPartStoragePtr();
+    String file_name = *stream_name + PROJECTION_INDEX_LARGE_POSTING_SUFFIX;
+    size_t file_size = proj_storage->getFileSize(file_name);
+
+    static constexpr size_t marks_count = 1;
+    auto large_posting_stream_settings = settings;
+    large_posting_stream_settings.is_compressed = false;
+    return std::make_shared<LargePostingListReaderStream>(
+        data_part_info_for_read->getMergedPartOffsets(),
+        data_part_info_for_read->getPartIndex(),
+        data_part_info_for_read->getPartStartingOffset(),
+        proj_storage,
+        *stream_name,
+        PROJECTION_INDEX_LARGE_POSTING_SUFFIX,
+        marks_count,
+        MarkRanges{{0, marks_count}},
+        large_posting_stream_settings,
+        /*uncompressed_cache=*/nullptr,
+        file_size,
+        /*marks_loader=*/nullptr,
+        ReadBufferFromFileBase::ProfileCallback{},
+        CLOCK_MONOTONIC_COARSE);
 }
 
 PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.cpp
@@ -76,12 +76,12 @@ PostingListCursorMap MergeTreeReaderProjectionIndex::buildCursorMap()
         else if (!token_info.offsets.empty())
         {
             /// For large postings, create cursor with the large posting stream.
-            /// Each LargePostingBlockMeta in offsets is treated as a segment.
+            /// Each LargePostingBlockMeta in offsets corresponds to one large block.
             chassert(granule_projection.large_posting_stream);
             auto cursor = std::make_shared<PostingListCursor>(
                 granule_projection.large_posting_stream.get(), token_info, 0);
             for (size_t s = 1; s < token_info.offsets.size(); ++s)
-                cursor->addSegment(s);
+                cursor->addLargeBlock(s);
             result.emplace(token, std::move(cursor));
         }
     }

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Storages/MergeTree/MergeTreeReaderTextIndex.h>
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
 
 namespace DB
 {
@@ -13,9 +14,38 @@ public:
 
     void prefetchBeginOfRange(Priority /* priority */) override { }
 
+    size_t readRows(
+        size_t from_mark,
+        size_t current_task_last_mark,
+        bool continue_reading,
+        size_t max_rows_to_read,
+        size_t offset,
+        Columns & res_columns) override;
+
 private:
     PostingListPtr
     readPostingsBlockForToken(std::string_view token, const TokenPostingsInfo & token_info, size_t block_idx, PostingListCodecPtr) override;
+
+    /// Build PostingListCursorMap from remaining_tokens.
+    PostingListCursorMap buildCursorMap();
+
+    /// Ensure cursor map is built (called once, lazy).
+    void ensureCursorMap();
+
+    /// Fill column using lazy cursor-based intersection/union.
+    void fillColumnLazy(
+        IColumn & column,
+        const String & column_name,
+        size_t column_offset,
+        size_t row_offset,
+        size_t num_rows);
+
+    /// Whether to use lazy posting list apply mode.
+    bool use_lazy_mode = false;
+
+    /// Lazily-built cursor map, shared across all marks in the part.
+    PostingListCursorMap cursor_map;
+    bool cursor_map_built = false;
 };
 
 }

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
@@ -40,9 +40,6 @@ private:
         size_t row_offset,
         size_t num_rows);
 
-    /// Whether to use lazy posting list apply mode.
-    bool use_lazy_mode = false;
-
     /// Lazily-built cursor map, shared across all marks in the part.
     PostingListCursorMap cursor_map;
     bool cursor_map_built = false;

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
@@ -31,6 +31,7 @@ private:
 
     /// Create an independent LargePostingListReaderStream for a cursor.
     /// Each cursor gets its own stream to avoid seek contention in leapfrog intersection.
+    /// Uses the projection part's storage and checksums (not the main part's).
     LargePostingListReaderStreamPtr createIndependentPostingStream() const;
 
     /// Ensure cursor map is built (called once, lazy).

--- a/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/MergeTreeReaderProjectionIndex.h
@@ -29,6 +29,10 @@ private:
     /// Build PostingListCursorMap from remaining_tokens.
     PostingListCursorMap buildCursorMap();
 
+    /// Create an independent LargePostingListReaderStream for a cursor.
+    /// Each cursor gets its own stream to avoid seek contention in leapfrog intersection.
+    LargePostingListReaderStreamPtr createIndependentPostingStream() const;
+
     /// Ensure cursor map is built (called once, lazy).
     void ensureCursorMap();
 

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -518,6 +518,19 @@ struct ReaderStreamCursor
     UInt64 offset;
     bool do_seek;
 
+    /// V2 large block boundary tracking: when Index Sections are interleaved
+    /// between Data Sections, we need to skip over them during sequential reads.
+    /// Each entry is (docs_remaining_in_this_block, next_block_data_offset).
+    /// When `remaining_in_large_block` hits 0, seek to the next block's offset.
+    struct LargeBlockSkip
+    {
+        UInt32 doc_count;
+        UInt64 next_data_offset; /// 0 means last block, no skip needed
+    };
+    std::vector<LargeBlockSkip> large_block_skips;
+    size_t current_large_block = 0;
+    UInt32 remaining_in_large_block = 0;
+
     /// Disk-based c'tor
     ReaderStreamCursor(
         LargePostingListReaderStream * s,
@@ -565,6 +578,22 @@ struct ReaderStreamCursor
         , do_seek(false)
     {
         chassert(doc_buffer);
+    }
+
+    /// Set up large block skip schedule for V2 format.
+    /// `blocks` contains per-large-block metadata; when a large block's Data Section
+    /// is fully consumed, the cursor seeks past its Index Section to the next block's
+    /// Data Section offset.
+    void setLargeBlockSkips(const LargePostingBlockMetas & blocks)
+    {
+        large_block_skips.resize(blocks.size());
+        for (size_t i = 0; i < blocks.size(); ++i)
+        {
+            large_block_skips[i].doc_count = blocks[i].block_doc_count;
+            large_block_skips[i].next_data_offset = (i + 1 < blocks.size()) ? blocks[i + 1].offset : 0;
+        }
+        current_large_block = 0;
+        remaining_in_large_block = blocks.empty() ? 0 : blocks[0].block_doc_count;
     }
 
     UInt32 ALWAYS_INLINE current() const
@@ -645,6 +674,24 @@ private:
         if (remaining_count == 0)
             return;
 
+        /// V2 large block boundary: if we've consumed all docs in the current
+        /// large block, skip over the trailing Index Section by seeking to the
+        /// next large block's Data Section offset.
+        if (!large_block_skips.empty() && remaining_in_large_block == 0)
+        {
+            ++current_large_block;
+            chassert(current_large_block < large_block_skips.size());
+            remaining_in_large_block = large_block_skips[current_large_block].doc_count;
+
+            /// Seek past the Index Section to the next Data Section
+            UInt64 next_offset = large_block_skips[current_large_block - 1].next_data_offset;
+            if (next_offset != 0)
+            {
+                stream->seek(next_offset);
+                do_seek = false;
+            }
+        }
+
         if (do_seek)
         {
             stream->seek(offset);
@@ -677,6 +724,10 @@ private:
         remaining_count -= count;
         buf_size = count;
         pos = 0;
+
+        if (!large_block_skips.empty())
+            remaining_in_large_block -= count;
+
         if (stream->merged_part_offsets)
             stream->merged_part_offsets->mapOffsets(stream->part_index, doc_buffer, count);
     }
@@ -918,25 +969,21 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
         chassert(!lazy_stream.large_posting_blocks.empty());
         const auto & blocks = lazy_stream.large_posting_blocks;
 
-        /// In the new V2 design, offset always points to Data Section start (same as V1).
-        /// Each large block may have an Index Section after Data Section, but since we read
-        /// sequentially, we must create separate cursors per block to avoid reading into
-        /// the Index Section of the preceding block.
-        for (size_t bi = 0; bi < blocks.size(); ++bi)
-        {
-            lazy_stream.stream->seek(blocks[bi].offset);
+        lazy_stream.stream->seek(blocks.front().offset);
 
-            bool is_first_block = (bi == 0);
-            UInt32 delta_base = is_first_block ? lazy_stream.first_doc_id : blocks[bi - 1].last_doc_id;
+        cursors.emplace_back(
+            lazy_stream.stream.get(),
+            lazy_stream.first_doc_id,
+            lazy_stream.doc_count - 1, /* remaining doc count (first doc is inline) */
+            static_cast<UInt64>(lazy_stream.stream->getPosition()),
+            false,
+            true);
 
-            cursors.emplace_back(
-                lazy_stream.stream.get(),
-                delta_base,
-                blocks[bi].block_doc_count,
-                static_cast<UInt64>(lazy_stream.stream->getPosition()),
-                true, /* do_seek — needed because blocks are not contiguous when Index Sections are interleaved */
-                is_first_block);
-        }
+        /// In V2 format, Index Sections are interleaved between Data Sections.
+        /// Set up skip schedule so the cursor seeks past each Index Section
+        /// at large block boundaries.
+        if (postingListFormatHasBlockIndex(lazy_posting_stream->streams.format_version))
+            cursors.back().setLargeBlockSkips(blocks);
     }
 
     UInt32 last_doc_id;
@@ -1015,21 +1062,18 @@ void PostingListStream::collect(UInt32 * buf) const
         chassert(!lazy_stream.large_posting_blocks.empty());
         const auto & blocks = lazy_stream.large_posting_blocks;
 
-        for (size_t bi = 0; bi < blocks.size(); ++bi)
-        {
-            lazy_stream.stream->seek(blocks[bi].offset);
+        lazy_stream.stream->seek(blocks.front().offset);
 
-            bool is_first_block = (bi == 0);
-            UInt32 delta_base = is_first_block ? lazy_stream.first_doc_id : blocks[bi - 1].last_doc_id;
+        cursors.emplace_back(
+            lazy_stream.stream.get(),
+            lazy_stream.first_doc_id,
+            lazy_stream.doc_count - 1,
+            static_cast<UInt64>(lazy_stream.stream->getPosition()),
+            false,
+            true);
 
-            cursors.emplace_back(
-                lazy_stream.stream.get(),
-                delta_base,
-                blocks[bi].block_doc_count,
-                static_cast<UInt64>(lazy_stream.stream->getPosition()),
-                true,
-                is_first_block);
-        }
+        if (postingListFormatHasBlockIndex(lazy_posting_stream->streams.format_version))
+            cursors.back().setLargeBlockSkips(blocks);
     }
 
     UInt32 buffered = 0;

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -266,13 +266,13 @@ void PostingListWriter::add(UInt32 doc_id, Arena * arena, uint8_t * packed_buffe
             break;
         case 17:
             doc_delta_buffer
-                = reinterpret_cast<UInt32 *>(arena->alignedRealloc(reinterpret_cast<char *>(doc_delta_buffer), 16 * 4, 128 * 4, 16));
+                = reinterpret_cast<UInt32 *>(arena->alignedRealloc(reinterpret_cast<char *>(doc_delta_buffer), 16 * 4, TURBOPFOR_BLOCK_SIZE * 4, 16));
             break;
         default:
             break;
     }
 
-    UInt8 doc_buffer_up_to = (doc_count - 1) % 128;
+    UInt8 doc_buffer_up_to = (doc_count - 1) % TURBOPFOR_BLOCK_SIZE;
     UInt32 doc_delta = doc_id - last_doc_id - 1;
     doc_delta_buffer[doc_buffer_up_to] = doc_delta;
 
@@ -280,9 +280,9 @@ void PostingListWriter::add(UInt32 doc_id, Arena * arena, uint8_t * packed_buffe
     ++doc_buffer_up_to;
     ++doc_count;
 
-    if (doc_buffer_up_to == 128)
+    if (doc_buffer_up_to == TURBOPFOR_BLOCK_SIZE)
     {
-        uint8_t * packed_buffer_end = turbopfor::p4Enc128v32(doc_delta_buffer, 128, packed_buffer);
+        uint8_t * packed_buffer_end = turbopfor::p4Enc128v32(doc_delta_buffer, TURBOPFOR_BLOCK_SIZE, packed_buffer);
         UInt32 len = static_cast<UInt32>(packed_buffer_end - packed_buffer);
         chassert(len <= 512);
         auto * place = arena->alignedAlloc(len + sizeof(PostingListChunk), alignof(PostingListChunk));
@@ -307,7 +307,7 @@ public:
     {
         if (write_block_index)
         {
-            UInt32 packed_blocks_per_large_block = docs_per_large_block / 128;
+            UInt32 packed_blocks_per_large_block = docs_per_large_block / TURBOPFOR_BLOCK_SIZE;
             packed_block_last_doc_ids.reserve(packed_blocks_per_large_block);
             packed_block_offsets.reserve(packed_blocks_per_large_block);
         }
@@ -328,10 +328,10 @@ public:
         VarInt::writeVarUInt32(bytes, data_out);
         data_out.write(data, bytes);
 
-        /// Always count a packed block as 128 docs.
+        /// Always count a packed block as TURBOPFOR_BLOCK_SIZE docs.
         /// The tail block is the final one and will be flushed immediately,
         /// so treating it as full does not affect block layout.
-        docs_in_current_block += 128;
+        docs_in_current_block += TURBOPFOR_BLOCK_SIZE;
         current_block_last_doc_id = last_doc_id;
 
         if (docs_in_current_block >= docs_per_large_block)
@@ -436,9 +436,9 @@ void PostingListWriter::finish(
     ///   ...
     /// --------------------------------------------
 
-    /// Align posting_list_block_size up to 128 docs, so that each large block
-    /// consists of an integral number of packed-128 blocks.
-    const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + 127) & ~127;
+    /// Align posting_list_block_size up to TURBOPFOR_BLOCK_SIZE docs, so that each large block
+    /// consists of an integral number of packed blocks.
+    const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + TURBOPFOR_BLOCK_SIZE - 1) & ~(TURBOPFOR_BLOCK_SIZE - 1);
 
     /// The first document is stored inline, so only (doc_count - 1) documents
     /// are written into the large_posting stream.
@@ -453,7 +453,7 @@ void PostingListWriter::finish(
     LargePostingBlockWriter block_writer(wb, large_posting, docs_per_large_block,
         postingListFormatHasBlockIndex(resolvePostingListFormatVersion(index_params.posting_list_version)));
 
-    /// Iterate packed 128-doc chunks
+    /// Iterate packed TURBOPFOR_BLOCK_SIZE-doc chunks
     PostingListChunk * it = blocks_head;
     while (it != nullptr)
     {
@@ -461,8 +461,8 @@ void PostingListWriter::finish(
         it = it->next;
     }
 
-    /// Tail packed block (large_doc_count % 128)
-    UInt8 doc_buffer_up_to = large_doc_count % 128;
+    /// Tail packed block (large_doc_count % TURBOPFOR_BLOCK_SIZE)
+    UInt8 doc_buffer_up_to = large_doc_count % TURBOPFOR_BLOCK_SIZE;
     if (doc_buffer_up_to > 0)
     {
         uint8_t * packed_buffer_end = turbopfor::p4Enc32(doc_delta_buffer, doc_buffer_up_to, packed_buffer);
@@ -700,7 +700,7 @@ private:
         auto & data_buf = *stream->getDataBuffer();
         UInt32 bytes;
         VarInt::readVarUInt32(bytes, data_buf);
-        UInt32 count = std::min(remaining_count, 128U);
+        UInt32 count = std::min(remaining_count, static_cast<UInt32>(TURBOPFOR_BLOCK_SIZE));
         uint8_t * src_ptr;
         if (data_buf.available() >= bytes)
         {
@@ -714,8 +714,8 @@ private:
             src_ptr = stream->packed_buffer;
         }
 
-        if (count == 128)
-            turbopfor::p4D1Dec128v32(src_ptr, 128, doc_buffer, last_doc_id);
+        if (count == TURBOPFOR_BLOCK_SIZE)
+            turbopfor::p4D1Dec128v32(src_ptr, TURBOPFOR_BLOCK_SIZE, doc_buffer, last_doc_id);
         else
             turbopfor::p4D1Dec32(src_ptr, count, doc_buffer, last_doc_id);
 
@@ -898,7 +898,7 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
     chassert(num_large_blocks >= 1);
 
     UInt32 remaining_docs = doc_count - 1;
-    const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + 127) & ~127;
+    const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + TURBOPFOR_BLOCK_SIZE - 1) & ~(TURBOPFOR_BLOCK_SIZE - 1);
 
     LargePostingBlockMetas large_posting_blocks;
     large_posting_blocks.reserve(num_large_blocks);
@@ -987,8 +987,8 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
 
     UInt32 last_doc_id;
 
-    /// Align to 128-doc blocks
-    const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + 127) & ~127;
+    /// Align to TURBOPFOR_BLOCK_SIZE-doc blocks
+    const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + TURBOPFOR_BLOCK_SIZE - 1) & ~(TURBOPFOR_BLOCK_SIZE - 1);
     const UInt32 large_doc_count = doc_count - 1;
     const UInt32 num_large_blocks = (large_doc_count + docs_per_large_block - 1) / docs_per_large_block;
     LargePostingBlockWriter block_writer(wb, stream.plain_hashing, docs_per_large_block,
@@ -997,7 +997,7 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     UInt32 buffered = 0;
     auto flush128 = [&]()
     {
-        uint8_t * end = turbopfor::p4Enc128v32(doc_delta_buffer, 128, packed_buffer);
+        uint8_t * end = turbopfor::p4Enc128v32(doc_delta_buffer, TURBOPFOR_BLOCK_SIZE, packed_buffer);
         block_writer.addBlock(last_doc_id, reinterpret_cast<const char *>(packed_buffer), static_cast<UInt32>(end - packed_buffer));
         buffered = 0;
     };
@@ -1025,7 +1025,7 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
             chassert(doc_id > last_doc_id);
             doc_delta_buffer[buffered++] = doc_id - last_doc_id - 1;
             last_doc_id = doc_id;
-            if (buffered == 128)
+            if (buffered == TURBOPFOR_BLOCK_SIZE)
                 flush128();
         });
 

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -12,7 +12,7 @@
 
 #include <fmt/ranges.h>
 #include <turbopfor.h>
-
+#pragma clang optimize off
 namespace DB
 {
 
@@ -350,14 +350,14 @@ public:
 private:
     void flushLargeBlock()
     {
-        UInt64 offset_for_dictionary = large_block_start_offset;
+        /// V1/V2 shared: offset_in_lpst always points to Data Section start
+        VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
+        writeVarUInt(large_block_start_offset, meta_out);
 
         if (write_block_index)
         {
             /// Data Section is already written to data_out. Now append the Index Section.
-            /// Record the Index Section start offset — this is what goes into the dictionary stream
-            /// so that the V2 reader can seek directly to the Index Section.
-            offset_for_dictionary = data_out.count();
+            UInt64 index_section_offset = data_out.count();
 
             UInt32 num_packed_blocks = static_cast<UInt32>(packed_block_last_doc_ids.size());
 
@@ -373,13 +373,10 @@ private:
 
             packed_block_last_doc_ids.clear();
             packed_block_offsets.clear();
-        }
 
-        /// Write `(last_doc_id, offset)` to dictionary stream.
-        /// V1 (write_block_index=false): offset points to Data Section start.
-        /// V2 (write_block_index=true): offset points to Index Section start.
-        VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
-        writeVarUInt(offset_for_dictionary, meta_out);
+            /// Write index_offset_in_lpst to dictionary stream (V2 only).
+            writeVarUInt(index_section_offset, meta_out);
+        }
 
         /// Reset for next large block.
         docs_in_current_block = 0;
@@ -740,33 +737,6 @@ void mergePostingCursors(std::vector<ReaderStreamCursor> & cursors, EmitFirst &&
     }
 }
 
-/// For v2 format, the dictionary offset points to the Index Section (not the Data Section).
-/// This function reads the Index Section to find the Data Section start offset.
-/// For v1 format, the offset already points to the Data Section.
-UInt64 resolveDataSectionOffset(
-    LargePostingListReaderStream & stream, UInt64 offset, size_t format_version)
-{
-    if (!postingListFormatHasBlockIndex(format_version))
-        return offset;
-
-    stream.seek(offset);
-    auto & data_buf = *stream.getDataBuffer();
-
-    /// Read Index Section header: [num_packed_blocks]
-    UInt32 num_packed_blocks;
-    VarInt::readVarUInt32(num_packed_blocks, data_buf);
-    /// Skip N × last_doc_ids
-    for (UInt32 j = 0; j < num_packed_blocks; ++j)
-    {
-        UInt32 dummy;
-        VarInt::readVarUInt32(dummy, data_buf);
-    }
-    /// Read the first packed_block_offset — this is the Data Section start
-    UInt64 data_section_start;
-    readVarUInt(data_section_start, data_buf);
-    return data_section_start;
-}
-
 PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
     LargePostingListReaderStream & stream, UInt32 last_doc_id, UInt32 block_doc_count, UInt64 offset, bool include_first_doc)
 {
@@ -792,7 +762,7 @@ PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
 
 std::string LargePostingBlockMeta::toString() const
 {
-    return fmt::format("{{last_doc_id: {}, block_doc_count: {}, offset: {}}}", last_doc_id, block_doc_count, offset);
+    return fmt::format("{{last_doc_id: {}, block_doc_count: {}, offset: {}, index_offset: {}}}", last_doc_id, block_doc_count, offset, index_offset);
 }
 
 std::string ReaderStreamEntry::toString() const
@@ -891,7 +861,11 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
         VarInt::readVarUInt32(id, in);
         readVarUInt(offset, in);
 
-        large_posting_blocks.emplace_back(id, docs_in_large_block, offset);
+        UInt64 index_offset = 0;
+        if (postingListFormatHasBlockIndex(format_version))
+            readVarUInt(index_offset, in);
+
+        large_posting_blocks.emplace_back(id, docs_in_large_block, offset, index_offset);
         remaining_docs -= docs_in_large_block;
     }
 
@@ -942,18 +916,27 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
-        UInt64 data_offset = resolveDataSectionOffset(
-            *lazy_stream.stream, lazy_stream.large_posting_blocks.front().offset,
-            lazy_posting_stream->streams.format_version);
-        lazy_stream.stream->seek(data_offset);
+        const auto & blocks = lazy_stream.large_posting_blocks;
 
-        cursors.emplace_back(
-            lazy_stream.stream.get(),
-            lazy_stream.first_doc_id,
-            lazy_stream.doc_count - 1, /* remaining doc counts */
-            static_cast<UInt64>(lazy_stream.stream->getPosition()),
-            false,
-            true);
+        /// In the new V2 design, offset always points to Data Section start (same as V1).
+        /// Each large block may have an Index Section after Data Section, but since we read
+        /// sequentially, we must create separate cursors per block to avoid reading into
+        /// the Index Section of the preceding block.
+        for (size_t bi = 0; bi < blocks.size(); ++bi)
+        {
+            lazy_stream.stream->seek(blocks[bi].offset);
+
+            bool is_first_block = (bi == 0);
+            UInt32 delta_base = is_first_block ? lazy_stream.first_doc_id : blocks[bi - 1].last_doc_id;
+
+            cursors.emplace_back(
+                lazy_stream.stream.get(),
+                delta_base,
+                blocks[bi].block_doc_count,
+                static_cast<UInt64>(lazy_stream.stream->getPosition()),
+                true, /* do_seek — needed because blocks are not contiguous when Index Sections are interleaved */
+                is_first_block);
+        }
     }
 
     UInt32 last_doc_id;
@@ -1030,18 +1013,23 @@ void PostingListStream::collect(UInt32 * buf) const
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
-        UInt64 data_offset = resolveDataSectionOffset(
-            *lazy_stream.stream, lazy_stream.large_posting_blocks.front().offset,
-            lazy_posting_stream->streams.format_version);
-        lazy_stream.stream->seek(data_offset);
+        const auto & blocks = lazy_stream.large_posting_blocks;
 
-        cursors.emplace_back(
-            lazy_stream.stream.get(),
-            lazy_stream.first_doc_id,
-            lazy_stream.doc_count - 1, /* remaining doc counts */
-            static_cast<UInt64>(lazy_stream.stream->getPosition()),
-            false,
-            true);
+        for (size_t bi = 0; bi < blocks.size(); ++bi)
+        {
+            lazy_stream.stream->seek(blocks[bi].offset);
+
+            bool is_first_block = (bi == 0);
+            UInt32 delta_base = is_first_block ? lazy_stream.first_doc_id : blocks[bi - 1].last_doc_id;
+
+            cursors.emplace_back(
+                lazy_stream.stream.get(),
+                delta_base,
+                blocks[bi].block_doc_count,
+                static_cast<UInt64>(lazy_stream.stream->getPosition()),
+                true,
+                is_first_block);
+        }
     }
 
     UInt32 buffered = 0;

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -12,7 +12,6 @@
 
 #include <fmt/ranges.h>
 #include <turbopfor.h>
-#pragma clang optimize off
 namespace DB
 {
 

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -5,6 +5,7 @@
 #include <Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/MergedPartOffsets.h>
+#include <Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h>
 #include <Storages/MergeTree/ProjectionIndex/PostingListState.h>
 #include <base/scope_guard.h>
 #include <Common/Arena.h>
@@ -17,222 +18,12 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int INCORRECT_DATA;
     extern const int LOGICAL_ERROR;
 }
 
-namespace VarInt
-{
-
-void throwReadAfterEOF()
-{
-    throw Exception(ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF, "Attempt to read after eof");
-}
-
-/// Prefix-Based Variable-Length Integer Encoding (Prefix VarInt).
-///
-/// This encoding is a variation of the "Length-Descriptor" VarInt,
-/// originating from the SQLite 4 design and widely utilized in systems
-/// like ClickHouse for high-performance serialization.
-///
-/// ### Key Advantages:
-/// 1. **Instruction-Level Parallelism (ILP)**: Unlike LEB128 (Protobuf) which
-///    has a serial data dependency on the continuation bit, this format
-///    determines the total length solely from the first byte. This allows
-///    the CPU to load and process payload bytes in parallel.
-/// 2. **Branch-Prediction Friendly**: The implementation is loop-less and
-///    unrolled, reducing CPU pipeline stalls during decoding.
-/// 3. **Lexicographical Comparison**: The big-endian-like prefix structure
-///    is designed to be more compatible with memcmp-based sorting and indexing
-///    compared to little-endian VarInts.
-///
-/// ### Encoding Thresholds:
-/// - [0 - 176]        : 1 byte  (Value = B0)
-/// - [177 - 16560]    : 2 bytes (Value = (B0-177) * 256 + B1 + 177)
-/// - [16561 - 540848] : 3 bytes (Value = (B0-241) * 65536 + (B1<<8) + B2 + 16561)
-/// - [540849 - 2^24-1]: 4 bytes (Marker 249 + 3 bytes raw payload)
-/// - [Up to 2^32-1]   : 5 bytes (Marker 250 + 4 bytes raw payload)
-
-/// Encoding thresholds
-static constexpr UInt32 ONE_BYTE_MAX = 176;
-static constexpr UInt32 TWO_BYTE_MAX = 16560;
-static constexpr UInt32 THREE_BYTE_MAX = 540848;
-static constexpr UInt32 FOUR_BYTE_MAX = 16777215;  /// 2^24 - 1
-
-/// Marker byte boundaries
-static constexpr UInt8 TWO_BYTE_MARKER_START = 177;
-static constexpr UInt8 TWO_BYTE_MARKER_END = 240;
-static constexpr UInt8 THREE_BYTE_MARKER_START = 241;
-static constexpr UInt8 THREE_BYTE_MARKER_END = 248;
-static constexpr UInt8 FOUR_BYTE_MARKER = 249;
-static constexpr UInt8 FIVE_BYTE_MARKER = 250;
-
-/// Offsets for compact encodings (1-3 bytes only)
-static constexpr UInt32 TWO_BYTE_OFFSET = 177;
-static constexpr UInt32 THREE_BYTE_OFFSET = 16561;
-
-template <bool check_eof>
-inline void readVarUInt32Impl(UInt32 & x, ReadBuffer & istr)
-{
-    if constexpr (check_eof)
-        if (istr.eof()) [[unlikely]]
-            throwReadAfterEOF();
-
-    const UInt8 first_byte = *istr.position()++;
-
-    if (first_byte <= ONE_BYTE_MAX)
-    {
-        x = first_byte;
-        return;
-    }
-
-    if constexpr (check_eof)
-        if (istr.eof()) [[unlikely]]
-            throwReadAfterEOF();
-
-    const UInt8 second_byte = *istr.position()++;
-
-    if (first_byte <= TWO_BYTE_MARKER_END)
-    {
-        x = ((first_byte - TWO_BYTE_MARKER_START) << 8) + second_byte + TWO_BYTE_OFFSET;
-        return;
-    }
-
-    if constexpr (check_eof)
-        if (istr.eof()) [[unlikely]]
-            throwReadAfterEOF();
-
-    const UInt8 third_byte = *istr.position()++;
-
-    if (first_byte <= THREE_BYTE_MARKER_END)
-    {
-        x = ((first_byte - THREE_BYTE_MARKER_START) << 16) + (second_byte << 8) + third_byte + THREE_BYTE_OFFSET;
-        return;
-    }
-
-    if constexpr (check_eof)
-        if (istr.eof()) [[unlikely]]
-            throwReadAfterEOF();
-
-    const UInt8 fourth_byte = *istr.position()++;
-
-    if (first_byte == FOUR_BYTE_MARKER)
-    {
-        x = (second_byte << 16) | (third_byte << 8) | fourth_byte;
-        return;
-    }
-
-    if constexpr (check_eof)
-        if (istr.eof()) [[unlikely]]
-            throwReadAfterEOF();
-
-    const UInt8 fifth_byte = *istr.position()++;
-    x = (UInt32(second_byte) << 24) | (UInt32(third_byte) << 16) | (UInt32(fourth_byte) << 8) | fifth_byte;
-}
-
-template <bool check_eof>
-inline void writeVarUInt32Impl(UInt32 x, WriteBuffer & ostr)
-{
-    if (x <= ONE_BYTE_MAX)
-    {
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>(x);
-        return;
-    }
-
-    if (x <= TWO_BYTE_MAX)
-    {
-        const UInt32 adjusted = x - TWO_BYTE_OFFSET;
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>(TWO_BYTE_MARKER_START + (adjusted >> 8));
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>(adjusted & 0xFF);
-        return;
-    }
-
-    if (x <= THREE_BYTE_MAX)
-    {
-        const UInt32 adjusted = x - THREE_BYTE_OFFSET;
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>(THREE_BYTE_MARKER_START + (adjusted >> 16));
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>((adjusted >> 8) & 0xFF);
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>(adjusted & 0xFF);
-        return;
-    }
-
-    if (x <= FOUR_BYTE_MAX)
-    {
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = FOUR_BYTE_MARKER;
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>((x >> 16) & 0xFF);
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>((x >> 8) & 0xFF);
-        if constexpr (check_eof)
-            ostr.nextIfAtEnd();
-        *ostr.position()++ = static_cast<UInt8>(x & 0xFF);
-        return;
-    }
-
-    if constexpr (check_eof)
-        ostr.nextIfAtEnd();
-    *ostr.position()++ = FIVE_BYTE_MARKER;
-    if constexpr (check_eof)
-        ostr.nextIfAtEnd();
-    *ostr.position()++ = static_cast<UInt8>((x >> 24) & 0xFF);
-    if constexpr (check_eof)
-        ostr.nextIfAtEnd();
-    *ostr.position()++ = static_cast<UInt8>((x >> 16) & 0xFF);
-    if constexpr (check_eof)
-        ostr.nextIfAtEnd();
-    *ostr.position()++ = static_cast<UInt8>((x >> 8) & 0xFF);
-    if constexpr (check_eof)
-        ostr.nextIfAtEnd();
-    *ostr.position()++ = static_cast<UInt8>(x & 0xFF);
-}
-
-inline void readVarUInt32(UInt32 & x, ReadBuffer & istr)
-{
-    if (istr.available() >= 5)
-        readVarUInt32Impl<false>(x, istr);
-    else
-        readVarUInt32Impl<true>(x, istr);
-}
-
-inline void writeVarUInt32(UInt32 x, WriteBuffer & ostr)
-{
-    if (ostr.available() >= 5)
-        writeVarUInt32Impl<false>(x, ostr);
-    else
-        writeVarUInt32Impl<true>(x, ostr);
-}
-
-inline size_t getLengthOfVarUInt32(UInt32 x)
-{
-    if (x <= ONE_BYTE_MAX)
-        return 1;
-    if (x <= TWO_BYTE_MAX)
-        return 2;
-    if (x <= THREE_BYTE_MAX)
-        return 3;
-    if (x <= FOUR_BYTE_MAX)
-        return 4;
-    return 5;
-}
-
-}
+/// Alias: VarInt functions delegate to the shared LengthPrefixedInt header.
+namespace VarInt = LengthPrefixedInt;
 
 void PostingListChunk::write(WriteBuffer & wb) const
 {
@@ -325,7 +116,7 @@ public:
             packed_block_offsets.push_back(data_out.count());
         }
 
-        VarInt::writeVarUInt32(bytes, data_out);
+        VarInt::writeUInt32(bytes, data_out);
         data_out.write(data, bytes);
 
         /// Always count a packed block as TURBOPFOR_BLOCK_SIZE docs.
@@ -350,7 +141,7 @@ private:
     void flushLargeBlock()
     {
         /// V1/V2 shared: offset_in_lpst always points to Data Section start
-        VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
+        VarInt::writeUInt32(current_block_last_doc_id, meta_out);
         writeVarUInt(large_block_start_offset, meta_out);
 
         if (write_block_index)
@@ -362,10 +153,10 @@ private:
 
             /// Write Index Section:
             /// [PrefixVarInt: num_packed_blocks]
-            VarInt::writeVarUInt32(num_packed_blocks, data_out);
+            VarInt::writeUInt32(num_packed_blocks, data_out);
             /// N × [PrefixVarInt: last_doc_id]
             for (const auto & id : packed_block_last_doc_ids)
-                VarInt::writeVarUInt32(id, data_out);
+                VarInt::writeUInt32(id, data_out);
             /// N × [VarUInt64: absolute_offset]
             for (const auto & off : packed_block_offsets)
                 writeVarUInt(off, data_out);
@@ -399,11 +190,11 @@ private:
 void PostingListWriter::finish(
     WriteBuffer & wb, WriteBuffer & large_posting, uint8_t * packed_buffer, const MergeTreeIndexTextParams & index_params) const
 {
-    VarInt::writeVarUInt32(doc_count, wb);
+    VarInt::writeUInt32(doc_count, wb);
     if (doc_count == 0)
         return;
 
-    VarInt::writeVarUInt32(first_doc_id, wb);
+    VarInt::writeUInt32(first_doc_id, wb);
 
     /// Single doc: nothing more to write
     if (doc_count == 1)
@@ -415,7 +206,7 @@ void PostingListWriter::finish(
     {
         uint8_t * packed_buffer_end = turbopfor::p4Enc32(doc_delta_buffer, doc_count - 1, packed_buffer);
         UInt32 len = static_cast<UInt32>(packed_buffer_end - packed_buffer);
-        VarInt::writeVarUInt32(len, wb);
+        VarInt::writeUInt32(len, wb);
         wb.write(reinterpret_cast<const char *>(packed_buffer), len);
         return;
     }
@@ -448,7 +239,7 @@ void PostingListWriter::finish(
     const UInt32 num_large_blocks = (large_doc_count + docs_per_large_block - 1) / docs_per_large_block;
 
     chassert(num_large_blocks >= 1);
-    VarInt::writeVarUInt32(num_large_blocks, wb);
+    VarInt::writeUInt32(num_large_blocks, wb);
 
     LargePostingBlockWriter block_writer(wb, large_posting, docs_per_large_block,
         postingListFormatHasBlockIndex(resolvePostingListFormatVersion(index_params.posting_list_version)));
@@ -699,7 +490,7 @@ private:
 
         auto & data_buf = *stream->getDataBuffer();
         UInt32 bytes;
-        VarInt::readVarUInt32(bytes, data_buf);
+        VarInt::readUInt32(bytes, data_buf);
         UInt32 count = std::min(remaining_count, static_cast<UInt32>(TURBOPFOR_BLOCK_SIZE));
         uint8_t * src_ptr;
         if (data_buf.available() >= bytes)
@@ -853,13 +644,13 @@ LazyPostingStream::~LazyPostingStream() = default;
 
 void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStreamPtr & stream, const MergeTreeIndexTextParams & index_params, size_t format_version)
 {
-    VarInt::readVarUInt32(doc_count, in);
+    VarInt::readUInt32(doc_count, in);
     if (doc_count == 0)
         return;
 
     /// Last document id, used as base for delta decoding
     UInt32 last_doc_id;
-    VarInt::readVarUInt32(last_doc_id, in);
+    VarInt::readUInt32(last_doc_id, in);
 
     chassert(stream);
 
@@ -869,7 +660,7 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
         if (doc_count > 1)
         {
             UInt32 bytes;
-            VarInt::readVarUInt32(bytes, in);
+            VarInt::readUInt32(bytes, in);
             if (in.available() >= bytes)
             {
                 uint8_t * packed_buffer_end
@@ -893,7 +684,7 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
     }
 
     UInt32 num_large_blocks;
-    VarInt::readVarUInt32(num_large_blocks, in);
+    VarInt::readUInt32(num_large_blocks, in);
 
     chassert(num_large_blocks >= 1);
 
@@ -908,7 +699,7 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
         UInt32 docs_in_large_block = std::min(remaining_docs, docs_per_large_block);
         UInt32 id;
         UInt64 offset;
-        VarInt::readVarUInt32(id, in);
+        VarInt::readUInt32(id, in);
         readVarUInt(offset, in);
 
         UInt64 index_offset = 0;
@@ -926,7 +717,7 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
 
 void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & stream, const MergeTreeIndexTextParams & index_params) const
 {
-    VarInt::writeVarUInt32(doc_count, wb);
+    VarInt::writeUInt32(doc_count, wb);
     if (doc_count == 0)
         return;
 
@@ -935,7 +726,7 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     /// --------------------------------------------
     if (doc_count == 1)
     {
-        VarInt::writeVarUInt32(embedded_postings[0], wb);
+        VarInt::writeUInt32(embedded_postings[0], wb);
         return;
     }
 
@@ -944,12 +735,12 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
 
     if (doc_count <= MAX_SIZE_OF_EMBEDDED_POSTINGS)
     {
-        VarInt::writeVarUInt32(embedded_postings[0], wb);
+        VarInt::writeUInt32(embedded_postings[0], wb);
         for (UInt32 i = 1; i < doc_count; ++i)
             doc_delta_buffer[i - 1] = embedded_postings[i] - embedded_postings[i - 1] - 1;
         uint8_t * end = turbopfor::p4Enc32(doc_delta_buffer, doc_count - 1, packed_buffer);
         UInt32 len = static_cast<UInt32>(end - packed_buffer);
-        VarInt::writeVarUInt32(len, wb);
+        VarInt::writeUInt32(len, wb);
         wb.write(reinterpret_cast<const char *>(packed_buffer), len);
         return;
     }
@@ -1017,8 +808,8 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
         [&](UInt32 first_doc_id)
         {
             last_doc_id = first_doc_id;
-            VarInt::writeVarUInt32(first_doc_id, wb);
-            VarInt::writeVarUInt32(num_large_blocks, wb);
+            VarInt::writeUInt32(first_doc_id, wb);
+            VarInt::writeUInt32(num_large_blocks, wb);
         },
         [&](UInt32 doc_id)
         {

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -5,6 +5,7 @@
 #include <Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/MergedPartOffsets.h>
+#include <Storages/MergeTree/ProjectionIndex/PostingListState.h>
 #include <base/scope_guard.h>
 #include <Common/Arena.h>
 #include <Common/Exception.h>
@@ -453,7 +454,8 @@ void PostingListWriter::finish(
     chassert(num_large_blocks >= 1);
     VarInt::writeVarUInt32(num_large_blocks, wb);
 
-    LargePostingBlockWriter block_writer(wb, large_posting, docs_per_large_block, true /* write_block_index */);
+    LargePostingBlockWriter block_writer(wb, large_posting, docs_per_large_block,
+        postingListFormatHasBlockIndex(resolvePostingListFormatVersion(index_params.posting_list_version)));
 
     /// Iterate packed 128-doc chunks
     PostingListChunk * it = blocks_head;
@@ -502,6 +504,9 @@ void ReaderStreamVector::merge(const ReaderStreamVector & other)
         }
         entries.emplace_back(oe);
     }
+    /// Propagate format_version from the other side if this side has no entries yet.
+    if (format_version == 0 && other.format_version != 0)
+        format_version = other.format_version;
 }
 
 struct ReaderStreamCursor
@@ -735,6 +740,33 @@ void mergePostingCursors(std::vector<ReaderStreamCursor> & cursors, EmitFirst &&
     }
 }
 
+/// For v2 format, the dictionary offset points to the Index Section (not the Data Section).
+/// This function reads the Index Section to find the Data Section start offset.
+/// For v1 format, the offset already points to the Data Section.
+UInt64 resolveDataSectionOffset(
+    LargePostingListReaderStream & stream, UInt64 offset, size_t format_version)
+{
+    if (!postingListFormatHasBlockIndex(format_version))
+        return offset;
+
+    stream.seek(offset);
+    auto & data_buf = *stream.getDataBuffer();
+
+    /// Read Index Section header: [num_packed_blocks]
+    UInt32 num_packed_blocks;
+    VarInt::readVarUInt32(num_packed_blocks, data_buf);
+    /// Skip N × last_doc_ids
+    for (UInt32 j = 0; j < num_packed_blocks; ++j)
+    {
+        UInt32 dummy;
+        VarInt::readVarUInt32(dummy, data_buf);
+    }
+    /// Read the first packed_block_offset — this is the Data Section start
+    UInt64 data_section_start;
+    readVarUInt(data_section_start, data_buf);
+    return data_section_start;
+}
+
 PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
     LargePostingListReaderStream & stream, UInt32 last_doc_id, UInt32 block_doc_count, UInt64 offset, bool include_first_doc)
 {
@@ -799,7 +831,7 @@ LazyPostingStream::LazyPostingStream(const UInt32 * embedded_postings, UInt32 nu
 
 LazyPostingStream::~LazyPostingStream() = default;
 
-void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStreamPtr & stream, const MergeTreeIndexTextParams & index_params)
+void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStreamPtr & stream, const MergeTreeIndexTextParams & index_params, size_t format_version)
 {
     VarInt::readVarUInt32(doc_count, in);
     if (doc_count == 0)
@@ -865,6 +897,7 @@ void PostingListStream::read(ReadBuffer & in, const LargePostingListReaderStream
 
     lazy_posting_stream = std::make_unique<LazyPostingStream>(
         nullptr, 0, ReaderStreamVector{stream, last_doc_id, doc_count, std::move(large_posting_blocks)});
+    lazy_posting_stream->streams.format_version = format_version;
 }
 
 void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & stream, const MergeTreeIndexTextParams & index_params) const
@@ -909,7 +942,10 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
-        lazy_stream.stream->seek(lazy_stream.large_posting_blocks.front().offset);
+        UInt64 data_offset = resolveDataSectionOffset(
+            *lazy_stream.stream, lazy_stream.large_posting_blocks.front().offset,
+            lazy_posting_stream->streams.format_version);
+        lazy_stream.stream->seek(data_offset);
 
         cursors.emplace_back(
             lazy_stream.stream.get(),
@@ -926,7 +962,8 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + 127) & ~127;
     const UInt32 large_doc_count = doc_count - 1;
     const UInt32 num_large_blocks = (large_doc_count + docs_per_large_block - 1) / docs_per_large_block;
-    LargePostingBlockWriter block_writer(wb, stream.plain_hashing, docs_per_large_block, true /* write_block_index */);
+    LargePostingBlockWriter block_writer(wb, stream.plain_hashing, docs_per_large_block,
+        postingListFormatHasBlockIndex(resolvePostingListFormatVersion(index_params.posting_list_version)));
 
     UInt32 buffered = 0;
     auto flush128 = [&]()
@@ -993,7 +1030,10 @@ void PostingListStream::collect(UInt32 * buf) const
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
-        lazy_stream.stream->seek(lazy_stream.large_posting_blocks.front().offset);
+        UInt64 data_offset = resolveDataSectionOffset(
+            *lazy_stream.stream, lazy_stream.large_posting_blocks.front().offset,
+            lazy_posting_stream->streams.format_version);
+        lazy_stream.stream->seek(data_offset);
 
         cursors.emplace_back(
             lazy_stream.stream.get(),

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/ProjectionIndex/PostingListData.h>
 
 #include <IO/WriteBuffer.h>
+#include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
@@ -219,6 +220,19 @@ inline void writeVarUInt32(UInt32 x, WriteBuffer & ostr)
         writeVarUInt32Impl<true>(x, ostr);
 }
 
+inline size_t getLengthOfVarUInt32(UInt32 x)
+{
+    if (x <= ONE_BYTE_MAX)
+        return 1;
+    if (x <= TWO_BYTE_MAX)
+        return 2;
+    if (x <= THREE_BYTE_MAX)
+        return 3;
+    if (x <= FOUR_BYTE_MAX)
+        return 4;
+    return 5;
+}
+
 }
 
 void PostingListChunk::write(WriteBuffer & wb) const
@@ -290,14 +304,17 @@ public:
         : meta_out(meta_out_)
         , data_out(data_out_)
         , docs_per_large_block(docs_per_large_block_)
-        , current_block_offset(data_out.count())
     {
     }
 
     void addBlock(UInt32 last_doc_id, const char * data, UInt32 bytes)
     {
-        VarInt::writeVarUInt32(bytes, data_out);
-        data_out.write(data, bytes);
+        /// Phase 1: buffer sub-block data and record metadata.
+        UInt32 varint_len = static_cast<UInt32>(VarInt::getLengthOfVarUInt32(bytes));
+        VarInt::writeVarUInt32(bytes, temp_data_buf);
+        temp_data_buf.write(data, bytes);
+
+        sub_block_metas.push_back({last_doc_id, varint_len + bytes});
 
         /// Always count a packed block as 128 docs.
         /// The tail block is the final one and will be flushed immediately,
@@ -320,13 +337,80 @@ public:
 private:
     void flushLargeBlock()
     {
-        VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
-        writeVarUInt(current_block_offset, meta_out);
+        /// Phase 2: write Index Section then Data Section.
+        UInt64 index_section_offset = data_out.count();
+        UInt32 num_sub_blocks = static_cast<UInt32>(sub_block_metas.size());
 
-        current_block_offset = data_out.count();
+        /// Compute the fixed part of the Index Section size:
+        /// `[PrefixVarInt: num_sub_blocks]` + N × `[PrefixVarInt: last_doc_id]`
+        size_t fixed_index_size = VarInt::getLengthOfVarUInt32(num_sub_blocks);
+        for (const auto & meta : sub_block_metas)
+            fixed_index_size += VarInt::getLengthOfVarUInt32(meta.last_doc_id);
+
+        /// Compute absolute offsets. Since `absolute_offset[j]` depends on `index_section_size`
+        /// which depends on encoding size of `absolute_offset[j]`, iterate until stable.
+        /// Converges in at most 2 passes because sizes only grow.
+        std::vector<UInt64> abs_offsets(num_sub_blocks);
+        size_t offsets_encoding_size = 0;
+
+        /// Pass 1: estimate with zero-valued offsets (minimum VarUInt64 encoding = 1 byte each)
+        offsets_encoding_size = num_sub_blocks; /// 1 byte per offset minimum
+        UInt64 data_section_start = index_section_offset + fixed_index_size + offsets_encoding_size;
+        UInt64 running = 0;
+        for (UInt32 j = 0; j < num_sub_blocks; ++j)
+        {
+            abs_offsets[j] = data_section_start + running;
+            running += sub_block_metas[j].data_bytes;
+        }
+
+        /// Recompute actual encoding size of offsets
+        size_t new_offsets_encoding_size = 0;
+        for (UInt32 j = 0; j < num_sub_blocks; ++j)
+            new_offsets_encoding_size += getLengthOfVarUInt(abs_offsets[j]);
+
+        /// Pass 2: if encoding size changed, recompute with correct size
+        if (new_offsets_encoding_size != offsets_encoding_size)
+        {
+            offsets_encoding_size = new_offsets_encoding_size;
+            data_section_start = index_section_offset + fixed_index_size + offsets_encoding_size;
+            running = 0;
+            for (UInt32 j = 0; j < num_sub_blocks; ++j)
+            {
+                abs_offsets[j] = data_section_start + running;
+                running += sub_block_metas[j].data_bytes;
+            }
+        }
+
+        /// Write Index Section to `data_out`:
+        /// [PrefixVarInt: num_sub_blocks]
+        VarInt::writeVarUInt32(num_sub_blocks, data_out);
+        /// N × [PrefixVarInt: last_doc_id]
+        for (const auto & meta : sub_block_metas)
+            VarInt::writeVarUInt32(meta.last_doc_id, data_out);
+        /// N × [VarUInt64: absolute_offset]
+        for (UInt32 j = 0; j < num_sub_blocks; ++j)
+            writeVarUInt(abs_offsets[j], data_out);
+
+        /// Write Data Section from temp buffer to `data_out`.
+        auto data_view = temp_data_buf.stringView();
+        data_out.write(data_view.data(), data_view.size());
+
+        /// Write `(last_doc_id, index_section_offset)` to dictionary stream.
+        VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
+        writeVarUInt(index_section_offset, meta_out);
+
+        /// Reset for next large block.
+        sub_block_metas.clear();
+        temp_data_buf.restart();
         docs_in_current_block = 0;
         ++num_large_blocks_written;
     }
+
+    struct SubBlockMeta
+    {
+        UInt32 last_doc_id;
+        UInt32 data_bytes; /// varint_size(packed_bytes_len) + packed_bytes_len
+    };
 
     WriteBuffer & meta_out;
     WriteBuffer & data_out;
@@ -334,9 +418,10 @@ private:
     UInt32 docs_per_large_block;
     UInt32 docs_in_current_block = 0;
     UInt32 current_block_last_doc_id = 0;
-
-    UInt64 current_block_offset;
     UInt32 num_large_blocks_written = 0;
+
+    std::vector<SubBlockMeta> sub_block_metas;
+    WriteBufferFromOwnString temp_data_buf;
 };
 
 void PostingListWriter::finish(
@@ -675,6 +760,24 @@ void mergePostingCursors(std::vector<ReaderStreamCursor> & cursors, EmitFirst &&
     }
 }
 
+/// Reads and discards the Index Section from a data buffer.
+/// After this call, the buffer is positioned at the start of the Data Section.
+static void skipIndexSection(ReadBuffer & buf)
+{
+    UInt32 num_sub_blocks;
+    VarInt::readVarUInt32(num_sub_blocks, buf);
+    for (UInt32 j = 0; j < num_sub_blocks; ++j)
+    {
+        UInt32 dummy;
+        VarInt::readVarUInt32(dummy, buf);
+    }
+    for (UInt32 j = 0; j < num_sub_blocks; ++j)
+    {
+        UInt64 dummy;
+        readVarUInt(dummy, buf);
+    }
+}
+
 PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
     LargePostingListReaderStream & stream, UInt32 last_doc_id, UInt32 block_doc_count, UInt64 offset, bool include_first_doc)
 {
@@ -685,7 +788,19 @@ PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
         block_doc_count,
         offset,
         include_first_doc);
-    ReaderStreamCursor cursor(&stream, last_doc_id, block_doc_count, offset, true /* do_seek */, include_first_doc);
+
+    /// Seek to the Index Section start, then skip past it to reach the Data Section.
+    stream.seek(offset);
+    auto & data_buf = *stream.getDataBuffer();
+    skipIndexSection(data_buf);
+
+    ReaderStreamCursor cursor(
+        &stream,
+        last_doc_id,
+        block_doc_count,
+        static_cast<UInt64>(stream.getPosition()),
+        false /* do_seek: already positioned at Data Section */,
+        include_first_doc);
     return cursor.materializeIntoBitmap();
 }
 
@@ -840,11 +955,17 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
+        /// Seek to the first large block and skip its Index Section to position
+        /// at the Data Section start.
+        lazy_stream.stream->seek(lazy_stream.large_posting_blocks.front().offset);
+        auto & data_buf = *lazy_stream.stream->getDataBuffer();
+        skipIndexSection(data_buf);
+
         cursors.emplace_back(
             lazy_stream.stream.get(),
             lazy_stream.first_doc_id,
             lazy_stream.doc_count - 1, /* remaining doc counts */
-            lazy_stream.large_posting_blocks.front().offset,
+            static_cast<UInt64>(lazy_stream.stream->getPosition()),
             false,
             true);
     }
@@ -922,12 +1043,18 @@ void PostingListStream::collect(UInt32 * buf) const
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
+        /// Seek to the first large block and skip its Index Section to position
+        /// at the Data Section start.
+        lazy_stream.stream->seek(lazy_stream.large_posting_blocks.front().offset);
+        auto & data_buf = *lazy_stream.stream->getDataBuffer();
+        skipIndexSection(data_buf);
+
         cursors.emplace_back(
             lazy_stream.stream.get(),
             lazy_stream.first_doc_id,
             lazy_stream.doc_count - 1, /* remaining doc counts */
-            lazy_stream.large_posting_blocks.front().offset,
-            true,
+            static_cast<UInt64>(lazy_stream.stream->getPosition()),
+            false,
             true);
     }
 

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -349,9 +349,15 @@ public:
 private:
     void flushLargeBlock()
     {
+        UInt64 offset_for_dictionary = large_block_start_offset;
+
         if (write_block_index)
         {
             /// Data Section is already written to data_out. Now append the Index Section.
+            /// Record the Index Section start offset — this is what goes into the dictionary stream
+            /// so that the V2 reader can seek directly to the Index Section.
+            offset_for_dictionary = data_out.count();
+
             UInt32 num_packed_blocks = static_cast<UInt32>(packed_block_last_doc_ids.size());
 
             /// Write Index Section:
@@ -369,11 +375,10 @@ private:
         }
 
         /// Write `(last_doc_id, offset)` to dictionary stream.
-        /// The offset always points to the Data Section start (= first sub-block).
-        /// v1 reader seeks here directly; v2 reader can locate the trailing
-        /// Index Section for sub-block random access.
+        /// V1 (write_block_index=false): offset points to Data Section start.
+        /// V2 (write_block_index=true): offset points to Index Section start.
         VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
-        writeVarUInt(large_block_start_offset, meta_out);
+        writeVarUInt(offset_for_dictionary, meta_out);
 
         /// Reset for next large block.
         docs_in_current_block = 0;

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.cpp
@@ -1,7 +1,6 @@
 #include <Storages/MergeTree/ProjectionIndex/PostingListData.h>
 
 #include <IO/WriteBuffer.h>
-#include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
@@ -300,21 +299,34 @@ void PostingListWriter::add(UInt32 doc_id, Arena * arena, uint8_t * packed_buffe
 class LargePostingBlockWriter
 {
 public:
-    LargePostingBlockWriter(WriteBuffer & meta_out_, WriteBuffer & data_out_, UInt32 docs_per_large_block_)
+    LargePostingBlockWriter(WriteBuffer & meta_out_, WriteBuffer & data_out_, UInt32 docs_per_large_block_, bool write_block_index_)
         : meta_out(meta_out_)
         , data_out(data_out_)
         , docs_per_large_block(docs_per_large_block_)
+        , write_block_index(write_block_index_)
     {
+        if (write_block_index)
+        {
+            UInt32 packed_blocks_per_large_block = docs_per_large_block / 128;
+            packed_block_last_doc_ids.reserve(packed_blocks_per_large_block);
+            packed_block_offsets.reserve(packed_blocks_per_large_block);
+        }
     }
 
     void addBlock(UInt32 last_doc_id, const char * data, UInt32 bytes)
     {
-        /// Phase 1: buffer sub-block data and record metadata.
-        UInt32 varint_len = static_cast<UInt32>(VarInt::getLengthOfVarUInt32(bytes));
-        VarInt::writeVarUInt32(bytes, temp_data_buf);
-        temp_data_buf.write(data, bytes);
+        if (docs_in_current_block == 0)
+            large_block_start_offset = data_out.count();
 
-        sub_block_metas.push_back({last_doc_id, varint_len + bytes});
+        if (write_block_index)
+        {
+            /// Record the absolute offset of this sub-block before writing.
+            packed_block_last_doc_ids.push_back(last_doc_id);
+            packed_block_offsets.push_back(data_out.count());
+        }
+
+        VarInt::writeVarUInt32(bytes, data_out);
+        data_out.write(data, bytes);
 
         /// Always count a packed block as 128 docs.
         /// The tail block is the final one and will be flushed immediately,
@@ -337,91 +349,49 @@ public:
 private:
     void flushLargeBlock()
     {
-        /// Phase 2: write Index Section then Data Section.
-        UInt64 index_section_offset = data_out.count();
-        UInt32 num_sub_blocks = static_cast<UInt32>(sub_block_metas.size());
-
-        /// Compute the fixed part of the Index Section size:
-        /// `[PrefixVarInt: num_sub_blocks]` + N × `[PrefixVarInt: last_doc_id]`
-        size_t fixed_index_size = VarInt::getLengthOfVarUInt32(num_sub_blocks);
-        for (const auto & meta : sub_block_metas)
-            fixed_index_size += VarInt::getLengthOfVarUInt32(meta.last_doc_id);
-
-        /// Compute absolute offsets. Since `absolute_offset[j]` depends on `index_section_size`
-        /// which depends on encoding size of `absolute_offset[j]`, iterate until stable.
-        /// Converges in at most 2 passes because sizes only grow.
-        std::vector<UInt64> abs_offsets(num_sub_blocks);
-        size_t offsets_encoding_size = 0;
-
-        /// Pass 1: estimate with zero-valued offsets (minimum VarUInt64 encoding = 1 byte each)
-        offsets_encoding_size = num_sub_blocks; /// 1 byte per offset minimum
-        UInt64 data_section_start = index_section_offset + fixed_index_size + offsets_encoding_size;
-        UInt64 running = 0;
-        for (UInt32 j = 0; j < num_sub_blocks; ++j)
+        if (write_block_index)
         {
-            abs_offsets[j] = data_section_start + running;
-            running += sub_block_metas[j].data_bytes;
+            /// Data Section is already written to data_out. Now append the Index Section.
+            UInt32 num_packed_blocks = static_cast<UInt32>(packed_block_last_doc_ids.size());
+
+            /// Write Index Section:
+            /// [PrefixVarInt: num_packed_blocks]
+            VarInt::writeVarUInt32(num_packed_blocks, data_out);
+            /// N × [PrefixVarInt: last_doc_id]
+            for (const auto & id : packed_block_last_doc_ids)
+                VarInt::writeVarUInt32(id, data_out);
+            /// N × [VarUInt64: absolute_offset]
+            for (const auto & off : packed_block_offsets)
+                writeVarUInt(off, data_out);
+
+            packed_block_last_doc_ids.clear();
+            packed_block_offsets.clear();
         }
 
-        /// Recompute actual encoding size of offsets
-        size_t new_offsets_encoding_size = 0;
-        for (UInt32 j = 0; j < num_sub_blocks; ++j)
-            new_offsets_encoding_size += getLengthOfVarUInt(abs_offsets[j]);
-
-        /// Pass 2: if encoding size changed, recompute with correct size
-        if (new_offsets_encoding_size != offsets_encoding_size)
-        {
-            offsets_encoding_size = new_offsets_encoding_size;
-            data_section_start = index_section_offset + fixed_index_size + offsets_encoding_size;
-            running = 0;
-            for (UInt32 j = 0; j < num_sub_blocks; ++j)
-            {
-                abs_offsets[j] = data_section_start + running;
-                running += sub_block_metas[j].data_bytes;
-            }
-        }
-
-        /// Write Index Section to `data_out`:
-        /// [PrefixVarInt: num_sub_blocks]
-        VarInt::writeVarUInt32(num_sub_blocks, data_out);
-        /// N × [PrefixVarInt: last_doc_id]
-        for (const auto & meta : sub_block_metas)
-            VarInt::writeVarUInt32(meta.last_doc_id, data_out);
-        /// N × [VarUInt64: absolute_offset]
-        for (UInt32 j = 0; j < num_sub_blocks; ++j)
-            writeVarUInt(abs_offsets[j], data_out);
-
-        /// Write Data Section from temp buffer to `data_out`.
-        auto data_view = temp_data_buf.stringView();
-        data_out.write(data_view.data(), data_view.size());
-
-        /// Write `(last_doc_id, index_section_offset)` to dictionary stream.
+        /// Write `(last_doc_id, offset)` to dictionary stream.
+        /// The offset always points to the Data Section start (= first sub-block).
+        /// v1 reader seeks here directly; v2 reader can locate the trailing
+        /// Index Section for sub-block random access.
         VarInt::writeVarUInt32(current_block_last_doc_id, meta_out);
-        writeVarUInt(index_section_offset, meta_out);
+        writeVarUInt(large_block_start_offset, meta_out);
 
         /// Reset for next large block.
-        sub_block_metas.clear();
-        temp_data_buf.restart();
         docs_in_current_block = 0;
         ++num_large_blocks_written;
     }
-
-    struct SubBlockMeta
-    {
-        UInt32 last_doc_id;
-        UInt32 data_bytes; /// varint_size(packed_bytes_len) + packed_bytes_len
-    };
 
     WriteBuffer & meta_out;
     WriteBuffer & data_out;
 
     UInt32 docs_per_large_block;
+    bool write_block_index;
     UInt32 docs_in_current_block = 0;
     UInt32 current_block_last_doc_id = 0;
     UInt32 num_large_blocks_written = 0;
+    UInt64 large_block_start_offset = 0;
 
-    std::vector<SubBlockMeta> sub_block_metas;
-    WriteBufferFromOwnString temp_data_buf;
+    std::vector<UInt32> packed_block_last_doc_ids;
+    std::vector<UInt64> packed_block_offsets;
 };
 
 void PostingListWriter::finish(
@@ -478,7 +448,7 @@ void PostingListWriter::finish(
     chassert(num_large_blocks >= 1);
     VarInt::writeVarUInt32(num_large_blocks, wb);
 
-    LargePostingBlockWriter block_writer(wb, large_posting, docs_per_large_block);
+    LargePostingBlockWriter block_writer(wb, large_posting, docs_per_large_block, true /* write_block_index */);
 
     /// Iterate packed 128-doc chunks
     PostingListChunk * it = blocks_head;
@@ -760,24 +730,6 @@ void mergePostingCursors(std::vector<ReaderStreamCursor> & cursors, EmitFirst &&
     }
 }
 
-/// Reads and discards the Index Section from a data buffer.
-/// After this call, the buffer is positioned at the start of the Data Section.
-static void skipIndexSection(ReadBuffer & buf)
-{
-    UInt32 num_sub_blocks;
-    VarInt::readVarUInt32(num_sub_blocks, buf);
-    for (UInt32 j = 0; j < num_sub_blocks; ++j)
-    {
-        UInt32 dummy;
-        VarInt::readVarUInt32(dummy, buf);
-    }
-    for (UInt32 j = 0; j < num_sub_blocks; ++j)
-    {
-        UInt64 dummy;
-        readVarUInt(dummy, buf);
-    }
-}
-
 PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
     LargePostingListReaderStream & stream, UInt32 last_doc_id, UInt32 block_doc_count, UInt64 offset, bool include_first_doc)
 {
@@ -789,16 +741,13 @@ PostingListPtr ReaderStreamEntry::materializeLargeBlockIntoBitmap(
         offset,
         include_first_doc);
 
-    /// Seek to the Index Section start, then skip past it to reach the Data Section.
     stream.seek(offset);
-    auto & data_buf = *stream.getDataBuffer();
-    skipIndexSection(data_buf);
 
     ReaderStreamCursor cursor(
         &stream,
         last_doc_id,
         block_doc_count,
-        static_cast<UInt64>(stream.getPosition()),
+        offset,
         false /* do_seek: already positioned at Data Section */,
         include_first_doc);
     return cursor.materializeIntoBitmap();
@@ -955,11 +904,7 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
-        /// Seek to the first large block and skip its Index Section to position
-        /// at the Data Section start.
         lazy_stream.stream->seek(lazy_stream.large_posting_blocks.front().offset);
-        auto & data_buf = *lazy_stream.stream->getDataBuffer();
-        skipIndexSection(data_buf);
 
         cursors.emplace_back(
             lazy_stream.stream.get(),
@@ -976,7 +921,7 @@ void PostingListStream::write(WriteBuffer & wb, LargePostingListWriterStream & s
     const UInt32 docs_per_large_block = (static_cast<UInt32>(index_params.posting_list_block_size) + 127) & ~127;
     const UInt32 large_doc_count = doc_count - 1;
     const UInt32 num_large_blocks = (large_doc_count + docs_per_large_block - 1) / docs_per_large_block;
-    LargePostingBlockWriter block_writer(wb, stream.plain_hashing, docs_per_large_block);
+    LargePostingBlockWriter block_writer(wb, stream.plain_hashing, docs_per_large_block, true /* write_block_index */);
 
     UInt32 buffered = 0;
     auto flush128 = [&]()
@@ -1043,11 +988,7 @@ void PostingListStream::collect(UInt32 * buf) const
     for (const auto & lazy_stream : lazy_posting_stream->streams)
     {
         chassert(!lazy_stream.large_posting_blocks.empty());
-        /// Seek to the first large block and skip its Index Section to position
-        /// at the Data Section start.
         lazy_stream.stream->seek(lazy_stream.large_posting_blocks.front().offset);
-        auto & data_buf = *lazy_stream.stream->getDataBuffer();
-        skipIndexSection(data_buf);
 
         cursors.emplace_back(
             lazy_stream.stream.get(),

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.h
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.h
@@ -140,9 +140,16 @@ struct ReaderStreamEntry
     String toString() const;
 };
 
+/// For v2 format, the dictionary offset points to the Index Section (not the Data Section).
+/// This function reads the Index Section to find the Data Section start offset.
+/// For v1 format, the offset already points to the Data Section.
+UInt64 resolveDataSectionOffset(
+    LargePostingListReaderStream & stream, UInt64 offset, size_t format_version);
+
 struct ReaderStreamVector
 {
     std::vector<ReaderStreamEntry> entries;
+    size_t format_version = 0;
 
     ReaderStreamVector() = default;
 
@@ -226,7 +233,7 @@ struct alignas(8) PostingListStream
         return *this;
     }
 
-    void read(ReadBuffer & in, const LargePostingListReaderStreamPtr & stream, const MergeTreeIndexTextParams & index_params);
+    void read(ReadBuffer & in, const LargePostingListReaderStreamPtr & stream, const MergeTreeIndexTextParams & index_params, size_t format_version);
 
     void write(WriteBuffer & wb, LargePostingListWriterStream & stream, const MergeTreeIndexTextParams & index_params) const;
 

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.h
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.h
@@ -197,6 +197,10 @@ using LazyPostingStreamPtr = std::unique_ptr<LazyPostingStream>;
 
 inline static constexpr UInt64 MAX_SIZE_OF_EMBEDDED_POSTINGS = 6;
 
+/// TurboPFor encodes/decodes deltas in fixed 128-element blocks.
+/// This constant is dictated by the TurboPFor library and must NOT be changed.
+inline static constexpr size_t TURBOPFOR_BLOCK_SIZE = 128;
+
 struct alignas(8) PostingListStream
 {
     PostingListKind type = PostingListKind::Stream;

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListData.h
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListData.h
@@ -86,13 +86,15 @@ struct LargePostingBlockMeta
 {
     UInt32 last_doc_id;
     UInt32 block_doc_count;
-    UInt64 offset;
+    UInt64 offset;           /// Data Section start offset (shared by v1 and v2)
+    UInt64 index_offset;     /// Index Section start offset (v2 only; 0 for v1)
 
     /// Default constructor (required by std::vector, resize, etc.)
     LargePostingBlockMeta() noexcept
         : last_doc_id(0)
         , block_doc_count(0)
         , offset(0)
+        , index_offset(0)
     {
     }
 
@@ -101,14 +103,25 @@ struct LargePostingBlockMeta
         : last_doc_id(0)
         , block_doc_count(0)
         , offset(offset_)
+        , index_offset(0)
     {
     }
 
-    /// Fully initialized constructor
+    /// Fully initialized constructor (v1 compatible)
     LargePostingBlockMeta(UInt32 last_doc_id_, UInt32 doc_count_, UInt64 offset_) noexcept
         : last_doc_id(last_doc_id_)
         , block_doc_count(doc_count_)
         , offset(offset_)
+        , index_offset(0)
+    {
+    }
+
+    /// Fully initialized constructor (v2 with index_offset)
+    LargePostingBlockMeta(UInt32 last_doc_id_, UInt32 doc_count_, UInt64 offset_, UInt64 index_offset_) noexcept
+        : last_doc_id(last_doc_id_)
+        , block_doc_count(doc_count_)
+        , offset(offset_)
+        , index_offset(index_offset_)
     {
     }
 
@@ -139,12 +152,6 @@ struct ReaderStreamEntry
 
     String toString() const;
 };
-
-/// For v2 format, the dictionary offset points to the Index Section (not the Data Section).
-/// This function reads the Index Section to find the Data Section start offset.
-/// For v1 format, the offset already points to the Data Section.
-UInt64 resolveDataSectionOffset(
-    LargePostingListReaderStream & stream, UInt64 offset, size_t format_version);
 
 struct ReaderStreamVector
 {

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListState.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListState.cpp
@@ -213,7 +213,7 @@ public:
                 {
                     auto & posting_list_data = reinterpret_cast<PostingListData &>(*place);
                     chassert(posting_list_data.isStream());
-                    posting_list_data.stream.read(*stream, large_posting_stream, function->index_params);
+                    posting_list_data.stream.read(*stream, large_posting_stream, function->index_params, function->version);
                 }
                 catch (...)
                 {
@@ -266,6 +266,21 @@ DataTypePtr createPostingListType(const ASTPtr & text_index_definition, size_t f
     }
 
     return buildPostingListType(params, index_params, format_version);
+}
+
+DataTypePtr createPostingListType(const ASTPtr & text_index_definition)
+{
+    Array params;
+    MergeTreeIndexTextParams index_params;
+
+    if (text_index_definition && !text_index_definition->children.empty())
+    {
+        auto index_arguments = MergeTreeIndexText::parseArgumentsListFromAST(text_index_definition);
+        params.assign_range(index_arguments);
+        index_params = std::get<0>(MergeTreeIndexText::parseTextIndexArguments("PostingList", index_arguments));
+    }
+
+    return buildPostingListType(params, index_params, resolvePostingListFormatVersion(index_params.posting_list_version));
 }
 
 DataTypePtr createPostingListTypeFromPartMetadata(const ASTPtr & parsed_fields)

--- a/src/Storages/MergeTree/ProjectionIndex/PostingListState.h
+++ b/src/Storages/MergeTree/ProjectionIndex/PostingListState.h
@@ -70,10 +70,27 @@ struct DataTypePostingList : public IDataTypeCustomName
 };
 
 static constexpr auto POSTING_LIST_FORMAT_VERSION_INITIAL = 0;
+static constexpr auto POSTING_LIST_FORMAT_VERSION_V2 = 1;
+
+inline bool postingListFormatHasBlockIndex(size_t format_version)
+{
+    return format_version >= POSTING_LIST_FORMAT_VERSION_V2;
+}
+
+/// Maps DDL `posting_list_version` (1 or 2) to the on-disk format version constant.
+inline size_t resolvePostingListFormatVersion(size_t ddl_version)
+{
+    if (ddl_version == 1)
+        return POSTING_LIST_FORMAT_VERSION_INITIAL;
+    return POSTING_LIST_FORMAT_VERSION_V2;
+}
 
 /// Construct PostingList DataType from index definition using the specified posting list format version. This is used
 /// in metadata construction paths (projection definition, merge, and output parts) to control the on-disk format.
 DataTypePtr createPostingListType(const ASTPtr & text_index_definition, size_t format_version);
+
+/// Like above, but resolves the format version from the `posting_list_version` DDL parameter in the definition.
+DataTypePtr createPostingListType(const ASTPtr & text_index_definition);
 
 /// Reconstruct PostingList DataType from on-disk part metadata. The format version is inferred from stored fields and
 /// all historical posting list format versions are supported.

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexText.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexText.cpp
@@ -144,7 +144,7 @@ Block tokenize(
     const ColumnUInt8::Container * null_map,
     const IColumn * index_column)
 {
-    alignas(16) uint8_t packed_buffer[128 * 4];
+    alignas(16) uint8_t packed_buffer[TURBOPFOR_BLOCK_SIZE * 4];
     ssize_t rows = array_offsets ? array_offsets->size() : (index_column ? index_column->size() : input_data_column.size());
     chassert(rows <= std::numeric_limits<UInt32>::max());
 

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexText.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexText.cpp
@@ -68,7 +68,7 @@ void ProjectionIndexText::fillProjectionDescription(
     result.type = ProjectionDescription::Type::Aggregate;
     result.sample_block_for_keys.insert({ColumnString::create(), std::make_shared<DataTypeString>(), "term"});
     auto posting_list_type
-        = createPostingListType(index_ast->as<ASTIndexDeclaration>()->getType()->arguments, POSTING_LIST_FORMAT_VERSION_INITIAL);
+        = createPostingListType(index_ast->as<ASTIndexDeclaration>()->getType()->arguments);
     result.sample_block
         = {result.sample_block_for_keys.getByPosition(0), {posting_list_type->createColumn(), posting_list_type, "posting"}};
 

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -1,0 +1,2236 @@
+#include <gtest/gtest.h>
+
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCursor.h>
+#include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <Storages/MergeTree/MergeTreeReaderStream.h>
+#include <Storages/MergeTree/MergeTreeIOSettings.h>
+#include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
+#include <Storages/MergeTree/ProjectionIndex/PostingListData.h>
+#include <Columns/ColumnsNumber.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/WriteBufferFromVector.h>
+#include <IO/WriteHelpers.h>
+#include <IO/VarInt.h>
+#include <Disks/DiskLocal.h>
+#include <Disks/SingleDiskVolume.h>
+
+#include <turbopfor.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+using namespace DB;
+namespace fs = std::filesystem;
+
+namespace
+{
+
+/// Helper: build a TokenPostingsInfo with an embedded Roaring bitmap from a sorted vector of doc IDs.
+TokenPostingsInfo makeEmbeddedInfo(const std::vector<uint32_t> & doc_ids)
+{
+    TokenPostingsInfo info;
+    info.cardinality = static_cast<UInt32>(doc_ids.size());
+
+    auto bitmap = std::make_shared<roaring::Roaring>();
+    for (auto id : doc_ids)
+        bitmap->add(id);
+    info.embedded_postings = bitmap;
+
+    if (!doc_ids.empty())
+    {
+        info.ranges.emplace_back(doc_ids.front(), doc_ids.back());
+        info.offsets.emplace_back(); // dummy, not used for embedded
+    }
+
+    return info;
+}
+
+/// Helper: create a PostingListCursor for an embedded posting list.
+PostingListCursorPtr makeEmbeddedCursor(const TokenPostingsInfo & info)
+{
+    return std::make_shared<PostingListCursor>(info);
+}
+
+/// Helper: generate a sequence of doc IDs: {start, start+step, start+2*step, ...}
+std::vector<uint32_t> generateRange(uint32_t start, uint32_t count, uint32_t step = 1)
+{
+    std::vector<uint32_t> result;
+    result.reserve(count);
+    for (uint32_t i = 0; i < count; ++i)
+        result.push_back(start + i * step);
+    return result;
+}
+
+/// Helper: collect all remaining doc IDs from a cursor using next().
+/// For non-embedded cursors, seek() must be called first to decode the first packed block.
+std::vector<uint32_t> drainCursor(PostingListCursorPtr cursor)
+{
+    std::vector<uint32_t> result;
+    while (cursor->valid())
+    {
+        result.push_back(cursor->value());
+        cursor->next();
+    }
+    return result;
+}
+
+/// Helper: seek to the first doc, then drain.
+/// Used for multi-block (non-embedded) cursors where construction only loads the
+/// Index Section but does not decode any packed block.
+std::vector<uint32_t> seekAndDrainCursor(PostingListCursorPtr cursor, uint32_t first_doc)
+{
+    cursor->seek(first_doc);
+    return drainCursor(cursor);
+}
+
+/// Helper: do linearOr into a buffer and return the set bits as doc IDs.
+std::vector<uint32_t> linearOrToDocIds(PostingListCursorPtr cursor, size_t row_offset, size_t num_rows)
+{
+    std::vector<UInt8> buf(num_rows, 0);
+    cursor->linearOr(buf.data(), row_offset, num_rows);
+    std::vector<uint32_t> result;
+    for (size_t i = 0; i < num_rows; ++i)
+        if (buf[i])
+            result.push_back(static_cast<uint32_t>(row_offset + i));
+    return result;
+}
+
+/// Helper: perform intersection using lazyIntersectPostingLists and return doc IDs.
+std::vector<uint32_t> intersectAndCollect(
+    PostingListCursorMap & postings,
+    const std::vector<String> & tokens,
+    size_t row_offset,
+    size_t num_rows,
+    bool brute_force,
+    float density_threshold = 0.5f)
+{
+    auto col = ColumnUInt8::create(num_rows, UInt8(0));
+    lazyIntersectPostingLists(*col, postings, tokens, 0, row_offset, num_rows, brute_force, density_threshold);
+    const auto & data = col->getData();
+    std::vector<uint32_t> result;
+    for (size_t i = 0; i < num_rows; ++i)
+        if (data[i])
+            result.push_back(static_cast<uint32_t>(row_offset + i));
+    return result;
+}
+
+/// Helper: perform union using lazyUnionPostingLists and return doc IDs.
+std::vector<uint32_t> unionAndCollect(
+    PostingListCursorMap & postings,
+    const std::vector<String> & tokens,
+    size_t row_offset,
+    size_t num_rows)
+{
+    auto col = ColumnUInt8::create(num_rows, UInt8(0));
+    lazyUnionPostingLists(*col, postings, tokens, 0, row_offset, num_rows, false, 0.5f);
+    const auto & data = col->getData();
+    std::vector<uint32_t> result;
+    for (size_t i = 0; i < num_rows; ++i)
+        if (data[i])
+            result.push_back(static_cast<uint32_t>(row_offset + i));
+    return result;
+}
+
+/// Helper: write a PrefixVarUInt32 to a byte vector (mirrors PostingListData.cpp VarInt namespace).
+void writePrefixVarUInt32(UInt32 x, std::vector<char> & out)
+{
+    static constexpr UInt32 ONE_BYTE_MAX = 176;
+    static constexpr UInt32 TWO_BYTE_MAX = 16560;
+    static constexpr UInt32 THREE_BYTE_MAX = 540848;
+    static constexpr UInt32 FOUR_BYTE_MAX = 16777215;
+
+    if (x <= ONE_BYTE_MAX)
+    {
+        out.push_back(static_cast<char>(x));
+        return;
+    }
+    if (x <= TWO_BYTE_MAX)
+    {
+        UInt32 adjusted = x - 177;
+        out.push_back(static_cast<char>(177 + (adjusted >> 8)));
+        out.push_back(static_cast<char>(adjusted & 0xFF));
+        return;
+    }
+    if (x <= THREE_BYTE_MAX)
+    {
+        UInt32 adjusted = x - 16561;
+        out.push_back(static_cast<char>(241 + (adjusted >> 16)));
+        out.push_back(static_cast<char>((adjusted >> 8) & 0xFF));
+        out.push_back(static_cast<char>(adjusted & 0xFF));
+        return;
+    }
+    if (x <= FOUR_BYTE_MAX)
+    {
+        out.push_back(static_cast<char>(249));
+        out.push_back(static_cast<char>((x >> 16) & 0xFF));
+        out.push_back(static_cast<char>((x >> 8) & 0xFF));
+        out.push_back(static_cast<char>(x & 0xFF));
+        return;
+    }
+    out.push_back(static_cast<char>(250));
+    out.push_back(static_cast<char>((x >> 24) & 0xFF));
+    out.push_back(static_cast<char>((x >> 16) & 0xFF));
+    out.push_back(static_cast<char>((x >> 8) & 0xFF));
+    out.push_back(static_cast<char>(x & 0xFF));
+}
+
+/// Helper: write a VarUInt64 (LEB128) to a byte vector.
+void writeVarUInt64(UInt64 x, std::vector<char> & out)
+{
+    while (x > 0x7F)
+    {
+        out.push_back(static_cast<char>(0x80 | (x & 0x7F)));
+        x >>= 7;
+    }
+    out.push_back(static_cast<char>(x));
+}
+
+/// Result of building multi-block test data.
+struct MultiBlockTestData
+{
+    std::vector<char> buffer;      /// The contiguous .lpst-like data buffer
+    TokenPostingsInfo info;        /// Populated TokenPostingsInfo
+    std::vector<uint32_t> all_docs; /// All doc IDs in order (for verification)
+};
+
+/// Build a multi-large-block TokenPostingsInfo and data buffer for testing.
+///
+/// @param blocks  Vector of sorted doc ID vectors, one per large block.
+///                blocks[0] must include the first_doc_id; the first doc of blocks[0]
+///                will be treated as first_doc_id (stored separately, not encoded in TurboPFor).
+///                Subsequent blocks encode ALL their docs in TurboPFor.
+///
+/// Returns a MultiBlockTestData with the binary buffer, TokenPostingsInfo, and flattened doc list.
+MultiBlockTestData makeMultiBlockData(const std::vector<std::vector<uint32_t>> & blocks)
+{
+    MultiBlockTestData result;
+    auto & buf = result.buffer;
+    auto & info = result.info;
+
+    if (blocks.empty())
+        return result;
+
+    uint32_t first_doc_id = blocks[0].front();
+
+    /// Flatten all doc IDs for verification
+    for (const auto & block_docs : blocks)
+        result.all_docs.insert(result.all_docs.end(), block_docs.begin(), block_docs.end());
+
+    UInt32 total_cardinality = static_cast<UInt32>(result.all_docs.size());
+    info.cardinality = total_cardinality;
+
+    alignas(16) uint8_t packed_buffer[512 * 2]; /// Enough for p4Enc output
+
+    for (size_t blk_idx = 0; blk_idx < blocks.size(); ++blk_idx)
+    {
+        const auto & block_docs = blocks[blk_idx];
+
+        /// For large block 0: first_doc_id is stored separately, so we encode
+        /// (block_docs.size() - 1) docs starting from block_docs[1].
+        /// For subsequent blocks: encode all docs.
+        std::vector<uint32_t> docs_to_encode;
+        uint32_t delta_base;
+
+        if (blk_idx == 0)
+        {
+            docs_to_encode.assign(block_docs.begin() + 1, block_docs.end());
+            delta_base = first_doc_id;
+        }
+        else
+        {
+            docs_to_encode.assign(block_docs.begin(), block_docs.end());
+            delta_base = block_docs.front() - 1;
+        }
+
+        UInt32 large_block_doc_count = static_cast<UInt32>(docs_to_encode.size());
+        UInt32 num_full_blocks = large_block_doc_count / 128;
+        UInt32 tail_count = large_block_doc_count % 128;
+        UInt32 num_packed_blocks = num_full_blocks + (tail_count > 0 ? 1 : 0);
+
+        /// Data Section: encode packed blocks
+        UInt64 data_section_offset = buf.size();
+        std::vector<UInt32> packed_block_last_doc_ids;
+        std::vector<UInt64> packed_block_offsets;
+
+        UInt32 prev_doc = delta_base;
+        size_t doc_pos = 0;
+
+        for (UInt32 pb = 0; pb < num_packed_blocks; ++pb)
+        {
+            UInt32 count = (pb == num_packed_blocks - 1 && tail_count > 0) ? tail_count : 128;
+
+            /// Compute delta-1 array
+            std::vector<UInt32> deltas(count);
+            for (UInt32 d = 0; d < count; ++d)
+            {
+                deltas[d] = docs_to_encode[doc_pos + d] - prev_doc - 1;
+                prev_doc = docs_to_encode[doc_pos + d];
+            }
+
+            /// TurboPFor encode
+            uint8_t * encoded_end;
+            if (count == 128)
+                encoded_end = turbopfor::p4Enc128v32(deltas.data(), 128, packed_buffer);
+            else
+                encoded_end = turbopfor::p4Enc32(deltas.data(), count, packed_buffer);
+
+            UInt32 compressed_bytes = static_cast<UInt32>(encoded_end - packed_buffer);
+
+            packed_block_last_doc_ids.push_back(docs_to_encode[doc_pos + count - 1]);
+            packed_block_offsets.push_back(static_cast<UInt64>(buf.size()));
+
+            /// Write: [PrefixVarInt: compressed_bytes][data]
+            writePrefixVarUInt32(compressed_bytes, buf);
+            buf.insert(buf.end(), reinterpret_cast<char *>(packed_buffer),
+                       reinterpret_cast<char *>(packed_buffer) + compressed_bytes);
+
+            doc_pos += count;
+        }
+
+        /// Index Section
+        UInt64 index_section_offset = buf.size();
+
+        /// [PrefixVarInt: num_packed_blocks]
+        writePrefixVarUInt32(num_packed_blocks, buf);
+
+        /// N × [PrefixVarInt: last_doc_id]
+        for (auto id : packed_block_last_doc_ids)
+            writePrefixVarUInt32(id, buf);
+
+        /// N × [VarUInt64: absolute_offset]
+        for (auto off : packed_block_offsets)
+            writeVarUInt64(off, buf);
+
+        /// Build LargePostingBlockMeta
+        LargePostingBlockMeta meta;
+        meta.last_doc_id = block_docs.back();
+        meta.block_doc_count = large_block_doc_count;
+        meta.offset = data_section_offset;
+        meta.index_offset = index_section_offset;
+        info.offsets.push_back(meta);
+
+        /// Build RowsRange
+        info.ranges.emplace_back(block_docs.front(), block_docs.back());
+    }
+
+    return result;
+}
+
+/// Helper: create a PostingListCursor for multi-block test data.
+/// Writes the binary buffer to a temporary .lpst file, constructs a real
+/// LargePostingListReaderStream via DiskLocal + DataPartStorageOnDiskFull,
+/// and uses the production PostingListCursor constructor — no modifications needed.
+PostingListCursorPtr makeMultiBlockCursor(const MultiBlockTestData & data)
+{
+    /// Create a unique temp directory for this test invocation
+    auto tmp_dir = fs::temp_directory_path() / ("gtest_plc_" + std::to_string(reinterpret_cast<uintptr_t>(&data)));
+    fs::create_directories(tmp_dir / "part");
+
+    /// Write the binary buffer to a .lpst file
+    {
+        auto out_path = tmp_dir / "part" / "stream.lpst";
+        std::ofstream ofs(out_path, std::ios::binary);
+        ofs.write(data.buffer.data(), static_cast<std::streamsize>(data.buffer.size()));
+        ofs.close();
+    }
+
+    /// Construct the stream infrastructure
+    auto disk = std::make_shared<DiskLocal>("test_disk", tmp_dir.string() + "/");
+    auto volume = std::make_shared<SingleDiskVolume>("test_vol", disk);
+    auto storage = std::make_shared<DataPartStorageOnDiskFull>(volume, "", "part");
+
+    auto settings = MergeTreeReaderSettings::createFromSettings();
+    settings.is_compressed = false;
+
+    static constexpr size_t marks_count = 1;
+    auto stream = std::make_shared<LargePostingListReaderStream>(
+        /*merged_part_offsets=*/nullptr,
+        /*part_index=*/0,
+        /*part_starting_offset=*/0,
+        storage,
+        "stream",
+        ".lpst",
+        marks_count,
+        MarkRanges{{0, marks_count}},
+        settings,
+        /*uncompressed_cache=*/nullptr,
+        data.buffer.size(),
+        /*marks_loader=*/nullptr,
+        ReadBufferFromFileBase::ProfileCallback{},
+        CLOCK_MONOTONIC_COARSE);
+
+    return std::make_shared<PostingListCursor>(std::move(stream), data.info);
+}
+
+} // anonymous namespace
+
+
+// ===========================================================================================
+// Section 1: Basic cursor operations (embedded path)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, EmptyEmbeddedCursor)
+{
+    auto info = makeEmbeddedInfo({});
+    auto cursor = makeEmbeddedCursor(info);
+    /// Empty embedded bitmap should still create a cursor, but it should be invalid
+    /// because there are no doc_ids to iterate.
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, SingleDocEmbedded)
+{
+    auto info = makeEmbeddedInfo({42});
+    auto cursor = makeEmbeddedCursor(info);
+
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 42u);
+    EXPECT_EQ(cursor->cardinality(), 1u);
+
+    cursor->next();
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, MultipleDocsSequentialIteration)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto drained = drainCursor(cursor);
+    EXPECT_EQ(drained, docs);
+}
+
+TEST(PostingListCursorTest, LargeEmbeddedCursor)
+{
+    auto docs = generateRange(0, 1000);
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto drained = drainCursor(cursor);
+    EXPECT_EQ(drained, docs);
+}
+
+TEST(PostingListCursorTest, SparseEmbeddedCursor)
+{
+    auto docs = generateRange(100, 50, 100); // 100,200,...,5000
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto drained = drainCursor(cursor);
+    EXPECT_EQ(drained, docs);
+}
+
+TEST(PostingListCursorTest, NextAfterInvalidIsNoop)
+{
+    auto info = makeEmbeddedInfo({5});
+    auto cursor = makeEmbeddedCursor(info);
+    cursor->next();
+    EXPECT_FALSE(cursor->valid());
+    cursor->next(); // Should not crash
+    EXPECT_FALSE(cursor->valid());
+    cursor->next(); // Multiple calls after invalid
+    EXPECT_FALSE(cursor->valid());
+}
+
+
+// ===========================================================================================
+// Section 2: Seek operations
+// ===========================================================================================
+
+TEST(PostingListCursorTest, SeekToExactValue)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(30);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 30u);
+}
+
+TEST(PostingListCursorTest, SeekToNonExistentGoesToNext)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(25);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 30u);
+}
+
+TEST(PostingListCursorTest, SeekBeyondLastInvalidates)
+{
+    std::vector<uint32_t> docs = {10, 20, 30};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(31);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, SeekToFirstDoc)
+{
+    std::vector<uint32_t> docs = {10, 20, 30};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(10);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 10u);
+}
+
+TEST(PostingListCursorTest, SeekToLastDoc)
+{
+    std::vector<uint32_t> docs = {10, 20, 30};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(30);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 30u);
+
+    cursor->next();
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, SeekToZero)
+{
+    std::vector<uint32_t> docs = {0, 5, 10};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(0);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 0u);
+}
+
+TEST(PostingListCursorTest, SeekBeforeFirst)
+{
+    std::vector<uint32_t> docs = {100, 200, 300};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(50);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 100u);
+}
+
+TEST(PostingListCursorTest, SeekProgressivelyForward)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(25);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 30u);
+
+    cursor->seek(55);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 60u);
+
+    cursor->seek(100);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 100u);
+
+    cursor->seek(101);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, SeekThenNext)
+{
+    std::vector<uint32_t> docs = {5, 10, 15, 20, 25, 30};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(15);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 15u);
+
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 20u);
+
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 25u);
+}
+
+
+// ===========================================================================================
+// Section 3: Density and cardinality
+// ===========================================================================================
+
+TEST(PostingListCursorTest, CardinalityReflectsDocCount)
+{
+    auto info = makeEmbeddedInfo({1, 2, 3, 4, 5});
+    auto cursor = makeEmbeddedCursor(info);
+    EXPECT_EQ(cursor->cardinality(), 5u);
+}
+
+TEST(PostingListCursorTest, DensityPerfectlyDense)
+{
+    auto docs = generateRange(0, 100);
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+    EXPECT_DOUBLE_EQ(cursor->density(), 1.0);
+}
+
+TEST(PostingListCursorTest, DensitySparse)
+{
+    std::vector<uint32_t> docs = {0, 100};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+    EXPECT_NEAR(cursor->density(), 2.0 / 101.0, 1e-6);
+}
+
+TEST(PostingListCursorTest, DensitySingleDoc)
+{
+    auto info = makeEmbeddedInfo({42});
+    auto cursor = makeEmbeddedCursor(info);
+    EXPECT_DOUBLE_EQ(cursor->density(), 1.0);
+}
+
+
+// ===========================================================================================
+// Section 4: linearOr (set bits for all doc IDs in range)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, LinearOrFullRange)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto result = linearOrToDocIds(cursor, 0, 60);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, LinearOrPartialRange)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto result = linearOrToDocIds(cursor, 15, 30); // rows [15, 45)
+    std::vector<uint32_t> expected = {20, 30, 40};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, LinearOrNoOverlap)
+{
+    std::vector<uint32_t> docs = {10, 20, 30};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto result = linearOrToDocIds(cursor, 100, 50);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(PostingListCursorTest, LinearOrSingleRowMatch)
+{
+    std::vector<uint32_t> docs = {42};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto result = linearOrToDocIds(cursor, 42, 1);
+    EXPECT_EQ(result, std::vector<uint32_t>{42});
+}
+
+TEST(PostingListCursorTest, LinearOrDenseRange)
+{
+    auto docs = generateRange(100, 500);
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto result = linearOrToDocIds(cursor, 0, 700);
+    EXPECT_EQ(result, docs);
+}
+
+
+// ===========================================================================================
+// Section 5: linearAnd (increment counts for matching rows)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, LinearAndFullRange)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    std::vector<UInt8> buf(60, 0);
+    cursor->linearAnd(buf.data(), 0, 60);
+
+    for (auto d : docs)
+        EXPECT_EQ(buf[d], 1u) << "Expected buf[" << d << "] == 1";
+    EXPECT_EQ(buf[0], 0u);
+    EXPECT_EQ(buf[15], 0u);
+}
+
+TEST(PostingListCursorTest, LinearAndIncrementsExisting)
+{
+    std::vector<uint32_t> docs = {10, 20, 30};
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    std::vector<UInt8> buf(40, 1);
+    cursor->linearAnd(buf.data(), 0, 40);
+
+    EXPECT_EQ(buf[10], 2u);
+    EXPECT_EQ(buf[20], 2u);
+    EXPECT_EQ(buf[30], 2u);
+    EXPECT_EQ(buf[0], 1u);
+    EXPECT_EQ(buf[5], 1u);
+}
+
+
+// ===========================================================================================
+// Section 6: Two-cursor intersection (intersectTwo)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectTwoIdentical)
+{
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50};
+    auto info1 = makeEmbeddedInfo(docs);
+    auto info2 = makeEmbeddedInfo(docs);
+    auto c1 = makeEmbeddedCursor(info1);
+    auto c2 = makeEmbeddedCursor(info2);
+
+    PostingListCursorMap postings;
+    postings["a"] = c1;
+    postings["b"] = c2;
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 60, false, 100.0);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, IntersectTwoDisjoint)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30});
+    auto info2 = makeEmbeddedInfo({15, 25, 35});
+    auto c1 = makeEmbeddedCursor(info1);
+    auto c2 = makeEmbeddedCursor(info2);
+
+    PostingListCursorMap postings;
+    postings["a"] = c1;
+    postings["b"] = c2;
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 50, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(PostingListCursorTest, IntersectTwoPartialOverlap)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30, 40, 50});
+    auto info2 = makeEmbeddedInfo({20, 30, 60, 70});
+    auto c1 = makeEmbeddedCursor(info1);
+    auto c2 = makeEmbeddedCursor(info2);
+
+    PostingListCursorMap postings;
+    postings["a"] = c1;
+    postings["b"] = c2;
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 80, false, 100.0);
+    std::vector<uint32_t> expected = {20, 30};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, IntersectTwoDenseVsSparse)
+{
+    auto dense_docs = generateRange(0, 1000);
+    auto sparse_docs = generateRange(0, 100, 10); // 0,10,20,...,990
+
+    auto info1 = makeEmbeddedInfo(dense_docs);
+    auto info2 = makeEmbeddedInfo(sparse_docs);
+    auto c1 = makeEmbeddedCursor(info1);
+    auto c2 = makeEmbeddedCursor(info2);
+
+    PostingListCursorMap postings;
+    postings["dense"] = c1;
+    postings["sparse"] = c2;
+
+    auto result = intersectAndCollect(postings, {"dense", "sparse"}, 0, 1000, false, 100.0);
+    EXPECT_EQ(result, sparse_docs);
+}
+
+TEST(PostingListCursorTest, IntersectTwoSingleCommon)
+{
+    auto info1 = makeEmbeddedInfo({1, 50, 100});
+    auto info2 = makeEmbeddedInfo({49, 50, 51});
+    auto c1 = makeEmbeddedCursor(info1);
+    auto c2 = makeEmbeddedCursor(info2);
+
+    PostingListCursorMap postings;
+    postings["a"] = c1;
+    postings["b"] = c2;
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 150, false, 100.0);
+    EXPECT_EQ(result, std::vector<uint32_t>{50});
+}
+
+
+// ===========================================================================================
+// Section 7: Three-cursor intersection (intersectThree)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectThreeAllMatch)
+{
+    auto docs = generateRange(0, 5, 10); // 0,10,20,30,40
+    auto info1 = makeEmbeddedInfo(docs);
+    auto info2 = makeEmbeddedInfo(docs);
+    auto info3 = makeEmbeddedInfo(docs);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 50, false, 100.0);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, IntersectThreePartialOverlap)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30, 40, 50, 60});
+    auto info2 = makeEmbeddedInfo({15, 20, 30, 45, 60});
+    auto info3 = makeEmbeddedInfo({20, 25, 30, 55, 60});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 70, false, 100.0);
+    std::vector<uint32_t> expected = {20, 30, 60};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, IntersectThreeNoCommon)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30});
+    auto info2 = makeEmbeddedInfo({11, 21, 31});
+    auto info3 = makeEmbeddedInfo({12, 22, 32});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 50, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 8: Four-cursor intersection (intersectFour)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectFourAllOverlap)
+{
+    auto docs = generateRange(0, 20, 5);
+    auto info1 = makeEmbeddedInfo(docs);
+    auto info2 = makeEmbeddedInfo(docs);
+    auto info3 = makeEmbeddedInfo(docs);
+    auto info4 = makeEmbeddedInfo(docs);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+    postings["d"] = makeEmbeddedCursor(info4);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c", "d"}, 0, 100, false, 100.0);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, IntersectFourMixedSelectivity)
+{
+    // Dense: every 2nd
+    auto docs1 = generateRange(0, 500, 2);
+    // Sparse: every 3rd
+    auto docs2 = generateRange(0, 334, 3);
+    // Sparser: every 5th
+    auto docs3 = generateRange(0, 200, 5);
+    // Sparsest: every 7th
+    auto docs4 = generateRange(0, 143, 7);
+
+    auto info1 = makeEmbeddedInfo(docs1);
+    auto info2 = makeEmbeddedInfo(docs2);
+    auto info3 = makeEmbeddedInfo(docs3);
+    auto info4 = makeEmbeddedInfo(docs4);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+    postings["d"] = makeEmbeddedCursor(info4);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c", "d"}, 0, 1000, false, 100.0);
+
+    // LCM(2,3,5,7) = 210
+    std::vector<uint32_t> expected;
+    for (uint32_t i = 0; i < 1000; i += 210)
+        expected.push_back(i);
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 9: Five+ cursor intersection (intersectLeapfrogLinear, n=5..8)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectFiveCursors)
+{
+    // Every i-th prime: 2,3,5,7,11 -> LCM=2310
+    auto docs1 = generateRange(0, 500, 2);
+    auto docs2 = generateRange(0, 334, 3);
+    auto docs3 = generateRange(0, 200, 5);
+    auto docs4 = generateRange(0, 143, 7);
+    auto docs5 = generateRange(0, 91, 11);
+
+    auto info1 = makeEmbeddedInfo(docs1);
+    auto info2 = makeEmbeddedInfo(docs2);
+    auto info3 = makeEmbeddedInfo(docs3);
+    auto info4 = makeEmbeddedInfo(docs4);
+    auto info5 = makeEmbeddedInfo(docs5);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+    postings["d"] = makeEmbeddedCursor(info4);
+    postings["e"] = makeEmbeddedCursor(info5);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c", "d", "e"}, 0, 1000, false, 100.0);
+    // Only 0 is common (LCM=2310, next would be 2310 which is >= 1000)
+    EXPECT_EQ(result, std::vector<uint32_t>{0});
+}
+
+TEST(PostingListCursorTest, IntersectEightCursors)
+{
+    auto docs = generateRange(0, 10, 10); // 0,10,...,90
+    std::vector<TokenPostingsInfo> infos(8);
+    PostingListCursorMap postings;
+    std::vector<String> tokens;
+
+    for (int i = 0; i < 8; ++i)
+    {
+        infos[i] = makeEmbeddedInfo(docs);
+        String name = "t" + std::to_string(i);
+        tokens.push_back(name);
+    }
+    for (int i = 0; i < 8; ++i)
+        postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+
+    auto result = intersectAndCollect(postings, tokens, 0, 100, false, 100.0);
+    EXPECT_EQ(result, docs);
+}
+
+
+// ===========================================================================================
+// Section 10: Nine+ cursor intersection (intersectLeapfrogHeap)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectNineCursorsHeap)
+{
+    auto docs = generateRange(0, 3, 20); // 0,20,40
+    std::vector<TokenPostingsInfo> infos(9);
+    PostingListCursorMap postings;
+    std::vector<String> tokens;
+
+    for (int i = 0; i < 9; ++i)
+    {
+        infos[i] = makeEmbeddedInfo(docs);
+        String name = "t" + std::to_string(i);
+        tokens.push_back(name);
+    }
+    for (int i = 0; i < 9; ++i)
+        postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+
+    auto result = intersectAndCollect(postings, tokens, 0, 50, false, 100.0);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, IntersectTenCursorsWithVaryingDocs)
+{
+    std::vector<TokenPostingsInfo> infos(10);
+    PostingListCursorMap postings;
+    std::vector<String> tokens;
+
+    for (int i = 0; i < 10; ++i)
+    {
+        String name = "t" + std::to_string(i);
+        tokens.push_back(name);
+    }
+
+    for (int i = 0; i < 10; ++i)
+    {
+        std::vector<uint32_t> docs;
+        for (uint32_t d = 0; d < 1000; d += (i + 1))
+            docs.push_back(d);
+        infos[i] = makeEmbeddedInfo(docs);
+        postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+    }
+
+    auto result = intersectAndCollect(postings, tokens, 0, 1000, false, 100.0);
+    // LCM(1,2,...,10) = 2520, so only 0 within [0,1000)
+    EXPECT_EQ(result, std::vector<uint32_t>{0});
+}
+
+
+// ===========================================================================================
+// Section 11: Brute-force intersection (intersectBruteForce)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, BruteForceIntersectTwo)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30, 40, 50});
+    auto info2 = makeEmbeddedInfo({20, 30, 60});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 70, true);
+    std::vector<uint32_t> expected = {20, 30};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, BruteForceIntersectThree)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30, 40, 50});
+    auto info2 = makeEmbeddedInfo({20, 30, 50, 60});
+    auto info3 = makeEmbeddedInfo({5, 20, 30, 45, 50, 70});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 80, true);
+    std::vector<uint32_t> expected = {20, 30, 50};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, BruteForceVsLeapfrogConsistency)
+{
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<uint32_t> dist(0, 999);
+
+    for (int trial = 0; trial < 10; ++trial)
+    {
+        std::vector<TokenPostingsInfo> infos(3);
+        std::vector<std::vector<uint32_t>> all_docs(3);
+
+        for (int i = 0; i < 3; ++i)
+        {
+            std::set<uint32_t> s;
+            size_t count = 50 + trial * 20;
+            while (s.size() < count)
+                s.insert(dist(rng));
+            all_docs[i].assign(s.begin(), s.end());
+            infos[i] = makeEmbeddedInfo(all_docs[i]);
+        }
+
+        // Brute force
+        PostingListCursorMap postings_bf;
+        postings_bf["a"] = makeEmbeddedCursor(infos[0]);
+        postings_bf["b"] = makeEmbeddedCursor(infos[1]);
+        postings_bf["c"] = makeEmbeddedCursor(infos[2]);
+        auto bf_result = intersectAndCollect(postings_bf, {"a", "b", "c"}, 0, 1000, true);
+
+        // Leapfrog (low density threshold to force leapfrog)
+        PostingListCursorMap postings_lf;
+        postings_lf["a"] = makeEmbeddedCursor(infos[0]);
+        postings_lf["b"] = makeEmbeddedCursor(infos[1]);
+        postings_lf["c"] = makeEmbeddedCursor(infos[2]);
+        auto lf_result = intersectAndCollect(postings_lf, {"a", "b", "c"}, 0, 1000, false, 100.0);
+
+        EXPECT_EQ(bf_result, lf_result) << "Brute-force vs leapfrog mismatch at trial " << trial;
+    }
+}
+
+
+// ===========================================================================================
+// Section 12: Union (lazyUnionPostingLists)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, UnionSingleCursor)
+{
+    std::vector<uint32_t> docs = {5, 15, 25};
+    auto info = makeEmbeddedInfo(docs);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info);
+
+    auto result = unionAndCollect(postings, {"a"}, 0, 30);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, UnionTwoCursorsNoOverlap)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30});
+    auto info2 = makeEmbeddedInfo({15, 25, 35});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = unionAndCollect(postings, {"a", "b"}, 0, 40);
+    std::vector<uint32_t> expected = {10, 15, 20, 25, 30, 35};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, UnionTwoCursorsWithOverlap)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30, 40});
+    auto info2 = makeEmbeddedInfo({20, 30, 50});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = unionAndCollect(postings, {"a", "b"}, 0, 60);
+    std::vector<uint32_t> expected = {10, 20, 30, 40, 50};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, UnionMultipleCursors)
+{
+    auto info1 = makeEmbeddedInfo({1, 4, 7});
+    auto info2 = makeEmbeddedInfo({2, 5, 8});
+    auto info3 = makeEmbeddedInfo({3, 6, 9});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+    postings["c"] = makeEmbeddedCursor(info3);
+
+    auto result = unionAndCollect(postings, {"a", "b", "c"}, 0, 10);
+    std::vector<uint32_t> expected = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 13: Intersection with row_offset (windowed intersection)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectWithRowOffset)
+{
+    auto info1 = makeEmbeddedInfo({100, 200, 300, 400, 500});
+    auto info2 = makeEmbeddedInfo({100, 200, 300, 400, 500});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    // Only look at rows [200, 400)
+    auto result = intersectAndCollect(postings, {"a", "b"}, 200, 200, false, 100.0);
+    std::vector<uint32_t> expected = {200, 300};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, IntersectWindowExcludesAll)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30});
+    auto info2 = makeEmbeddedInfo({10, 20, 30});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 100, 50, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 14: Union with row_offset (windowed union)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, UnionWithRowOffset)
+{
+    auto info1 = makeEmbeddedInfo({50, 100, 150, 200});
+    auto info2 = makeEmbeddedInfo({75, 125, 175});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    // Look at rows [100, 200) -> 100 rows
+    auto result = unionAndCollect(postings, {"a", "b"}, 100, 100);
+    std::vector<uint32_t> expected = {100, 125, 150, 175};
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 15: Single cursor intersection (degenerate case, acts like OR)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectSingleCursor)
+{
+    auto info = makeEmbeddedInfo({5, 10, 15, 20, 25});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info);
+
+    auto result = intersectAndCollect(postings, {"a"}, 0, 30, false);
+    std::vector<uint32_t> expected = {5, 10, 15, 20, 25};
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 16: Missing tokens in postings map
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectMissingToken)
+{
+    auto info = makeEmbeddedInfo({1, 2, 3});
+
+    PostingListCursorMap postings;
+    postings["exists"] = makeEmbeddedCursor(info);
+
+    // "missing" token doesn't exist in map → should act as if 0 cursors intersect
+    auto result = intersectAndCollect(postings, {"exists", "missing"}, 0, 10, false, 100.0);
+    // Only "exists" cursor is used, intersect with nothing → depends on implementation
+    // Since only 1 cursor found, it should just do linearOr
+    // But actually if only 1 cursor found out of 2 tokens, n=1 path is taken
+    std::vector<uint32_t> expected = {1, 2, 3};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, UnionMissingToken)
+{
+    auto info = makeEmbeddedInfo({10, 20, 30});
+
+    PostingListCursorMap postings;
+    postings["exists"] = makeEmbeddedCursor(info);
+
+    auto result = unionAndCollect(postings, {"exists", "missing"}, 0, 40);
+    std::vector<uint32_t> expected = {10, 20, 30};
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 17: Empty intersection/union
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectZeroCursors)
+{
+    PostingListCursorMap postings;
+    auto result = intersectAndCollect(postings, {}, 0, 100, false);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(PostingListCursorTest, UnionZeroCursors)
+{
+    PostingListCursorMap postings;
+    auto result = unionAndCollect(postings, {}, 0, 100);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 18: Stress tests — large random intersections
+// ===========================================================================================
+
+TEST(PostingListCursorTest, StressRandomIntersectTwo)
+{
+    std::mt19937 rng(12345);
+
+    for (int trial = 0; trial < 20; ++trial)
+    {
+        std::uniform_int_distribution<uint32_t> dist(0, 9999);
+        std::set<uint32_t> s1, s2;
+
+        size_t sz1 = 200 + trial * 50;
+        size_t sz2 = 100 + trial * 30;
+        while (s1.size() < sz1) s1.insert(dist(rng));
+        while (s2.size() < sz2) s2.insert(dist(rng));
+
+        std::vector<uint32_t> v1(s1.begin(), s1.end());
+        std::vector<uint32_t> v2(s2.begin(), s2.end());
+
+        // Compute expected intersection
+        std::vector<uint32_t> expected;
+        std::set_intersection(s1.begin(), s1.end(), s2.begin(), s2.end(), std::back_inserter(expected));
+
+        auto info1 = makeEmbeddedInfo(v1);
+        auto info2 = makeEmbeddedInfo(v2);
+
+        PostingListCursorMap postings;
+        postings["a"] = makeEmbeddedCursor(info1);
+        postings["b"] = makeEmbeddedCursor(info2);
+
+        auto result = intersectAndCollect(postings, {"a", "b"}, 0, 10000, false, 100.0);
+        EXPECT_EQ(result, expected) << "Mismatch at trial " << trial;
+    }
+}
+
+TEST(PostingListCursorTest, StressRandomIntersectFour)
+{
+    std::mt19937 rng(54321);
+
+    for (int trial = 0; trial < 10; ++trial)
+    {
+        std::uniform_int_distribution<uint32_t> dist(0, 4999);
+
+        std::vector<std::set<uint32_t>> sets(4);
+        std::vector<TokenPostingsInfo> infos(4);
+        PostingListCursorMap postings;
+        std::vector<String> tokens;
+
+        for (int i = 0; i < 4; ++i)
+        {
+            size_t sz = 100 + trial * 30 + i * 20;
+            while (sets[i].size() < sz) sets[i].insert(dist(rng));
+
+            std::vector<uint32_t> v(sets[i].begin(), sets[i].end());
+            infos[i] = makeEmbeddedInfo(v);
+
+            String name = "t" + std::to_string(i);
+            tokens.push_back(name);
+        }
+        for (int i = 0; i < 4; ++i)
+            postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+
+        // Compute expected 4-way intersection
+        std::vector<uint32_t> tmp1, tmp2, expected;
+        std::set_intersection(sets[0].begin(), sets[0].end(), sets[1].begin(), sets[1].end(), std::back_inserter(tmp1));
+        std::set_intersection(sets[2].begin(), sets[2].end(), sets[3].begin(), sets[3].end(), std::back_inserter(tmp2));
+        std::set_intersection(tmp1.begin(), tmp1.end(), tmp2.begin(), tmp2.end(), std::back_inserter(expected));
+
+        auto result = intersectAndCollect(postings, tokens, 0, 5000, false, 100.0);
+        EXPECT_EQ(result, expected) << "Mismatch at trial " << trial;
+    }
+}
+
+TEST(PostingListCursorTest, StressRandomUnion)
+{
+    std::mt19937 rng(99999);
+
+    for (int trial = 0; trial < 10; ++trial)
+    {
+        std::uniform_int_distribution<uint32_t> dist(0, 999);
+
+        std::set<uint32_t> all;
+        std::vector<TokenPostingsInfo> infos(3);
+        PostingListCursorMap postings;
+        std::vector<String> tokens;
+
+        for (int i = 0; i < 3; ++i)
+        {
+            std::set<uint32_t> s;
+            size_t sz = 50 + trial * 10;
+            while (s.size() < sz) s.insert(dist(rng));
+            all.insert(s.begin(), s.end());
+
+            std::vector<uint32_t> v(s.begin(), s.end());
+            infos[i] = makeEmbeddedInfo(v);
+
+            String name = "t" + std::to_string(i);
+            tokens.push_back(name);
+        }
+        for (int i = 0; i < 3; ++i)
+            postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+
+        std::vector<uint32_t> expected(all.begin(), all.end());
+        auto result = unionAndCollect(postings, tokens, 0, 1000);
+        EXPECT_EQ(result, expected) << "Mismatch at trial " << trial;
+    }
+}
+
+
+// ===========================================================================================
+// Section 19: Edge cases for intersection algorithms
+// ===========================================================================================
+
+TEST(PostingListCursorTest, IntersectOneCursorEndsEarly)
+{
+    auto info1 = makeEmbeddedInfo({10, 20, 30});
+    auto info2 = makeEmbeddedInfo({10, 20, 30, 40, 50, 60, 70, 80, 90, 100});
+
+    PostingListCursorMap postings;
+    postings["short"] = makeEmbeddedCursor(info1);
+    postings["long"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"short", "long"}, 0, 110, false, 100.0);
+    std::vector<uint32_t> expected = {10, 20, 30};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, IntersectAllDocsAtMaxValue)
+{
+    uint32_t big = 1000000;
+    auto info1 = makeEmbeddedInfo({big - 2, big - 1, big});
+    auto info2 = makeEmbeddedInfo({big - 2, big - 1, big});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, big - 2, 3, false, 100.0);
+    std::vector<uint32_t> expected = {big - 2, big - 1, big};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, IntersectLargeGapBetweenMatches)
+{
+    auto info1 = makeEmbeddedInfo({0, 10000, 20000});
+    auto info2 = makeEmbeddedInfo({0, 10000, 20000});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 30000, false, 100.0);
+    std::vector<uint32_t> expected = {0, 10000, 20000};
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 20: Brute-force with high cardinality
+// ===========================================================================================
+
+TEST(PostingListCursorTest, BruteForceDenseLargeRange)
+{
+    auto docs1 = generateRange(0, 5000);
+    auto docs2 = generateRange(0, 2500, 2); // 0,2,4,...,4998
+
+    auto info1 = makeEmbeddedInfo(docs1);
+    auto info2 = makeEmbeddedInfo(docs2);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 5000, true);
+    EXPECT_EQ(result, docs2);
+}
+
+
+// ===========================================================================================
+// Section 21: Cursor-level seek+next interleaving
+// ===========================================================================================
+
+TEST(PostingListCursorTest, AlternatingSeekAndNext)
+{
+    auto docs = generateRange(0, 100, 3); // 0,3,6,...,297
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    // Start: value should be 0
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 0u);
+
+    // Seek to 10 -> should land on 12 (first multiple of 3 >= 10)
+    cursor->seek(10);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 12u);
+
+    // next() -> 15
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 15u);
+
+    // Seek to 100 -> should land on 102
+    cursor->seek(100);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 102u);
+
+    // next() -> 105
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 105u);
+
+    // Seek way ahead to 290 -> 291
+    cursor->seek(290);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 291u);
+
+    // next() -> 294
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 294u);
+
+    // next() -> 297
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 297u);
+
+    // next() -> invalid
+    cursor->next();
+    EXPECT_FALSE(cursor->valid());
+}
+
+
+// ===========================================================================================
+// Section 22: Regression test for the two bugs that were fixed
+// ===========================================================================================
+
+/// The next() bug: when a cursor exhausts all packed blocks in one large block,
+/// it should advance to the next large block (not just invalidate).
+/// For embedded cursors, all data is in one "block", so this is implicitly tested
+/// through the draining tests above. This test verifies the cursor properly exhausts
+/// all elements.
+TEST(PostingListCursorTest, NextExhaustsAllElementsProperly)
+{
+    auto docs = generateRange(0, 500);
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    size_t count = 0;
+    while (cursor->valid())
+    {
+        EXPECT_EQ(cursor->value(), static_cast<uint32_t>(count));
+        cursor->next();
+        ++count;
+    }
+    EXPECT_EQ(count, 500u);
+}
+
+/// The seek() bug: seek on the slow path should start from the next large block,
+/// not retry the current one. For embedded cursors, this manifests as: after seek
+/// fails (target beyond all data), cursor should be invalid.
+TEST(PostingListCursorTest, SeekBeyondEndMakesInvalid)
+{
+    auto info = makeEmbeddedInfo({10, 20, 30});
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(31);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, SeekExactLastThenNextInvalidates)
+{
+    auto info = makeEmbeddedInfo({10, 20, 30});
+    auto cursor = makeEmbeddedCursor(info);
+
+    cursor->seek(30);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 30u);
+
+    cursor->next();
+    EXPECT_FALSE(cursor->valid());
+}
+
+
+// ===========================================================================================
+// Section 23: Mixed algorithm paths — brute-force threshold switching
+// ===========================================================================================
+
+TEST(PostingListCursorTest, DensityThresholdSwitchesAlgorithm)
+{
+    // Two dense cursors: density ~= 1.0
+    auto docs1 = generateRange(0, 100);
+    auto docs2 = generateRange(0, 100);
+    auto info1 = makeEmbeddedInfo(docs1);
+    auto info2 = makeEmbeddedInfo(docs2);
+
+    // With high threshold → leapfrog
+    {
+        PostingListCursorMap postings;
+        postings["a"] = makeEmbeddedCursor(info1);
+        postings["b"] = makeEmbeddedCursor(info2);
+        auto result = intersectAndCollect(postings, {"a", "b"}, 0, 100, false, 100.0);
+        EXPECT_EQ(result, docs1);
+    }
+
+    // With low threshold → brute-force (density 1.0 >= 0.1)
+    {
+        PostingListCursorMap postings;
+        postings["a"] = makeEmbeddedCursor(info1);
+        postings["b"] = makeEmbeddedCursor(info2);
+        auto result = intersectAndCollect(postings, {"a", "b"}, 0, 100, false, 0.1f);
+        EXPECT_EQ(result, docs1);
+    }
+}
+
+
+// ===========================================================================================
+// Section 24: Interleaving of cursors with very different cardinalities
+// ===========================================================================================
+
+TEST(PostingListCursorTest, HighlyAsymmetricCardinalities)
+{
+    // Cursor A: single doc at 500
+    auto info1 = makeEmbeddedInfo({500});
+    // Cursor B: 5000 docs
+    auto docs2 = generateRange(0, 5000);
+    auto info2 = makeEmbeddedInfo(docs2);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 5000, false, 100.0);
+    EXPECT_EQ(result, std::vector<uint32_t>{500});
+}
+
+TEST(PostingListCursorTest, OneEmptyOneFullIntersection)
+{
+    auto info1 = makeEmbeddedInfo({});
+    auto docs2 = generateRange(0, 100);
+    auto info2 = makeEmbeddedInfo(docs2);
+
+    PostingListCursorMap postings;
+    postings["empty"] = makeEmbeddedCursor(info1);
+    postings["full"] = makeEmbeddedCursor(info2);
+
+    // The empty cursor is invalid from the start, so intersect should return empty.
+    // But since the cursor is invalid after seek(0), intersect returns immediately.
+    auto result = intersectAndCollect(postings, {"empty", "full"}, 0, 100, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 25: Consecutive doc IDs
+// ===========================================================================================
+
+TEST(PostingListCursorTest, ConsecutiveDocIds)
+{
+    auto docs = generateRange(1000, 200);
+    auto info = makeEmbeddedInfo(docs);
+    auto cursor = makeEmbeddedCursor(info);
+
+    auto result = drainCursor(cursor);
+    EXPECT_EQ(result.size(), 200u);
+    EXPECT_EQ(result.front(), 1000u);
+    EXPECT_EQ(result.back(), 1199u);
+}
+
+
+// ===========================================================================================
+// Section 26: Intersection with window at exactly the boundary of matching docs
+// ===========================================================================================
+
+TEST(PostingListCursorTest, WindowExactlyOnFirstMatch)
+{
+    auto info1 = makeEmbeddedInfo({50, 100, 150});
+    auto info2 = makeEmbeddedInfo({50, 100, 150});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    // Window [50, 51) — exactly covers only doc 50
+    auto result = intersectAndCollect(postings, {"a", "b"}, 50, 1, false, 100.0);
+    EXPECT_EQ(result, std::vector<uint32_t>{50});
+}
+
+TEST(PostingListCursorTest, WindowJustMissesMatch)
+{
+    auto info1 = makeEmbeddedInfo({50, 100, 150});
+    auto info2 = makeEmbeddedInfo({50, 100, 150});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeEmbeddedCursor(info1);
+    postings["b"] = makeEmbeddedCursor(info2);
+
+    // Window [51, 100) — misses 50, captures nothing (100 is at end boundary)
+    auto result = intersectAndCollect(postings, {"a", "b"}, 51, 49, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 27: Multi-large-block — basic next() iteration
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSingleBlockSmall)
+{
+    /// Single large block with fewer than 128 docs (tail block only).
+    std::vector<uint32_t> docs = generateRange(0, 50); // 0..49
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockSingleBlockExact128)
+{
+    /// Single large block with exactly 128+1 = 129 docs total.
+    /// first_doc_id (doc 0) is stored separately, 128 docs encoded in one full packed block.
+    std::vector<uint32_t> docs = generateRange(0, 129); // 0..128
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockSingleBlockWithTail)
+{
+    /// 200 docs total: first_doc_id + 199 encoded = 1 full block (128) + tail (71).
+    std::vector<uint32_t> docs = generateRange(0, 200);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockTwoBlocks)
+{
+    /// Two large blocks.
+    /// Block 0: docs 0..199 (first_doc_id=0, 199 encoded)
+    /// Block 1: docs 300..499 (200 docs encoded)
+    std::vector<uint32_t> block0 = generateRange(0, 200);
+    std::vector<uint32_t> block1 = generateRange(300, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, data.all_docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockThreeBlocks)
+{
+    /// Three large blocks with gaps.
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    std::vector<uint32_t> block2 = generateRange(1000, 100);
+    auto data = makeMultiBlockData({block0, block1, block2});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, data.all_docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockSparseDocsInBlocks)
+{
+    /// Sparse doc IDs within each block.
+    std::vector<uint32_t> block0 = generateRange(0, 150, 3); // 0,3,6,...,447
+    std::vector<uint32_t> block1 = generateRange(1000, 150, 5); // 1000,1005,...,1745
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, data.all_docs);
+}
+
+
+// ===========================================================================================
+// Section 28: Multi-large-block — seek operations
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSeekWithinFirstBlock)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 200);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(100);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 100u);
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekToSecondBlock)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 200);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(500);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 500u);
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekToGapBetweenBlocks)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 200); // 0..199
+    std::vector<uint32_t> block1 = generateRange(500, 200); // 500..699
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to 300 — beyond block 0, should land on block 1's first doc (500)
+    cursor->seek(300);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 500u);
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekBeyondAll)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 200);
+    std::vector<uint32_t> block1 = generateRange(500, 200); // ..699
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(700);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekProgressivelyAcrossBlocks)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    std::vector<uint32_t> block2 = generateRange(1000, 100);
+    auto data = makeMultiBlockData({block0, block1, block2});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(50);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 50u);
+
+    cursor->seek(600);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 600u);
+
+    cursor->seek(1050);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1050u);
+
+    cursor->seek(1100);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekThenNext)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(148);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 148u);
+
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 149u);
+
+    /// next() should cross to block 1
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 500u);
+
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 501u);
+}
+
+
+// ===========================================================================================
+// Section 29: Multi-large-block — linearOr
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockLinearOrFullRange)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 700);
+    EXPECT_EQ(result, data.all_docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearOrPartialFirstBlock)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 200);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 50, 100); // [50, 150)
+    auto expected = generateRange(50, 100); // 50..149
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearOrSecondBlockOnly)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 500, 200); // [500, 700)
+    auto expected = generateRange(500, 200);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearOrSpansBothBlocks)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 100, 550); // [100, 650)
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 100; d < 150; ++d)
+        expected.push_back(d);
+    for (uint32_t d = 500; d < 650; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 30: Multi-large-block — linearAnd
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockLinearAndFullRange)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    std::vector<UInt8> buf(700, 0);
+    cursor->linearAnd(buf.data(), 0, 700);
+
+    for (auto d : data.all_docs)
+        EXPECT_EQ(buf[d], 1u) << "Expected buf[" << d << "] == 1";
+
+    /// Check some docs in the gap are 0
+    EXPECT_EQ(buf[200], 0u);
+    EXPECT_EQ(buf[400], 0u);
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearAndIncrementsExisting)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    std::vector<UInt8> buf(700, 1);
+    cursor->linearAnd(buf.data(), 0, 700);
+
+    for (auto d : data.all_docs)
+        EXPECT_EQ(buf[d], 2u) << "Expected buf[" << d << "] == 2";
+    EXPECT_EQ(buf[200], 1u);
+}
+
+
+// ===========================================================================================
+// Section 31: Multi-large-block — packed block index binary search (seekImpl)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSeekToMiddleOfPackedBlocks)
+{
+    /// Large block with 400 docs → 399 encoded → 3 full packed blocks + tail of 15.
+    /// Seek should binary-search packed_block_last_doc_ids to find the right block.
+    std::vector<uint32_t> docs = generateRange(0, 400);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to doc 200 → should be in packed block 1 (docs 129..256)
+    cursor->seek(200);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 200u);
+
+    /// Seek forward to 350 → should be in packed block 2
+    cursor->seek(350);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 350u);
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekExactPackedBlockBoundary)
+{
+    /// 257 docs → first_doc_id + 256 encoded → 2 full packed blocks.
+    /// packed_block_last_doc_ids should be [128, 256].
+    std::vector<uint32_t> docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to exactly doc 128 (last doc of first packed block)
+    cursor->seek(128);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 128u);
+
+    /// Seek to doc 129 (first doc of second packed block)
+    cursor->seek(129);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 129u);
+}
+
+
+// ===========================================================================================
+// Section 32: Multi-large-block — next() crossing packed block and large block boundaries
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockNextCrossesPackedBlockBoundary)
+{
+    /// 260 docs → first_doc_id + 259 encoded → 2 full blocks + tail of 3.
+    std::vector<uint32_t> docs = generateRange(0, 260);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to last element in first packed block (doc 128)
+    cursor->seek(128);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 128u);
+
+    /// next() should cross to second packed block
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 129u);
+}
+
+TEST(PostingListCursorTest, MultiBlockNextCrossesLargeBlockBoundary)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 130); // 0..129
+    std::vector<uint32_t> block1 = generateRange(500, 130); // 500..629
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Drain to end of block 0
+    cursor->seek(129);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 129u);
+
+    /// next() should cross to block 1
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 500u);
+}
+
+
+// ===========================================================================================
+// Section 33: Multi-large-block — tail block handling
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockTailBlockOnly)
+{
+    /// 10 docs: first_doc_id + 9 encoded → single tail block (9 docs).
+    std::vector<uint32_t> docs = generateRange(100, 10);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockExactlyOneFullBlock)
+{
+    /// 129 docs: first_doc_id + 128 encoded → exactly one full packed block (128).
+    std::vector<uint32_t> docs = generateRange(0, 129);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockTailInSecondLargeBlock)
+{
+    /// Block 0: 129 docs (1 full packed block)
+    /// Block 1: 50 docs (tail block only)
+    std::vector<uint32_t> block0 = generateRange(0, 129);
+    std::vector<uint32_t> block1 = generateRange(500, 50);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, data.all_docs);
+}
+
+
+// ===========================================================================================
+// Section 34: Multi-large-block — intersection with multi-block cursors
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockIntersectTwoMultiBlockCursors)
+{
+    /// Cursor A: block0=[0..149], block1=[500..699]
+    /// Cursor B: block0=[100..299], block1=[600..799]
+    /// Intersection: [100..149] ∪ [600..699]
+    auto dataA = makeMultiBlockData({generateRange(0, 150), generateRange(500, 200)});
+    auto dataB = makeMultiBlockData({generateRange(100, 200), generateRange(600, 200)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 800, false, 100.0);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 100; d < 150; ++d)
+        expected.push_back(d);
+    for (uint32_t d = 600; d < 700; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockIntersectMultiBlockWithEmbedded)
+{
+    /// Multi-block cursor A: [0..199], [500..699]
+    /// Embedded cursor B: {50, 150, 550, 650, 800}
+    /// Intersection: {50, 150, 550, 650}
+    auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
+    auto infoB = makeEmbeddedInfo({50, 150, 550, 650, 800});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeEmbeddedCursor(infoB);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 1000, false, 100.0);
+    std::vector<uint32_t> expected = {50, 150, 550, 650};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockIntersectDisjoint)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 150)});
+    auto dataB = makeMultiBlockData({generateRange(500, 150)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 700, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 35: Multi-large-block — union with multi-block cursors
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockUnionTwoCursors)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 150)});
+    auto dataB = makeMultiBlockData({generateRange(500, 150)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+
+    auto result = unionAndCollect(postings, {"a", "b"}, 0, 700);
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 0; d < 150; ++d) expected.push_back(d);
+    for (uint32_t d = 500; d < 650; ++d) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 36: Multi-large-block — brute-force intersection
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockBruteForceIntersect)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
+    auto dataB = makeMultiBlockData({generateRange(100, 200), generateRange(600, 200)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 800, true);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 100; d < 200; ++d)
+        expected.push_back(d);
+    for (uint32_t d = 600; d < 700; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockBruteForceVsLeapfrogConsistency)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
+    auto dataB = makeMultiBlockData({generateRange(50, 250), generateRange(550, 250)});
+
+    // Brute force
+    {
+        PostingListCursorMap postings;
+        postings["a"] = makeMultiBlockCursor(dataA);
+        postings["b"] = makeMultiBlockCursor(dataB);
+        auto bf = intersectAndCollect(postings, {"a", "b"}, 0, 800, true);
+
+        PostingListCursorMap postings2;
+        postings2["a"] = makeMultiBlockCursor(dataA);
+        postings2["b"] = makeMultiBlockCursor(dataB);
+        auto lf = intersectAndCollect(postings2, {"a", "b"}, 0, 800, false, 100.0);
+
+        EXPECT_EQ(bf, lf);
+    }
+}
+
+
+// ===========================================================================================
+// Section 37: Multi-large-block — large doc count stress test
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockLargeDocCount)
+{
+    /// 1000 docs in one block: first_doc_id + 999 encoded.
+    /// 999 / 128 = 7 full blocks + tail of 103.
+    std::vector<uint32_t> docs = generateRange(0, 1000);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockManyLargeBlocks)
+{
+    /// 5 large blocks of 130 docs each, with gaps.
+    std::vector<std::vector<uint32_t>> blocks;
+    for (int i = 0; i < 5; ++i)
+        blocks.push_back(generateRange(static_cast<uint32_t>(i * 500), 130));
+
+    auto data = makeMultiBlockData(blocks);
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, data.all_docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekAcrossManyBlocks)
+{
+    std::vector<std::vector<uint32_t>> blocks;
+    for (int i = 0; i < 5; ++i)
+        blocks.push_back(generateRange(static_cast<uint32_t>(i * 500), 130));
+
+    auto data = makeMultiBlockData(blocks);
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to each block's midpoint
+    for (int i = 0; i < 5; ++i)
+    {
+        uint32_t target = static_cast<uint32_t>(i * 500 + 65);
+        cursor->seek(target);
+        ASSERT_TRUE(cursor->valid()) << "Block " << i << " seek failed";
+        EXPECT_EQ(cursor->value(), target) << "Block " << i;
+    }
+
+    /// Seek beyond last block
+    cursor->seek(5000);
+    EXPECT_FALSE(cursor->valid());
+}
+
+
+// ===========================================================================================
+// Section 38: Multi-large-block — cardinality and density
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockCardinality)
+{
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    EXPECT_EQ(cursor->cardinality(), 350u);
+}

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -2234,3 +2234,693 @@ TEST(PostingListCursorTest, MultiBlockCardinality)
 
     EXPECT_EQ(cursor->cardinality(), 350u);
 }
+
+
+// ===========================================================================================
+// Section 39: Multi-block — seek to middle packed block, then next() across large block boundary
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSeekToMiddlePackedBlockThenDrainAcrossLargeBlock)
+{
+    /// Block 0: 400 docs (0..399) → first_doc_id + 399 encoded → 3 full packed blocks + tail.
+    /// Block 1: 200 docs (1000..1199).
+    /// Seek to doc 200 (middle of packed block 1), then next() all the way through
+    /// block 0 and across into block 1.
+    std::vector<uint32_t> block0 = generateRange(0, 400);
+    std::vector<uint32_t> block1 = generateRange(1000, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(200);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 200u);
+
+    /// Drain the rest and verify
+    std::vector<uint32_t> result;
+    while (cursor->valid())
+    {
+        result.push_back(cursor->value());
+        cursor->next();
+    }
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 200; d < 400; ++d)
+        expected.push_back(d);
+    for (uint32_t d = 1000; d < 1200; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 40: Multi-block — seek on sparse doc IDs (gap values)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSparseSeekToGapValue)
+{
+    /// Sparse docs: 0,3,6,...,447 in block 0; 1000,1005,...,1745 in block 1.
+    /// Seek to values that fall in gaps between actual doc IDs.
+    std::vector<uint32_t> block0 = generateRange(0, 150, 3);  // 0,3,6,...,447
+    std::vector<uint32_t> block1 = generateRange(1000, 150, 5); // 1000,1005,...,1745
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to 4 (between 3 and 6) → should land on 6
+    cursor->seek(4);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 6u);
+
+    /// Seek to 100 (between 99 and 102) → should land on 102
+    cursor->seek(100);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 102u);
+
+    /// Seek to 500 (in gap between blocks) → should land on 1000
+    cursor->seek(500);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1000u);
+
+    /// Seek to 1001 (between 1000 and 1005) → should land on 1005
+    cursor->seek(1001);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1005u);
+
+    /// Seek to 1746 (beyond last doc) → invalid
+    cursor->seek(1746);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, MultiBlockSparseSeekToFirstDocOfEachBlock)
+{
+    std::vector<uint32_t> block0 = generateRange(10, 150, 3);  // 10,13,...,457
+    std::vector<uint32_t> block1 = generateRange(1000, 150, 5); // 1000,1005,...,1745
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to exact first doc of block 0
+    cursor->seek(10);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 10u);
+
+    /// Seek to exact first doc of block 1
+    cursor->seek(1000);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1000u);
+}
+
+
+// ===========================================================================================
+// Section 41: Multi-block — linearOr/linearAnd when range misses all large blocks
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockLinearOrRangeBeforeAllBlocks)
+{
+    /// Block 0: 500..649, Block 1: 1000..1149
+    /// Range [0, 100) is entirely before block 0.
+    std::vector<uint32_t> block0 = generateRange(500, 150);
+    std::vector<uint32_t> block1 = generateRange(1000, 150);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 100);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearOrRangeAfterAllBlocks)
+{
+    /// Block 0: 0..149, Block 1: 500..699
+    /// Range [2000, 100) is entirely after all blocks.
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 2000, 100);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearOrRangeInGapBetweenBlocks)
+{
+    /// Block 0: 0..149, Block 1: 500..699
+    /// Range [200, 200) = [200, 400) is in the gap.
+    std::vector<uint32_t> block0 = generateRange(0, 150);
+    std::vector<uint32_t> block1 = generateRange(500, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 200, 200);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearAndRangeBeforeAllBlocks)
+{
+    std::vector<uint32_t> block0 = generateRange(500, 150);
+    std::vector<uint32_t> block1 = generateRange(1000, 150);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    std::vector<UInt8> buf(100, 1);
+    cursor->linearAnd(buf.data(), 0, 100);
+
+    /// All values should remain 1 (no increments)
+    for (size_t i = 0; i < 100; ++i)
+        EXPECT_EQ(buf[i], 1u) << "Unexpected increment at offset " << i;
+}
+
+
+// ===========================================================================================
+// Section 42: Multi-block — density computation verification
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockDensityPerfectlyDenseBlock0)
+{
+    /// Block 0: consecutive docs 0..199 → 200 total docs.
+    /// large_block_doc_count = 199 (first_doc_id excluded from count).
+    /// range = (0, 199), range_span = 200.
+    /// density = (199 + 1) / 200 = 1.0
+    std::vector<uint32_t> docs = generateRange(0, 200);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    EXPECT_DOUBLE_EQ(cursor->density(), 1.0);
+}
+
+TEST(PostingListCursorTest, MultiBlockDensitySparseBlock0)
+{
+    /// Block 0: sparse docs 0,3,6,...,447 → 150 docs total.
+    /// large_block_doc_count = 149.
+    /// range = (0, 447), range_span = 448.
+    /// density = (149 + 1) / 448 = 150/448
+    std::vector<uint32_t> docs = generateRange(0, 150, 3);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    double expected_density = 150.0 / 448.0;
+    EXPECT_NEAR(cursor->density(), expected_density, 1e-6);
+}
+
+TEST(PostingListCursorTest, MultiBlockDensityAfterSeekToSecondLargeBlock)
+{
+    /// Block 0: 0..199 (dense).
+    /// Block 1: 500,502,504,...,698 → 100 docs, step 2.
+    /// After seek to block 1: large_block_doc_count = 100, range = (500,698), span = 199.
+    /// density = 100 / 199
+    std::vector<uint32_t> block0 = generateRange(0, 200);
+    std::vector<uint32_t> block1 = generateRange(500, 100, 2); // 500,502,...,698
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// After construction, density reflects block 0 = 1.0
+    EXPECT_DOUBLE_EQ(cursor->density(), 1.0);
+
+    /// Seek to block 1 triggers prepare(1), which updates density
+    cursor->seek(500);
+    ASSERT_TRUE(cursor->valid());
+    double expected_density = 100.0 / 199.0;
+    EXPECT_NEAR(cursor->density(), expected_density, 1e-6);
+}
+
+
+// ===========================================================================================
+// Section 43: Multi-block — 3-way and 4-way intersection with multi-block cursors
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockIntersectThreeMultiBlockCursors)
+{
+    /// Cursor A: [0..199], [500..699]
+    /// Cursor B: [50..249], [550..749]
+    /// Cursor C: [100..299], [600..799]
+    /// Intersection: [100..199] ∪ [600..699]
+    auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
+    auto dataB = makeMultiBlockData({generateRange(50, 200), generateRange(550, 200)});
+    auto dataC = makeMultiBlockData({generateRange(100, 200), generateRange(600, 200)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    postings["c"] = makeMultiBlockCursor(dataC);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 800, false, 100.0);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 100; d < 200; ++d) expected.push_back(d);
+    for (uint32_t d = 600; d < 700; ++d) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockIntersectFourMultiBlockCursors)
+{
+    /// Cursor A: [0..199]
+    /// Cursor B: [50..249]
+    /// Cursor C: [100..299]
+    /// Cursor D: [150..349]
+    /// Intersection: [150..199]
+    auto dataA = makeMultiBlockData({generateRange(0, 200)});
+    auto dataB = makeMultiBlockData({generateRange(50, 200)});
+    auto dataC = makeMultiBlockData({generateRange(100, 200)});
+    auto dataD = makeMultiBlockData({generateRange(150, 200)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    postings["c"] = makeMultiBlockCursor(dataC);
+    postings["d"] = makeMultiBlockCursor(dataD);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c", "d"}, 0, 400, false, 100.0);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 150; d < 200; ++d) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockIntersectFiveMultiBlockLeapfrogLinear)
+{
+    /// 5 cursors → dispatches to intersectLeapfrogLinear.
+    /// All share [100..149].
+    auto dataA = makeMultiBlockData({generateRange(0, 200)});
+    auto dataB = makeMultiBlockData({generateRange(50, 200)});
+    auto dataC = makeMultiBlockData({generateRange(100, 200)});
+    auto dataD = makeMultiBlockData({generateRange(100, 150)});
+    auto dataE = makeMultiBlockData({generateRange(100, 130)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    postings["c"] = makeMultiBlockCursor(dataC);
+    postings["d"] = makeMultiBlockCursor(dataD);
+    postings["e"] = makeMultiBlockCursor(dataE);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c", "d", "e"}, 0, 400, false, 100.0);
+
+    /// Intersection is [100..229] ∩ each cursor. Cursor E is [100..229] (130 docs).
+    /// Cursor D is [100..249]. Cursor C is [100..299]. Cursor B is [50..249]. Cursor A is [0..199].
+    /// So intersection = [100..199] ∩ [100..229] = [100..199]
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 100; d < 200; ++d) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockIntersectThreeDisjoint)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 150)});
+    auto dataB = makeMultiBlockData({generateRange(200, 150)});
+    auto dataC = makeMultiBlockData({generateRange(400, 150)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    postings["c"] = makeMultiBlockCursor(dataC);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 600, false, 100.0);
+    EXPECT_TRUE(result.empty());
+}
+
+
+// ===========================================================================================
+// Section 44: Multi-block — seek to first_doc_id with non-zero start
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSeekToFirstDocIdNonZero)
+{
+    /// first_doc_id = 1000 (ranges[0].begin), stored separately.
+    /// Seek to exactly 1000 should find it via the prepend_first_doc_id logic.
+    std::vector<uint32_t> docs = generateRange(1000, 200); // 1000..1199
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(1000);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1000u);
+
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1001u);
+}
+
+TEST(PostingListCursorTest, MultiBlockSeekBeforeFirstDocIdNonZero)
+{
+    /// first_doc_id = 500. Seek to 400 (before range) should land on 500.
+    std::vector<uint32_t> docs = generateRange(500, 200); // 500..699
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(400);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 500u);
+}
+
+TEST(PostingListCursorTest, MultiBlockDrainFromFirstDocIdNonZero)
+{
+    /// Verify all docs including first_doc_id are returned when draining.
+    std::vector<uint32_t> docs = generateRange(5000, 300); // 5000..5299
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, 5000);
+    EXPECT_EQ(result, docs);
+}
+
+
+// ===========================================================================================
+// Section 45: Multi-block — need_seek_before_decode state transitions
+//   Seek sets need_seek=true, decodeNextBlock clears it, subsequent next()
+//   should do sequential reads (no redundant seek).
+//   We verify indirectly: seek to a packed block, then next() through
+//   the remaining packed blocks and into the next large block.
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockSeekThenSequentialNextThroughMultiplePackedBlocks)
+{
+    /// 500 docs in block 0 → first_doc_id + 499 encoded → 3 full blocks + tail.
+    /// 200 docs in block 1.
+    /// Seek to doc 200 (packed block 1), then next() all the way.
+    std::vector<uint32_t> block0 = generateRange(0, 500);
+    std::vector<uint32_t> block1 = generateRange(1000, 200);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(200);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 200u);
+
+    /// Walk through remaining packed blocks in block 0
+    uint32_t prev = 200;
+    while (cursor->valid() && cursor->value() < 500)
+    {
+        EXPECT_GE(cursor->value(), prev);
+        prev = cursor->value();
+        cursor->next();
+    }
+
+    /// Should now be at block 1
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 1000u);
+
+    /// Walk through block 1
+    prev = 1000;
+    while (cursor->valid())
+    {
+        EXPECT_GE(cursor->value(), prev);
+        prev = cursor->value();
+        cursor->next();
+    }
+    EXPECT_EQ(prev, 1199u);
+}
+
+
+// ===========================================================================================
+// Section 46: Multi-block — single doc in block (doc_count == 1 equivalent)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockMinimalBlock)
+{
+    /// Block 0 with only 2 docs: first_doc_id + 1 encoded doc.
+    /// This is the minimum for the large block path (1 doc would be embedded).
+    std::vector<uint32_t> docs = {100, 200};
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, 100);
+    EXPECT_EQ(result, docs);
+}
+
+
+// ===========================================================================================
+// Section 47: Multi-block — many large blocks (10+) seek stress test
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockTenLargeBlocksSeekStress)
+{
+    /// 10 large blocks, each 130 docs, spaced 500 apart.
+    std::vector<std::vector<uint32_t>> blocks;
+    for (int i = 0; i < 10; ++i)
+        blocks.push_back(generateRange(static_cast<uint32_t>(i * 500), 130));
+
+    auto data = makeMultiBlockData(blocks);
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Forward seek to every block's last doc
+    for (int i = 0; i < 10; ++i)
+    {
+        uint32_t last_doc = static_cast<uint32_t>(i * 500 + 129);
+        cursor->seek(last_doc);
+        ASSERT_TRUE(cursor->valid()) << "Block " << i << " last doc seek failed";
+        EXPECT_EQ(cursor->value(), last_doc) << "Block " << i;
+    }
+
+    /// Seek beyond all
+    cursor->seek(5000);
+    EXPECT_FALSE(cursor->valid());
+}
+
+TEST(PostingListCursorTest, MultiBlockTenLargeBlocksFullDrain)
+{
+    std::vector<std::vector<uint32_t>> blocks;
+    for (int i = 0; i < 10; ++i)
+        blocks.push_back(generateRange(static_cast<uint32_t>(i * 500), 130));
+
+    auto data = makeMultiBlockData(blocks);
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = seekAndDrainCursor(cursor, data.all_docs.front());
+    EXPECT_EQ(result, data.all_docs);
+}
+
+TEST(PostingListCursorTest, MultiBlockTwentyLargeBlocksSeekSkip)
+{
+    /// 20 blocks — seek to every other block to test skipping.
+    std::vector<std::vector<uint32_t>> blocks;
+    for (int i = 0; i < 20; ++i)
+        blocks.push_back(generateRange(static_cast<uint32_t>(i * 300), 130));
+
+    auto data = makeMultiBlockData(blocks);
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to every even-numbered block
+    for (int i = 0; i < 20; i += 2)
+    {
+        uint32_t target = static_cast<uint32_t>(i * 300 + 50);
+        cursor->seek(target);
+        ASSERT_TRUE(cursor->valid()) << "Block " << i;
+        EXPECT_EQ(cursor->value(), target) << "Block " << i;
+    }
+}
+
+
+// ===========================================================================================
+// Section 48: Multi-block + Embedded mixed — brute-force path
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockWithEmbeddedBruteForceIntersect)
+{
+    /// Multi-block cursor A: [0..199], [500..699]
+    /// Embedded cursor B: all even numbers 0,2,4,...,698
+    /// Brute-force intersection: even numbers in [0..199] ∪ even numbers in [500..699]
+    auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
+    auto docsB = generateRange(0, 350, 2); // 0,2,4,...,698
+    auto infoB = makeEmbeddedInfo(docsB);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeEmbeddedCursor(infoB);
+
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 700, true);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 0; d < 200; d += 2) expected.push_back(d);
+    for (uint32_t d = 500; d < 700; d += 2) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockWithEmbeddedBruteForceThreeWay)
+{
+    /// 3-way brute-force: multi-block A, multi-block B, embedded C.
+    auto dataA = makeMultiBlockData({generateRange(0, 300)});
+    auto dataB = makeMultiBlockData({generateRange(100, 300)});
+    auto docsC = generateRange(150, 50); // 150..199
+    auto infoC = makeEmbeddedInfo(docsC);
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    postings["c"] = makeEmbeddedCursor(infoC);
+
+    auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 500, true);
+
+    /// A=[0..299], B=[100..399], C=[150..199]
+    /// Intersection = [150..199]
+    std::vector<uint32_t> expected = generateRange(150, 50);
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 49: Multi-block — linearOrImpl/linearAndImpl packed block skip/early-return branches
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockLinearOrPackedBlockSkipBeforeRange)
+{
+    /// 400 docs: first_doc_id=0, docs 0..399. Packed blocks:
+    ///   block 0: docs 0..128, block 1: docs 129..256, block 2: docs 257..384, tail: 385..399
+    /// linearOr with row_offset=300 should skip blocks 0 and 1 (back() < 300),
+    /// then process blocks 2 and tail.
+    std::vector<uint32_t> docs = generateRange(0, 400);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 300, 100); // [300, 400)
+    std::vector<uint32_t> expected = generateRange(300, 100);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearOrPackedBlockEarlyReturnAfterRange)
+{
+    /// Same 400 docs. linearOr with range [50, 150) should process block 0 and
+    /// part of block 1, then early-return when block 2's front > 150.
+    std::vector<uint32_t> docs = generateRange(0, 400);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 50, 100); // [50, 150)
+    std::vector<uint32_t> expected = generateRange(50, 100);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockLinearAndPackedBlockSkipAndEarlyReturn)
+{
+    /// Verify that linearAnd also correctly skips blocks before range and
+    /// stops early after range.
+    std::vector<uint32_t> docs = generateRange(0, 500);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    std::vector<UInt8> buf(100, 0);
+    cursor->linearAnd(buf.data(), 200, 100); // [200, 300)
+
+    for (size_t i = 0; i < 100; ++i)
+        EXPECT_EQ(buf[i], 1u) << "Expected buf[" << i << "] == 1 (doc " << (200 + i) << ")";
+}
+
+
+// ===========================================================================================
+// Section 50: Multi-block — union with multiple multi-block cursors
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockUnionThreeMultiBlockCursors)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 150)});   // 0..149
+    auto dataB = makeMultiBlockData({generateRange(200, 150)});  // 200..349
+    auto dataC = makeMultiBlockData({generateRange(400, 150)});  // 400..549
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    postings["c"] = makeMultiBlockCursor(dataC);
+
+    auto result = unionAndCollect(postings, {"a", "b", "c"}, 0, 600);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 0; d < 150; ++d) expected.push_back(d);
+    for (uint32_t d = 200; d < 350; ++d) expected.push_back(d);
+    for (uint32_t d = 400; d < 550; ++d) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockUnionOverlapping)
+{
+    /// Two multi-block cursors with overlapping doc ranges.
+    auto dataA = makeMultiBlockData({generateRange(0, 200)});   // 0..199
+    auto dataB = makeMultiBlockData({generateRange(100, 200)});  // 100..299
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+
+    auto result = unionAndCollect(postings, {"a", "b"}, 0, 300);
+
+    /// Union should be 0..299
+    std::vector<uint32_t> expected = generateRange(0, 300);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockUnionWithWindow)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
+    auto dataB = makeMultiBlockData({generateRange(300, 200)});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+
+    /// Window [250, 600) should capture: A's [500..599], B's [300..499]
+    auto result = unionAndCollect(postings, {"a", "b"}, 250, 350);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 300; d < 500; ++d) expected.push_back(d);
+    for (uint32_t d = 500; d < 600; ++d) expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+
+// ===========================================================================================
+// Section 51: Multi-block intersection — brute-force vs leapfrog consistency (3+ cursors)
+// ===========================================================================================
+
+TEST(PostingListCursorTest, MultiBlockBruteForceVsLeapfrogThreeWay)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 300), generateRange(500, 200)});
+    auto dataB = makeMultiBlockData({generateRange(50, 300), generateRange(550, 200)});
+    auto dataC = makeMultiBlockData({generateRange(100, 200), generateRange(600, 150)});
+
+    // Brute force
+    PostingListCursorMap postings_bf;
+    postings_bf["a"] = makeMultiBlockCursor(dataA);
+    postings_bf["b"] = makeMultiBlockCursor(dataB);
+    postings_bf["c"] = makeMultiBlockCursor(dataC);
+    auto bf = intersectAndCollect(postings_bf, {"a", "b", "c"}, 0, 800, true);
+
+    // Leapfrog
+    PostingListCursorMap postings_lf;
+    postings_lf["a"] = makeMultiBlockCursor(dataA);
+    postings_lf["b"] = makeMultiBlockCursor(dataB);
+    postings_lf["c"] = makeMultiBlockCursor(dataC);
+    auto lf = intersectAndCollect(postings_lf, {"a", "b", "c"}, 0, 800, false, 100.0);
+
+    EXPECT_EQ(bf, lf);
+
+    /// Also verify expected result:
+    /// A∩B∩C block0: [100..299] ∩ [50..349] ∩ [0..299] = [100..299]
+    /// A∩B∩C block1: [500..699] ∩ [550..749] ∩ [600..749] = [600..699]
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 100; d < 300; ++d) expected.push_back(d);
+    for (uint32_t d = 600; d < 700; ++d) expected.push_back(d);
+    EXPECT_EQ(bf, expected);
+}
+
+TEST(PostingListCursorTest, MultiBlockBruteForceVsLeapfrogFourWay)
+{
+    auto dataA = makeMultiBlockData({generateRange(0, 250)});
+    auto dataB = makeMultiBlockData({generateRange(50, 250)});
+    auto dataC = makeMultiBlockData({generateRange(100, 250)});
+    auto dataD = makeMultiBlockData({generateRange(150, 250)});
+
+    PostingListCursorMap postings_bf;
+    postings_bf["a"] = makeMultiBlockCursor(dataA);
+    postings_bf["b"] = makeMultiBlockCursor(dataB);
+    postings_bf["c"] = makeMultiBlockCursor(dataC);
+    postings_bf["d"] = makeMultiBlockCursor(dataD);
+    auto bf = intersectAndCollect(postings_bf, {"a", "b", "c", "d"}, 0, 500, true);
+
+    PostingListCursorMap postings_lf;
+    postings_lf["a"] = makeMultiBlockCursor(dataA);
+    postings_lf["b"] = makeMultiBlockCursor(dataB);
+    postings_lf["c"] = makeMultiBlockCursor(dataC);
+    postings_lf["d"] = makeMultiBlockCursor(dataD);
+    auto lf = intersectAndCollect(postings_lf, {"a", "b", "c", "d"}, 0, 500, false, 100.0);
+
+    EXPECT_EQ(bf, lf);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 150; d < 250; ++d) expected.push_back(d);
+    EXPECT_EQ(bf, expected);
+}

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -408,7 +408,7 @@ TEST(PostingListCursorTest, MultipleDocsSequentialIteration)
 
 TEST(PostingListCursorTest, LargeEmbeddedCursor)
 {
-    auto docs = generateRange(0, 1000);
+    auto docs = generateRange(0, 6);
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
@@ -418,7 +418,7 @@ TEST(PostingListCursorTest, LargeEmbeddedCursor)
 
 TEST(PostingListCursorTest, SparseEmbeddedCursor)
 {
-    auto docs = generateRange(100, 50, 100); // 100,200,...,5000
+    auto docs = generateRange(100, 5, 100); // 100,200,300,400,500
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
@@ -524,7 +524,7 @@ TEST(PostingListCursorTest, SeekBeforeFirst)
 
 TEST(PostingListCursorTest, SeekProgressivelyForward)
 {
-    std::vector<uint32_t> docs = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+    std::vector<uint32_t> docs = {10, 20, 30, 40, 50, 60};
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
@@ -536,11 +536,7 @@ TEST(PostingListCursorTest, SeekProgressivelyForward)
     ASSERT_TRUE(cursor->valid());
     EXPECT_EQ(cursor->value(), 60u);
 
-    cursor->seek(100);
-    ASSERT_TRUE(cursor->valid());
-    EXPECT_EQ(cursor->value(), 100u);
-
-    cursor->seek(101);
+    cursor->seek(61);
     EXPECT_FALSE(cursor->valid());
 }
 
@@ -577,7 +573,7 @@ TEST(PostingListCursorTest, CardinalityReflectsDocCount)
 
 TEST(PostingListCursorTest, DensityPerfectlyDense)
 {
-    auto docs = generateRange(0, 100);
+    auto docs = generateRange(0, 5);
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
     EXPECT_DOUBLE_EQ(cursor->density(), 1.0);
@@ -646,11 +642,11 @@ TEST(PostingListCursorTest, LinearOrSingleRowMatch)
 
 TEST(PostingListCursorTest, LinearOrDenseRange)
 {
-    auto docs = generateRange(100, 500);
+    auto docs = generateRange(100, 6);
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
-    auto result = linearOrToDocIds(cursor, 0, 700);
+    auto result = linearOrToDocIds(cursor, 0, 110);
     EXPECT_EQ(result, docs);
 }
 
@@ -747,14 +743,12 @@ TEST(PostingListCursorTest, IntersectTwoDenseVsSparse)
     auto dense_docs = generateRange(0, 1000);
     auto sparse_docs = generateRange(0, 100, 10); // 0,10,20,...,990
 
-    auto info1 = makeEmbeddedInfo(dense_docs);
-    auto info2 = makeEmbeddedInfo(sparse_docs);
-    auto c1 = makeEmbeddedCursor(info1);
-    auto c2 = makeEmbeddedCursor(info2);
+    auto dataD = makeMultiBlockData({dense_docs});
+    auto dataS = makeMultiBlockData({sparse_docs});
 
     PostingListCursorMap postings;
-    postings["dense"] = c1;
-    postings["sparse"] = c2;
+    postings["dense"] = makeMultiBlockCursor(dataD);
+    postings["sparse"] = makeMultiBlockCursor(dataS);
 
     auto result = intersectAndCollect(postings, {"dense", "sparse"}, 0, 1000, false, 100.0);
     EXPECT_EQ(result, sparse_docs);
@@ -834,7 +828,7 @@ TEST(PostingListCursorTest, IntersectThreeNoCommon)
 
 TEST(PostingListCursorTest, IntersectFourAllOverlap)
 {
-    auto docs = generateRange(0, 20, 5);
+    auto docs = generateRange(0, 5, 10); // 0,10,20,30,40
     auto info1 = makeEmbeddedInfo(docs);
     auto info2 = makeEmbeddedInfo(docs);
     auto info3 = makeEmbeddedInfo(docs);
@@ -846,7 +840,7 @@ TEST(PostingListCursorTest, IntersectFourAllOverlap)
     postings["c"] = makeEmbeddedCursor(info3);
     postings["d"] = makeEmbeddedCursor(info4);
 
-    auto result = intersectAndCollect(postings, {"a", "b", "c", "d"}, 0, 100, false, 100.0);
+    auto result = intersectAndCollect(postings, {"a", "b", "c", "d"}, 0, 50, false, 100.0);
     EXPECT_EQ(result, docs);
 }
 
@@ -861,16 +855,16 @@ TEST(PostingListCursorTest, IntersectFourMixedSelectivity)
     // Sparsest: every 7th
     auto docs4 = generateRange(0, 143, 7);
 
-    auto info1 = makeEmbeddedInfo(docs1);
-    auto info2 = makeEmbeddedInfo(docs2);
-    auto info3 = makeEmbeddedInfo(docs3);
-    auto info4 = makeEmbeddedInfo(docs4);
+    auto data1 = makeMultiBlockData({docs1});
+    auto data2 = makeMultiBlockData({docs2});
+    auto data3 = makeMultiBlockData({docs3});
+    auto data4 = makeMultiBlockData({docs4});
 
     PostingListCursorMap postings;
-    postings["a"] = makeEmbeddedCursor(info1);
-    postings["b"] = makeEmbeddedCursor(info2);
-    postings["c"] = makeEmbeddedCursor(info3);
-    postings["d"] = makeEmbeddedCursor(info4);
+    postings["a"] = makeMultiBlockCursor(data1);
+    postings["b"] = makeMultiBlockCursor(data2);
+    postings["c"] = makeMultiBlockCursor(data3);
+    postings["d"] = makeMultiBlockCursor(data4);
 
     auto result = intersectAndCollect(postings, {"a", "b", "c", "d"}, 0, 1000, false, 100.0);
 
@@ -895,18 +889,18 @@ TEST(PostingListCursorTest, IntersectFiveCursors)
     auto docs4 = generateRange(0, 143, 7);
     auto docs5 = generateRange(0, 91, 11);
 
-    auto info1 = makeEmbeddedInfo(docs1);
-    auto info2 = makeEmbeddedInfo(docs2);
-    auto info3 = makeEmbeddedInfo(docs3);
-    auto info4 = makeEmbeddedInfo(docs4);
-    auto info5 = makeEmbeddedInfo(docs5);
+    auto data1 = makeMultiBlockData({docs1});
+    auto data2 = makeMultiBlockData({docs2});
+    auto data3 = makeMultiBlockData({docs3});
+    auto data4 = makeMultiBlockData({docs4});
+    auto data5 = makeMultiBlockData({docs5});
 
     PostingListCursorMap postings;
-    postings["a"] = makeEmbeddedCursor(info1);
-    postings["b"] = makeEmbeddedCursor(info2);
-    postings["c"] = makeEmbeddedCursor(info3);
-    postings["d"] = makeEmbeddedCursor(info4);
-    postings["e"] = makeEmbeddedCursor(info5);
+    postings["a"] = makeMultiBlockCursor(data1);
+    postings["b"] = makeMultiBlockCursor(data2);
+    postings["c"] = makeMultiBlockCursor(data3);
+    postings["d"] = makeMultiBlockCursor(data4);
+    postings["e"] = makeMultiBlockCursor(data5);
 
     auto result = intersectAndCollect(postings, {"a", "b", "c", "d", "e"}, 0, 1000, false, 100.0);
     // Only 0 is common (LCM=2310, next would be 2310 which is >= 1000)
@@ -915,21 +909,21 @@ TEST(PostingListCursorTest, IntersectFiveCursors)
 
 TEST(PostingListCursorTest, IntersectEightCursors)
 {
-    auto docs = generateRange(0, 10, 10); // 0,10,...,90
-    std::vector<TokenPostingsInfo> infos(8);
+    auto docs = generateRange(0, 6, 10); // 0,10,20,30,40,50
+    std::vector<MultiBlockTestData> datas(8);
     PostingListCursorMap postings;
     std::vector<String> tokens;
 
     for (int i = 0; i < 8; ++i)
     {
-        infos[i] = makeEmbeddedInfo(docs);
+        datas[i] = makeMultiBlockData({docs});
         String name = "t" + std::to_string(i);
         tokens.push_back(name);
     }
     for (int i = 0; i < 8; ++i)
-        postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+        postings[tokens[i]] = makeMultiBlockCursor(datas[i]);
 
-    auto result = intersectAndCollect(postings, tokens, 0, 100, false, 100.0);
+    auto result = intersectAndCollect(postings, tokens, 0, 60, false, 100.0);
     EXPECT_EQ(result, docs);
 }
 
@@ -960,7 +954,7 @@ TEST(PostingListCursorTest, IntersectNineCursorsHeap)
 
 TEST(PostingListCursorTest, IntersectTenCursorsWithVaryingDocs)
 {
-    std::vector<TokenPostingsInfo> infos(10);
+    std::vector<MultiBlockTestData> datas(10);
     PostingListCursorMap postings;
     std::vector<String> tokens;
 
@@ -975,8 +969,8 @@ TEST(PostingListCursorTest, IntersectTenCursorsWithVaryingDocs)
         std::vector<uint32_t> docs;
         for (uint32_t d = 0; d < 1000; d += (i + 1))
             docs.push_back(d);
-        infos[i] = makeEmbeddedInfo(docs);
-        postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+        datas[i] = makeMultiBlockData({docs});
+        postings[tokens[i]] = makeMultiBlockCursor(datas[i]);
     }
 
     auto result = intersectAndCollect(postings, tokens, 0, 1000, false, 100.0);
@@ -1026,7 +1020,7 @@ TEST(PostingListCursorTest, BruteForceVsLeapfrogConsistency)
 
     for (int trial = 0; trial < 10; ++trial)
     {
-        std::vector<TokenPostingsInfo> infos(3);
+        std::vector<MultiBlockTestData> datas(3);
         std::vector<std::vector<uint32_t>> all_docs(3);
 
         for (int i = 0; i < 3; ++i)
@@ -1036,21 +1030,21 @@ TEST(PostingListCursorTest, BruteForceVsLeapfrogConsistency)
             while (s.size() < count)
                 s.insert(dist(rng));
             all_docs[i].assign(s.begin(), s.end());
-            infos[i] = makeEmbeddedInfo(all_docs[i]);
+            datas[i] = makeMultiBlockData({all_docs[i]});
         }
 
         // Brute force
         PostingListCursorMap postings_bf;
-        postings_bf["a"] = makeEmbeddedCursor(infos[0]);
-        postings_bf["b"] = makeEmbeddedCursor(infos[1]);
-        postings_bf["c"] = makeEmbeddedCursor(infos[2]);
+        postings_bf["a"] = makeMultiBlockCursor(datas[0]);
+        postings_bf["b"] = makeMultiBlockCursor(datas[1]);
+        postings_bf["c"] = makeMultiBlockCursor(datas[2]);
         auto bf_result = intersectAndCollect(postings_bf, {"a", "b", "c"}, 0, 1000, true);
 
         // Leapfrog (low density threshold to force leapfrog)
         PostingListCursorMap postings_lf;
-        postings_lf["a"] = makeEmbeddedCursor(infos[0]);
-        postings_lf["b"] = makeEmbeddedCursor(infos[1]);
-        postings_lf["c"] = makeEmbeddedCursor(infos[2]);
+        postings_lf["a"] = makeMultiBlockCursor(datas[0]);
+        postings_lf["b"] = makeMultiBlockCursor(datas[1]);
+        postings_lf["c"] = makeMultiBlockCursor(datas[2]);
         auto lf_result = intersectAndCollect(postings_lf, {"a", "b", "c"}, 0, 1000, false, 100.0);
 
         EXPECT_EQ(bf_result, lf_result) << "Brute-force vs leapfrog mismatch at trial " << trial;
@@ -1266,12 +1260,12 @@ TEST(PostingListCursorTest, StressRandomIntersectTwo)
         std::vector<uint32_t> expected;
         std::set_intersection(s1.begin(), s1.end(), s2.begin(), s2.end(), std::back_inserter(expected));
 
-        auto info1 = makeEmbeddedInfo(v1);
-        auto info2 = makeEmbeddedInfo(v2);
+        auto data1 = makeMultiBlockData({v1});
+        auto data2 = makeMultiBlockData({v2});
 
         PostingListCursorMap postings;
-        postings["a"] = makeEmbeddedCursor(info1);
-        postings["b"] = makeEmbeddedCursor(info2);
+        postings["a"] = makeMultiBlockCursor(data1);
+        postings["b"] = makeMultiBlockCursor(data2);
 
         auto result = intersectAndCollect(postings, {"a", "b"}, 0, 10000, false, 100.0);
         EXPECT_EQ(result, expected) << "Mismatch at trial " << trial;
@@ -1287,7 +1281,7 @@ TEST(PostingListCursorTest, StressRandomIntersectFour)
         std::uniform_int_distribution<uint32_t> dist(0, 4999);
 
         std::vector<std::set<uint32_t>> sets(4);
-        std::vector<TokenPostingsInfo> infos(4);
+        std::vector<MultiBlockTestData> datas(4);
         PostingListCursorMap postings;
         std::vector<String> tokens;
 
@@ -1297,13 +1291,13 @@ TEST(PostingListCursorTest, StressRandomIntersectFour)
             while (sets[i].size() < sz) sets[i].insert(dist(rng));
 
             std::vector<uint32_t> v(sets[i].begin(), sets[i].end());
-            infos[i] = makeEmbeddedInfo(v);
+            datas[i] = makeMultiBlockData({v});
 
             String name = "t" + std::to_string(i);
             tokens.push_back(name);
         }
         for (int i = 0; i < 4; ++i)
-            postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+            postings[tokens[i]] = makeMultiBlockCursor(datas[i]);
 
         // Compute expected 4-way intersection
         std::vector<uint32_t> tmp1, tmp2, expected;
@@ -1325,7 +1319,7 @@ TEST(PostingListCursorTest, StressRandomUnion)
         std::uniform_int_distribution<uint32_t> dist(0, 999);
 
         std::set<uint32_t> all;
-        std::vector<TokenPostingsInfo> infos(3);
+        std::vector<MultiBlockTestData> datas(3);
         PostingListCursorMap postings;
         std::vector<String> tokens;
 
@@ -1337,13 +1331,13 @@ TEST(PostingListCursorTest, StressRandomUnion)
             all.insert(s.begin(), s.end());
 
             std::vector<uint32_t> v(s.begin(), s.end());
-            infos[i] = makeEmbeddedInfo(v);
+            datas[i] = makeMultiBlockData({v});
 
             String name = "t" + std::to_string(i);
             tokens.push_back(name);
         }
         for (int i = 0; i < 3; ++i)
-            postings[tokens[i]] = makeEmbeddedCursor(infos[i]);
+            postings[tokens[i]] = makeMultiBlockCursor(datas[i]);
 
         std::vector<uint32_t> expected(all.begin(), all.end());
         auto result = unionAndCollect(postings, tokens, 0, 1000);
@@ -1359,13 +1353,14 @@ TEST(PostingListCursorTest, StressRandomUnion)
 TEST(PostingListCursorTest, IntersectOneCursorEndsEarly)
 {
     auto info1 = makeEmbeddedInfo({10, 20, 30});
-    auto info2 = makeEmbeddedInfo({10, 20, 30, 40, 50, 60, 70, 80, 90, 100});
+    auto docs2 = generateRange(10, 6, 10); // 10,20,30,40,50,60
+    auto info2 = makeEmbeddedInfo(docs2);
 
     PostingListCursorMap postings;
     postings["short"] = makeEmbeddedCursor(info1);
     postings["long"] = makeEmbeddedCursor(info2);
 
-    auto result = intersectAndCollect(postings, {"short", "long"}, 0, 110, false, 100.0);
+    auto result = intersectAndCollect(postings, {"short", "long"}, 0, 70, false, 100.0);
     std::vector<uint32_t> expected = {10, 20, 30};
     EXPECT_EQ(result, expected);
 }
@@ -1409,12 +1404,12 @@ TEST(PostingListCursorTest, BruteForceDenseLargeRange)
     auto docs1 = generateRange(0, 5000);
     auto docs2 = generateRange(0, 2500, 2); // 0,2,4,...,4998
 
-    auto info1 = makeEmbeddedInfo(docs1);
-    auto info2 = makeEmbeddedInfo(docs2);
+    auto data1 = makeMultiBlockData({docs1});
+    auto data2 = makeMultiBlockData({docs2});
 
     PostingListCursorMap postings;
-    postings["a"] = makeEmbeddedCursor(info1);
-    postings["b"] = makeEmbeddedCursor(info2);
+    postings["a"] = makeMultiBlockCursor(data1);
+    postings["b"] = makeMultiBlockCursor(data2);
 
     auto result = intersectAndCollect(postings, {"a", "b"}, 0, 5000, true);
     EXPECT_EQ(result, docs2);
@@ -1427,7 +1422,7 @@ TEST(PostingListCursorTest, BruteForceDenseLargeRange)
 
 TEST(PostingListCursorTest, AlternatingSeekAndNext)
 {
-    auto docs = generateRange(0, 100, 3); // 0,3,6,...,297
+    auto docs = generateRange(0, 6, 3); // 0,3,6,9,12,15
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
@@ -1435,7 +1430,17 @@ TEST(PostingListCursorTest, AlternatingSeekAndNext)
     ASSERT_TRUE(cursor->valid());
     EXPECT_EQ(cursor->value(), 0u);
 
-    // Seek to 10 -> should land on 12 (first multiple of 3 >= 10)
+    // Seek to 2 -> should land on 3 (first multiple of 3 >= 2)
+    cursor->seek(2);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 3u);
+
+    // next() -> 6
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 6u);
+
+    // Seek to 10 -> should land on 12
     cursor->seek(10);
     ASSERT_TRUE(cursor->valid());
     EXPECT_EQ(cursor->value(), 12u);
@@ -1444,31 +1449,6 @@ TEST(PostingListCursorTest, AlternatingSeekAndNext)
     cursor->next();
     ASSERT_TRUE(cursor->valid());
     EXPECT_EQ(cursor->value(), 15u);
-
-    // Seek to 100 -> should land on 102
-    cursor->seek(100);
-    ASSERT_TRUE(cursor->valid());
-    EXPECT_EQ(cursor->value(), 102u);
-
-    // next() -> 105
-    cursor->next();
-    ASSERT_TRUE(cursor->valid());
-    EXPECT_EQ(cursor->value(), 105u);
-
-    // Seek way ahead to 290 -> 291
-    cursor->seek(290);
-    ASSERT_TRUE(cursor->valid());
-    EXPECT_EQ(cursor->value(), 291u);
-
-    // next() -> 294
-    cursor->next();
-    ASSERT_TRUE(cursor->valid());
-    EXPECT_EQ(cursor->value(), 294u);
-
-    // next() -> 297
-    cursor->next();
-    ASSERT_TRUE(cursor->valid());
-    EXPECT_EQ(cursor->value(), 297u);
 
     // next() -> invalid
     cursor->next();
@@ -1487,7 +1467,7 @@ TEST(PostingListCursorTest, AlternatingSeekAndNext)
 /// all elements.
 TEST(PostingListCursorTest, NextExhaustsAllElementsProperly)
 {
-    auto docs = generateRange(0, 500);
+    auto docs = generateRange(0, 6);
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
@@ -1498,7 +1478,7 @@ TEST(PostingListCursorTest, NextExhaustsAllElementsProperly)
         cursor->next();
         ++count;
     }
-    EXPECT_EQ(count, 500u);
+    EXPECT_EQ(count, 6u);
 }
 
 /// The seek() bug: seek on the slow path should start from the next large block,
@@ -1536,14 +1516,14 @@ TEST(PostingListCursorTest, DensityThresholdSwitchesAlgorithm)
     // Two dense cursors: density ~= 1.0
     auto docs1 = generateRange(0, 100);
     auto docs2 = generateRange(0, 100);
-    auto info1 = makeEmbeddedInfo(docs1);
-    auto info2 = makeEmbeddedInfo(docs2);
+    auto data1 = makeMultiBlockData({docs1});
+    auto data2 = makeMultiBlockData({docs2});
 
     // With high threshold → leapfrog
     {
         PostingListCursorMap postings;
-        postings["a"] = makeEmbeddedCursor(info1);
-        postings["b"] = makeEmbeddedCursor(info2);
+        postings["a"] = makeMultiBlockCursor(data1);
+        postings["b"] = makeMultiBlockCursor(data2);
         auto result = intersectAndCollect(postings, {"a", "b"}, 0, 100, false, 100.0);
         EXPECT_EQ(result, docs1);
     }
@@ -1551,8 +1531,8 @@ TEST(PostingListCursorTest, DensityThresholdSwitchesAlgorithm)
     // With low threshold → brute-force (density 1.0 >= 0.1)
     {
         PostingListCursorMap postings;
-        postings["a"] = makeEmbeddedCursor(info1);
-        postings["b"] = makeEmbeddedCursor(info2);
+        postings["a"] = makeMultiBlockCursor(data1);
+        postings["b"] = makeMultiBlockCursor(data2);
         auto result = intersectAndCollect(postings, {"a", "b"}, 0, 100, false, 0.1f);
         EXPECT_EQ(result, docs1);
     }
@@ -1569,11 +1549,11 @@ TEST(PostingListCursorTest, HighlyAsymmetricCardinalities)
     auto info1 = makeEmbeddedInfo({500});
     // Cursor B: 5000 docs
     auto docs2 = generateRange(0, 5000);
-    auto info2 = makeEmbeddedInfo(docs2);
+    auto data2 = makeMultiBlockData({docs2});
 
     PostingListCursorMap postings;
     postings["a"] = makeEmbeddedCursor(info1);
-    postings["b"] = makeEmbeddedCursor(info2);
+    postings["b"] = makeMultiBlockCursor(data2);
 
     auto result = intersectAndCollect(postings, {"a", "b"}, 0, 5000, false, 100.0);
     EXPECT_EQ(result, std::vector<uint32_t>{500});
@@ -1583,11 +1563,11 @@ TEST(PostingListCursorTest, OneEmptyOneFullIntersection)
 {
     auto info1 = makeEmbeddedInfo({});
     auto docs2 = generateRange(0, 100);
-    auto info2 = makeEmbeddedInfo(docs2);
+    auto data2 = makeMultiBlockData({docs2});
 
     PostingListCursorMap postings;
     postings["empty"] = makeEmbeddedCursor(info1);
-    postings["full"] = makeEmbeddedCursor(info2);
+    postings["full"] = makeMultiBlockCursor(data2);
 
     // The empty cursor is invalid from the start, so intersect should return empty.
     // But since the cursor is invalid after seek(0), intersect returns immediately.
@@ -1602,14 +1582,14 @@ TEST(PostingListCursorTest, OneEmptyOneFullIntersection)
 
 TEST(PostingListCursorTest, ConsecutiveDocIds)
 {
-    auto docs = generateRange(1000, 200);
+    auto docs = generateRange(1000, 6);
     auto info = makeEmbeddedInfo(docs);
     auto cursor = makeEmbeddedCursor(info);
 
     auto result = drainCursor(cursor);
-    EXPECT_EQ(result.size(), 200u);
+    EXPECT_EQ(result.size(), 6u);
     EXPECT_EQ(result.front(), 1000u);
-    EXPECT_EQ(result.back(), 1199u);
+    EXPECT_EQ(result.back(), 1005u);
 }
 
 
@@ -2717,12 +2697,11 @@ TEST(PostingListCursorTest, MultiBlockWithEmbeddedBruteForceIntersect)
     /// Embedded cursor B: all even numbers 0,2,4,...,698
     /// Brute-force intersection: even numbers in [0..199] ∪ even numbers in [500..699]
     auto dataA = makeMultiBlockData({generateRange(0, 200), generateRange(500, 200)});
-    auto docsB = generateRange(0, 350, 2); // 0,2,4,...,698
-    auto infoB = makeEmbeddedInfo(docsB);
+    auto dataB = makeMultiBlockData({generateRange(0, 350, 2)}); // 0,2,4,...,698
 
     PostingListCursorMap postings;
     postings["a"] = makeMultiBlockCursor(dataA);
-    postings["b"] = makeEmbeddedCursor(infoB);
+    postings["b"] = makeMultiBlockCursor(dataB);
 
     auto result = intersectAndCollect(postings, {"a", "b"}, 0, 700, true);
 
@@ -2737,13 +2716,12 @@ TEST(PostingListCursorTest, MultiBlockWithEmbeddedBruteForceThreeWay)
     /// 3-way brute-force: multi-block A, multi-block B, embedded C.
     auto dataA = makeMultiBlockData({generateRange(0, 300)});
     auto dataB = makeMultiBlockData({generateRange(100, 300)});
-    auto docsC = generateRange(150, 50); // 150..199
-    auto infoC = makeEmbeddedInfo(docsC);
+    auto dataC = makeMultiBlockData({generateRange(150, 50)}); // 150..199
 
     PostingListCursorMap postings;
     postings["a"] = makeMultiBlockCursor(dataA);
     postings["b"] = makeMultiBlockCursor(dataB);
-    postings["c"] = makeEmbeddedCursor(infoC);
+    postings["c"] = makeMultiBlockCursor(dataC);
 
     auto result = intersectAndCollect(postings, {"a", "b", "c"}, 0, 500, true);
 

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -2401,22 +2401,21 @@ TEST(PostingListCursorTest, MultiBlockDensitySparseBlock0)
 
 TEST(PostingListCursorTest, MultiBlockDensityAfterSeekToSecondLargeBlock)
 {
-    /// Block 0: 0..199 (dense).
+    /// Block 0: 0..199 (dense, 200 docs).
     /// Block 1: 500,502,504,...,698 → 100 docs, step 2.
-    /// After seek to block 1: large_block_doc_count = 100, range = (500,698), span = 199.
-    /// density = 100 / 199
+    /// Global density = cardinality / (global_end - global_begin + 1) = 300 / 699.
+    /// Density is computed once at construction and does not change after seek.
     std::vector<uint32_t> block0 = generateRange(0, 200);
     std::vector<uint32_t> block1 = generateRange(500, 100, 2); // 500,502,...,698
     auto data = makeMultiBlockData({block0, block1});
     auto cursor = makeMultiBlockCursor(data);
 
-    /// After construction, density reflects block 0 = 1.0
-    EXPECT_DOUBLE_EQ(cursor->density(), 1.0);
+    double expected_density = 300.0 / 699.0;
+    EXPECT_NEAR(cursor->density(), expected_density, 1e-6);
 
-    /// Seek to block 1 triggers prepare(1), which updates density
+    /// Seek to block 1 — density stays the same (global).
     cursor->seek(500);
     ASSERT_TRUE(cursor->valid());
-    double expected_density = 100.0 / 199.0;
     EXPECT_NEAR(cursor->density(), expected_density, 1e-6);
 }
 

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <numeric>
 #include <random>
+#include <set>
 #include <vector>
 
 using namespace DB;
@@ -2900,4 +2901,552 @@ TEST(PostingListCursorTest, MultiBlockBruteForceVsLeapfrogFourWay)
     std::vector<uint32_t> expected;
     for (uint32_t d = 150; d < 250; ++d) expected.push_back(d);
     EXPECT_EQ(bf, expected);
+}
+
+
+// ===========================================================================================
+// Section: Arithmetic block skip optimization tests
+//
+// These tests verify that the TurboPFor constant/zero-delta block fast-skip
+// optimization produces identical results to full decompression.  Key scenarios:
+//   - Zero-delta blocks (consecutive doc_ids, step=1)
+//   - Constant-delta blocks (uniform step > 1)
+//   - Mixed blocks (some arithmetic, some not)
+//   - seek/next/linearOr/linearAnd/intersection through arithmetic blocks
+//   - Tail blocks (< 128 elements) that are arithmetic
+//   - Large block 0 packed block 0 is excluded (prepend_first_doc_id)
+//   - Transitions between arithmetic and non-arithmetic blocks
+// ===========================================================================================
+
+/// Zero-delta block: 257 consecutive docs → packed block 0 (128, prepend, not arithmetic),
+/// packed block 1 (128, zero-delta → arithmetic).  Seek into the arithmetic block.
+TEST(PostingListCursorTest, ArithmeticZeroDeltaSeekDrain)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to a doc_id in the second packed block (block 1, which is arithmetic).
+    cursor->seek(200);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 200u);
+
+    /// Drain the rest and verify.
+    auto remaining = drainCursor(cursor);
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 200; d <= 256; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(remaining, expected);
+}
+
+/// Zero-delta: full drain via seek(0) + next.
+TEST(PostingListCursorTest, ArithmeticZeroDeltaFullDrain)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto all = seekAndDrainCursor(cursor, 0);
+    EXPECT_EQ(all, docs);
+}
+
+/// Zero-delta: linearOr over the full range.
+TEST(PostingListCursorTest, ArithmeticZeroDeltaLinearOr)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 260);
+    EXPECT_EQ(result, docs);
+}
+
+/// Zero-delta: linearOr with a partial range that clips into the arithmetic block.
+TEST(PostingListCursorTest, ArithmeticZeroDeltaLinearOrPartialRange)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Request range [150, 230) — starts in packed block 1 (arithmetic).
+    auto result = linearOrToDocIds(cursor, 150, 80);
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 150; d < 230; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+/// Zero-delta: linearAnd over full range.
+TEST(PostingListCursorTest, ArithmeticZeroDeltaLinearAnd)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    std::vector<UInt8> buf(260, 0);
+    cursor->linearAnd(buf.data(), 0, 260);
+    /// linearAnd increments counters; check that the arithmetic block docs are counted.
+    for (uint32_t d = 0; d <= 256; ++d)
+        EXPECT_EQ(buf[d], 1u) << "at doc_id " << d;
+    for (uint32_t d = 257; d < 260; ++d)
+        EXPECT_EQ(buf[d], 0u);
+}
+
+/// Constant-delta block: step=3 (constant_value=2).
+/// 257 docs with step 3: block 1 is constant-delta arithmetic.
+TEST(PostingListCursorTest, ArithmeticConstantDeltaSeekDrain)
+{
+    auto docs = generateRange(0, 257, 3);  // 0, 3, 6, 9, ..., 768
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to something in the second packed block (arithmetic, step=3).
+    /// Block 1 starts at docs[129] = 129*3 = 387.
+    cursor->seek(400);
+    ASSERT_TRUE(cursor->valid());
+    /// 400 is not a multiple of 3 from 0, so we expect the next multiple: ceil((400-387)/3)*3 + 387
+    /// docs in block 1: 387, 390, 393, ...; first >= 400 is 402.
+    EXPECT_EQ(cursor->value(), 402u);
+
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 405u);
+}
+
+/// Constant-delta: full drain.
+TEST(PostingListCursorTest, ArithmeticConstantDeltaFullDrain)
+{
+    auto docs = generateRange(0, 257, 3);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto all = seekAndDrainCursor(cursor, 0);
+    EXPECT_EQ(all, docs);
+}
+
+/// Constant-delta: linearOr.
+TEST(PostingListCursorTest, ArithmeticConstantDeltaLinearOr)
+{
+    auto docs = generateRange(0, 257, 3);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 770);
+    EXPECT_EQ(result, docs);
+}
+
+/// Constant-delta: seek to exact arithmetic value.
+TEST(PostingListCursorTest, ArithmeticConstantDeltaSeekExact)
+{
+    auto docs = generateRange(10, 257, 5);  // 10, 15, 20, ..., 10 + 256*5 = 1290
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to 650 (which is 10 + 128*5 = 650, first doc of block 1).
+    cursor->seek(650);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 650u);
+}
+
+/// Constant-delta: seek to first and last doc of arithmetic block.
+TEST(PostingListCursorTest, ArithmeticSeekFirstAndLastOfBlock)
+{
+    auto docs = generateRange(0, 257, 2);  // 0, 2, 4, ..., 512
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Block 1 (arithmetic): docs[129]=258 to docs[256]=512.
+    cursor->seek(258);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 258u);
+
+    /// Re-create cursor, seek to last doc of block 1.
+    auto cursor2 = makeMultiBlockCursor(data);
+    cursor2->seek(512);
+    ASSERT_TRUE(cursor2->valid());
+    EXPECT_EQ(cursor2->value(), 512u);
+
+    cursor2->next();
+    EXPECT_FALSE(cursor2->valid());
+}
+
+/// Seek within arithmetic block then next() transitions to next block.
+TEST(PostingListCursorTest, ArithmeticNextTransitionsToNextBlock)
+{
+    /// 385 consecutive docs → docs_to_encode = 384 → 3 packed blocks of 128.
+    /// Blocks 1 and 2 are zero-delta arithmetic.
+    auto docs = generateRange(0, 385);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek to last element of block 1: docs[256]=256.
+    cursor->seek(256);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 256u);
+
+    /// next() should transition to block 2 (also arithmetic).
+    cursor->next();
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 257u);
+}
+
+/// Mixed: first block is non-arithmetic, second block is arithmetic.
+TEST(PostingListCursorTest, ArithmeticMixedNonArithThenArith)
+{
+    std::vector<uint32_t> docs;
+    docs.push_back(0);  // first_doc_id
+
+    /// Block 0: 128 docs with variable gaps (non-constant delta).
+    uint32_t prev = 0;
+    std::mt19937 rng(42);
+    for (int i = 0; i < 128; ++i)
+    {
+        prev += 1 + (rng() % 5);  // gap 1-5 (variable → non-constant delta)
+        docs.push_back(prev);
+    }
+
+    /// Block 1: 128 consecutive docs after prev (step=1 → zero-delta).
+    for (int i = 0; i < 128; ++i)
+    {
+        ++prev;
+        docs.push_back(prev);
+    }
+
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto all = seekAndDrainCursor(cursor, 0);
+    EXPECT_EQ(all, docs);
+}
+
+/// Seek across a mixed sequence: seek from non-arithmetic block into arithmetic block.
+TEST(PostingListCursorTest, ArithmeticSeekFromNonArithToArith)
+{
+    std::vector<uint32_t> docs;
+    docs.push_back(0);
+
+    uint32_t prev = 0;
+    std::mt19937 rng(123);
+    for (int i = 0; i < 128; ++i)
+    {
+        prev += 1 + (rng() % 10);
+        docs.push_back(prev);
+    }
+
+    /// Block 1: 128 docs with step=1 starting from prev+1.
+    uint32_t block1_start = prev + 1;
+    for (int i = 0; i < 128; ++i)
+        docs.push_back(block1_start + static_cast<uint32_t>(i));
+
+    auto data = makeMultiBlockData({docs});
+
+    /// Seek from block 0 into block 1.
+    auto cursor = makeMultiBlockCursor(data);
+    cursor->seek(block1_start + 50);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), block1_start + 50);
+}
+
+/// Tail block (< 128 elements) that is arithmetic.
+TEST(PostingListCursorTest, ArithmeticTailBlock)
+{
+    /// 179 docs consecutive → docs_to_encode=178 → packed block 0 (128) + tail block (50, zero-delta arithmetic).
+    auto docs = generateRange(0, 179);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek into the tail block.
+    cursor->seek(140);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 140u);
+
+    auto remaining = drainCursor(cursor);
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 140; d <= 178; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(remaining, expected);
+}
+
+/// Tail block with constant delta > 1.
+TEST(PostingListCursorTest, ArithmeticTailBlockConstantDelta)
+{
+    /// 179 docs with step 4.
+    auto docs = generateRange(0, 179, 4);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Tail block starts at docs[129] = 129 * 4 = 516.
+    cursor->seek(516);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 516u);
+
+    /// Seek to non-exact value in tail.
+    auto cursor2 = makeMultiBlockCursor(data);
+    cursor2->seek(520);
+    ASSERT_TRUE(cursor2->valid());
+    EXPECT_EQ(cursor2->value(), 520u);
+
+    auto cursor3 = makeMultiBlockCursor(data);
+    cursor3->seek(519);
+    ASSERT_TRUE(cursor3->valid());
+    EXPECT_EQ(cursor3->value(), 520u);
+}
+
+/// Block 0 of large block 0 is NOT arithmetic (prepend_first_doc_id).
+/// Verify that the optimization does not apply to it.
+TEST(PostingListCursorTest, ArithmeticBlock0NotOptimized)
+{
+    /// 129 consecutive docs: docs_to_encode has 128 (one full packed block).
+    /// This packed block 0 has prepend_first_doc_id, so it should NOT be arithmetic.
+    auto docs = generateRange(0, 129);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Should still work correctly — full decode path.
+    auto all = seekAndDrainCursor(cursor, 0);
+    EXPECT_EQ(all, docs);
+}
+
+/// Intersection (leapfrog) with arithmetic blocks.
+TEST(PostingListCursorTest, ArithmeticIntersectTwoLeapfrog)
+{
+    /// Cursor A: 257 consecutive docs [0..256], block 1 is arithmetic.
+    auto docsA = generateRange(0, 257);
+    auto dataA = makeMultiBlockData({docsA});
+
+    /// Cursor B: 257 docs with step 2 [0, 2, 4, ..., 512], block 1 is arithmetic.
+    auto docsB = generateRange(0, 257, 2);
+    auto dataB = makeMultiBlockData({docsB});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 520, false, 100.0);
+
+    /// Intersection: even numbers from 0 to 256.
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 0; d <= 256; d += 2)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+/// Intersection (brute force) with arithmetic blocks.
+TEST(PostingListCursorTest, ArithmeticIntersectTwoBruteForce)
+{
+    auto docsA = generateRange(0, 257);
+    auto dataA = makeMultiBlockData({docsA});
+
+    auto docsB = generateRange(0, 257, 2);
+    auto dataB = makeMultiBlockData({docsB});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    auto result = intersectAndCollect(postings, {"a", "b"}, 0, 520, true);
+
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 0; d <= 256; d += 2)
+        expected.push_back(d);
+    EXPECT_EQ(result, expected);
+}
+
+/// Union with arithmetic blocks.
+TEST(PostingListCursorTest, ArithmeticUnionTwo)
+{
+    auto docsA = generateRange(0, 257);
+    auto dataA = makeMultiBlockData({docsA});
+
+    auto docsB = generateRange(300, 130, 2);  // 300, 302, ..., 558
+    auto dataB = makeMultiBlockData({docsB});
+
+    PostingListCursorMap postings;
+    postings["a"] = makeMultiBlockCursor(dataA);
+    postings["b"] = makeMultiBlockCursor(dataB);
+    auto result = unionAndCollect(postings, {"a", "b"}, 0, 600);
+
+    /// Build expected: union of both sets.
+    std::set<uint32_t> expected_set(docsA.begin(), docsA.end());
+    expected_set.insert(docsB.begin(), docsB.end());
+    std::vector<uint32_t> expected(expected_set.begin(), expected_set.end());
+    EXPECT_EQ(result, expected);
+}
+
+/// Multiple packed blocks, all arithmetic (zero-delta), drain through all.
+TEST(PostingListCursorTest, ArithmeticMultipleBlocksAllZeroDelta)
+{
+    /// 513 consecutive docs → docs_to_encode has 512 → 4 packed blocks of 128,
+    /// blocks 1,2,3 are all zero-delta arithmetic.
+    auto docs = generateRange(0, 513);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto all = seekAndDrainCursor(cursor, 0);
+    EXPECT_EQ(all, docs);
+}
+
+/// Multiple packed blocks, all arithmetic, linearOr.
+TEST(PostingListCursorTest, ArithmeticMultipleBlocksLinearOr)
+{
+    auto docs = generateRange(0, 513);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 520);
+    EXPECT_EQ(result, docs);
+}
+
+/// Seek to every doc_id in an arithmetic block to verify correctness.
+TEST(PostingListCursorTest, ArithmeticSeekEveryDocInBlock)
+{
+    auto docs = generateRange(0, 257, 3);
+    auto data = makeMultiBlockData({docs});
+
+    /// Block 1 contains docs[129]=387 to docs[256]=768.
+    for (uint32_t target = 387; target <= 768; target += 3)
+    {
+        auto cursor = makeMultiBlockCursor(data);
+        cursor->seek(target);
+        ASSERT_TRUE(cursor->valid()) << "target=" << target;
+        EXPECT_EQ(cursor->value(), target) << "target=" << target;
+    }
+}
+
+/// Seek to values between arithmetic doc_ids (non-exact).
+TEST(PostingListCursorTest, ArithmeticSeekBetweenDocs)
+{
+    auto docs = generateRange(0, 257, 5);  // 0, 5, 10, ..., 1280
+    auto data = makeMultiBlockData({docs});
+
+    /// Block 1 starts at docs[129] = 645.
+    for (uint32_t target = 646; target <= 660; ++target)
+    {
+        if (target % 5 == 0) continue;  // skip exact matches
+        auto cursor = makeMultiBlockCursor(data);
+        cursor->seek(target);
+        ASSERT_TRUE(cursor->valid()) << "target=" << target;
+        /// Should land on the next multiple of 5 >= target.
+        uint32_t expected_val = ((target + 4) / 5) * 5;
+        EXPECT_EQ(cursor->value(), expected_val) << "target=" << target;
+    }
+}
+
+/// Seek beyond the last doc of an arithmetic block.
+TEST(PostingListCursorTest, ArithmeticSeekBeyondBlock)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    cursor->seek(300);
+    EXPECT_FALSE(cursor->valid());
+}
+
+/// Brute force vs leapfrog consistency with arithmetic blocks.
+TEST(PostingListCursorTest, ArithmeticBruteForceVsLeapfrogConsistency)
+{
+    auto docsA = generateRange(0, 385);
+    auto dataA = makeMultiBlockData({docsA});
+
+    auto docsB = generateRange(0, 257, 2);
+    auto dataB = makeMultiBlockData({docsB});
+
+    auto docsC = generateRange(100, 200);
+    auto dataC = makeMultiBlockData({docsC});
+
+    PostingListCursorMap postings_bf;
+    postings_bf["a"] = makeMultiBlockCursor(dataA);
+    postings_bf["b"] = makeMultiBlockCursor(dataB);
+    postings_bf["c"] = makeMultiBlockCursor(dataC);
+    auto bf = intersectAndCollect(postings_bf, {"a", "b", "c"}, 0, 520, true);
+
+    PostingListCursorMap postings_lf;
+    postings_lf["a"] = makeMultiBlockCursor(dataA);
+    postings_lf["b"] = makeMultiBlockCursor(dataB);
+    postings_lf["c"] = makeMultiBlockCursor(dataC);
+    auto lf = intersectAndCollect(postings_lf, {"a", "b", "c"}, 0, 520, false, 100.0);
+
+    EXPECT_EQ(bf, lf);
+}
+
+/// Two large blocks where the second large block has arithmetic blocks.
+TEST(PostingListCursorTest, ArithmeticSecondLargeBlock)
+{
+    auto block0 = generateRange(0, 150);     // 1 packed block + 22 tail
+    auto block1 = generateRange(200, 257);   // 2 packed blocks, block 1 is arithmetic
+
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek into the arithmetic block of the second large block.
+    /// block1 docs_to_encode starts from docs[0]=200 with delta_base=199.
+    /// Packed block 0 of large block 1: docs[0..127] = 200..327.
+    /// Packed block 1 of large block 1: docs[128..256] = 328..456 — arithmetic.
+    cursor->seek(350);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 350u);
+
+    auto remaining = drainCursor(cursor);
+    std::vector<uint32_t> expected;
+    for (uint32_t d = 350; d <= 456; ++d)
+        expected.push_back(d);
+    EXPECT_EQ(remaining, expected);
+}
+
+/// linearOr spanning two large blocks, second has arithmetic blocks.
+TEST(PostingListCursorTest, ArithmeticSecondLargeBlockLinearOr)
+{
+    auto block0 = generateRange(0, 150);
+    auto block1 = generateRange(200, 257);
+
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 460);
+
+    std::set<uint32_t> expected_set;
+    for (auto d : block0) expected_set.insert(d);
+    for (auto d : block1) expected_set.insert(d);
+    std::vector<uint32_t> expected(expected_set.begin(), expected_set.end());
+    EXPECT_EQ(result, expected);
+}
+
+/// Large constant-delta value (step=100).
+TEST(PostingListCursorTest, ArithmeticLargeStep)
+{
+    auto docs = generateRange(0, 257, 100);  // 0, 100, 200, ..., 25600
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto all = seekAndDrainCursor(cursor, 0);
+    EXPECT_EQ(all, docs);
+
+    /// linearOr
+    auto cursor2 = makeMultiBlockCursor(data);
+    auto result = linearOrToDocIds(cursor2, 0, 25700);
+    EXPECT_EQ(result, docs);
+}
+
+/// Seek repeatedly within the same arithmetic block (cache hit path).
+TEST(PostingListCursorTest, ArithmeticRepeatedSeekSameBlock)
+{
+    auto docs = generateRange(0, 257);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    /// Seek multiple times within block 1 (arithmetic).
+    cursor->seek(130);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 130u);
+
+    cursor->seek(150);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 150u);
+
+    cursor->seek(200);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 200u);
+
+    cursor->seek(256);
+    ASSERT_TRUE(cursor->valid());
+    EXPECT_EQ(cursor->value(), 256u);
 }

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -248,8 +248,8 @@ MultiBlockTestData makeMultiBlockData(const std::vector<std::vector<uint32_t>> &
         }
 
         UInt32 large_block_doc_count = static_cast<UInt32>(docs_to_encode.size());
-        UInt32 num_full_blocks = large_block_doc_count / 128;
-        UInt32 tail_count = large_block_doc_count % 128;
+        UInt32 num_full_blocks = large_block_doc_count / TURBOPFOR_BLOCK_SIZE;
+        UInt32 tail_count = large_block_doc_count % TURBOPFOR_BLOCK_SIZE;
         UInt32 num_packed_blocks = num_full_blocks + (tail_count > 0 ? 1 : 0);
 
         /// Data Section: encode packed blocks
@@ -262,7 +262,7 @@ MultiBlockTestData makeMultiBlockData(const std::vector<std::vector<uint32_t>> &
 
         for (UInt32 pb = 0; pb < num_packed_blocks; ++pb)
         {
-            UInt32 count = (pb == num_packed_blocks - 1 && tail_count > 0) ? tail_count : 128;
+            UInt32 count = (pb == num_packed_blocks - 1 && tail_count > 0) ? tail_count : static_cast<UInt32>(TURBOPFOR_BLOCK_SIZE);
 
             /// Compute delta-1 array
             std::vector<UInt32> deltas(count);
@@ -274,8 +274,8 @@ MultiBlockTestData makeMultiBlockData(const std::vector<std::vector<uint32_t>> &
 
             /// TurboPFor encode
             uint8_t * encoded_end;
-            if (count == 128)
-                encoded_end = turbopfor::p4Enc128v32(deltas.data(), 128, packed_buffer);
+            if (count == TURBOPFOR_BLOCK_SIZE)
+                encoded_end = turbopfor::p4Enc128v32(deltas.data(), TURBOPFOR_BLOCK_SIZE, packed_buffer);
             else
                 encoded_end = turbopfor::p4Enc32(deltas.data(), count, packed_buffer);
 

--- a/tests/performance/run_text_index_benchmark.sh
+++ b/tests/performance/run_text_index_benchmark.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+#
+# Text Index Apply Mode Benchmark Script
+# Usage: ./run_text_index_benchmark.sh [clickhouse-client-path] [iterations]
+#
+# This script benchmarks three modes:
+# - lazy: Compressed posting lists with lazy cursor-based decoding
+# - materialize: Compressed posting lists with full materialization
+# - uncompressed: Traditional roaring bitmap
+#
+
+set -e
+
+CLICKHOUSE_CLIENT="${1:-clickhouse-client}"
+ITERATIONS="${2:-5}"
+ROWS=1000000
+
+echo "=========================================="
+echo "Text Index Apply Mode Benchmark"
+echo "=========================================="
+echo "ClickHouse client: $CLICKHOUSE_CLIENT"
+echo "Iterations per query: $ITERATIONS"
+echo "Total rows: $ROWS"
+echo ""
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up tables..."
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS text_index_lazy"
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS text_index_materialize"
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS text_index_uncompressed"
+}
+
+# Setup tables
+setup() {
+    echo "Creating tables..."
+
+    # LAZY mode
+    $CLICKHOUSE_CLIENT --query "
+    CREATE TABLE text_index_lazy (
+        id UInt64,
+        text String,
+        INDEX idx_text (text) TYPE text(tokenizer = 'splitByNonAlpha', posting_list_codec = 'bitpacking', posting_list_apply_mode = 'lazy')
+    ) ENGINE = MergeTree ORDER BY id
+    "
+
+    # MATERIALIZE mode
+    $CLICKHOUSE_CLIENT --query "
+    CREATE TABLE text_index_materialize (
+        id UInt64,
+        text String,
+        INDEX idx_text (text) TYPE text(tokenizer = 'splitByNonAlpha', posting_list_codec = 'bitpacking', posting_list_apply_mode = 'materialize')
+    ) ENGINE = MergeTree ORDER BY id
+    "
+
+    # UNCOMPRESSED mode
+    $CLICKHOUSE_CLIENT --query "
+    CREATE TABLE text_index_uncompressed (
+        id UInt64,
+        text String,
+        INDEX idx_text (text) TYPE text(tokenizer = 'splitByNonAlpha')
+    ) ENGINE = MergeTree ORDER BY id
+    "
+
+    echo "Inserting data (this may take a while)..."
+
+    # Insert data with various token distributions
+    $CLICKHOUSE_CLIENT --query "
+    INSERT INTO text_index_lazy
+    SELECT
+        number AS id,
+        concat(
+            if(rand(number) % 1000 = 0, 'rare_alpha ', ''),
+            if(rand(number + 1) % 1000 = 1, 'rare_beta ', ''),
+            if(rand(number + 2) % 1000 = 2, 'rare_gamma ', ''),
+            if(rand(number + 3) % 1000 = 3, 'rare_delta ', ''),
+            if(rand(number + 10) % 20 = 0, 'medium_one ', ''),
+            if(rand(number + 11) % 20 = 1, 'medium_two ', ''),
+            if(rand(number + 12) % 20 = 2, 'medium_three ', ''),
+            if(rand(number + 13) % 20 = 3, 'medium_four ', ''),
+            if(rand(number + 20) % 10 < 3, 'frequent_x ', ''),
+            if(rand(number + 21) % 10 < 3, 'frequent_y ', ''),
+            if(rand(number + 22) % 10 < 3, 'frequent_z ', ''),
+            if(rand(number + 30) % 5 < 4, 'common ', ''),
+            'text_content_', toString(number % 100)
+        ) AS text
+    FROM numbers($ROWS)
+    "
+
+    $CLICKHOUSE_CLIENT --query "INSERT INTO text_index_materialize SELECT * FROM text_index_lazy"
+    $CLICKHOUSE_CLIENT --query "INSERT INTO text_index_uncompressed SELECT * FROM text_index_lazy"
+
+    echo "Data insertion complete."
+    echo ""
+}
+
+# Run a single benchmark
+run_benchmark() {
+    local description="$1"
+    local query_lazy="$2"
+    local query_materialize="$3"
+    local query_uncompressed="$4"
+
+    echo "--- $description ---"
+
+    # Run with timing
+    printf "  lazy:        "
+    $CLICKHOUSE_CLIENT --time --format Null --query "$query_lazy" 2>&1 | tail -1
+
+    printf "  materialize: "
+    $CLICKHOUSE_CLIENT --time --format Null --query "$query_materialize" 2>&1 | tail -1
+
+    printf "  uncompressed:"
+    $CLICKHOUSE_CLIENT --time --format Null --query "$query_uncompressed" 2>&1 | tail -1
+
+    echo ""
+}
+
+# Run benchmarks using clickhouse-benchmark for more accurate results
+run_benchmark_accurate() {
+    local description="$1"
+    local query_lazy="$2"
+    local query_materialize="$3"
+    local query_uncompressed="$4"
+
+    echo "--- $description ---"
+
+    printf "  lazy:        "
+    echo "$query_lazy" | clickhouse-benchmark -i $ITERATIONS 2>&1 | grep -E "^[0-9]" | head -1
+
+    printf "  materialize: "
+    echo "$query_materialize" | clickhouse-benchmark -i $ITERATIONS 2>&1 | grep -E "^[0-9]" | head -1
+
+    printf "  uncompressed:"
+    echo "$query_uncompressed" | clickhouse-benchmark -i $ITERATIONS 2>&1 | grep -E "^[0-9]" | head -1
+
+    echo ""
+}
+
+SETTINGS="SETTINGS force_data_skipping_indices='idx_text', enable_full_text_index=1, query_plan_direct_read_from_text_index=1"
+
+# Main execution
+trap cleanup EXIT
+
+cleanup
+setup
+
+echo "=========================================="
+echo "Running Benchmarks"
+echo "=========================================="
+echo ""
+
+echo "=== Group 1: Single Token Queries ==="
+run_benchmark "Single rare token (~0.1% rows)" \
+    "SELECT count() FROM text_index_lazy WHERE hasToken(text, 'rare_alpha') $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasToken(text, 'rare_alpha') $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'rare_alpha') $SETTINGS"
+
+run_benchmark "Single medium token (~5% rows)" \
+    "SELECT count() FROM text_index_lazy WHERE hasToken(text, 'medium_one') $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasToken(text, 'medium_one') $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'medium_one') $SETTINGS"
+
+run_benchmark "Single frequent token (~30% rows)" \
+    "SELECT count() FROM text_index_lazy WHERE hasToken(text, 'frequent_x') $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasToken(text, 'frequent_x') $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'frequent_x') $SETTINGS"
+
+run_benchmark "Single common token (~80% rows)" \
+    "SELECT count() FROM text_index_lazy WHERE hasToken(text, 'common') $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasToken(text, 'common') $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'common') $SETTINGS"
+
+echo "=== Group 2: Union Queries (hasAnyTokens) ==="
+run_benchmark "Union 2 rare tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta']) $SETTINGS"
+
+run_benchmark "Union 4 medium tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) $SETTINGS"
+
+run_benchmark "Union 3 frequent tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) $SETTINGS"
+
+echo "=== Group 3: Intersection Queries (hasAllTokens) ==="
+run_benchmark "Intersect 2 rare tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['rare_alpha', 'rare_beta']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['rare_alpha', 'rare_beta']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['rare_alpha', 'rare_beta']) $SETTINGS"
+
+run_benchmark "Intersect 2 medium tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['medium_one', 'medium_two']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['medium_one', 'medium_two']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['medium_one', 'medium_two']) $SETTINGS"
+
+run_benchmark "Intersect 4 medium tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) $SETTINGS"
+
+run_benchmark "Intersect 2 frequent tokens" \
+    "SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['frequent_x', 'frequent_y']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['frequent_x', 'frequent_y']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['frequent_x', 'frequent_y']) $SETTINGS"
+
+run_benchmark "Intersect rare + frequent (skip-list advantage)" \
+    "SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['rare_alpha', 'frequent_x']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['rare_alpha', 'frequent_x']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['rare_alpha', 'frequent_x']) $SETTINGS"
+
+echo "=== Group 4: Edge Cases ==="
+run_benchmark "Non-existent token" \
+    "SELECT count() FROM text_index_lazy WHERE hasToken(text, 'nonexistent_xyz') $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasToken(text, 'nonexistent_xyz') $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'nonexistent_xyz') $SETTINGS"
+
+run_benchmark "Intersect with non-existent token" \
+    "SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['frequent_x', 'nonexistent_xyz']) $SETTINGS" \
+    "SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['frequent_x', 'nonexistent_xyz']) $SETTINGS" \
+    "SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['frequent_x', 'nonexistent_xyz']) $SETTINGS"
+
+echo "=========================================="
+echo "Benchmark Complete"
+echo "=========================================="

--- a/tests/performance/text_index_apply_mode.xml
+++ b/tests/performance/text_index_apply_mode.xml
@@ -1,0 +1,225 @@
+<test>
+  <!--
+  Performance benchmark for text index apply modes:
+  - lazy: Compressed posting lists with lazy cursor-based decoding
+  - materialize: Compressed posting lists with full materialization to roaring bitmap
+  - uncompressed: Traditional uncompressed roaring bitmap storage
+
+  Test dimensions:
+  1. Query type: hasToken, hasAnyTokens (union/OR), hasAllTokens (intersection/AND)
+  2. Posting list length: short (rare tokens), medium, long (frequent tokens)
+  3. Posting list density: sparse (low selectivity), dense (high selectivity)
+  4. Number of tokens: single, few (2-3), many (4+)
+  -->
+
+  <settings>
+      <enable_full_text_index>1</enable_full_text_index>
+      <use_skip_indexes_on_data_read>1</use_skip_indexes_on_data_read>
+      <query_plan_direct_read_from_text_index>1</query_plan_direct_read_from_text_index>
+  </settings>
+
+  <!-- ==================== Table Creation ==================== -->
+  <!-- Table with LAZY apply mode (compressed + cursor-based) -->
+  <create_query>
+    CREATE TABLE text_index_lazy (
+        id UInt64,
+        text String,
+        INDEX idx_text (text) TYPE text(tokenizer = 'splitByNonAlpha', posting_list_codec = 'bitpacking', posting_list_apply_mode = 'lazy')
+    ) ENGINE = MergeTree ORDER BY id;
+  </create_query>
+
+  <!-- Table with MATERIALIZE apply mode (compressed + roaring bitmap) -->
+  <create_query>
+    CREATE TABLE text_index_materialize (
+        id UInt64,
+        text String,
+        INDEX idx_text (text) TYPE text(tokenizer = 'splitByNonAlpha', posting_list_codec = 'bitpacking', posting_list_apply_mode = 'materialize')
+    ) ENGINE = MergeTree ORDER BY id;
+  </create_query>
+
+  <!-- Table with UNCOMPRESSED mode (traditional roaring bitmap) -->
+  <create_query>
+    CREATE TABLE text_index_uncompressed (
+        id UInt64,
+        text String,
+        INDEX idx_text (text) TYPE text(tokenizer = 'splitByNonAlpha')
+    ) ENGINE = MergeTree ORDER BY id;
+  </create_query>
+
+  <!-- ==================== Data Generation ==================== -->
+  <!--
+  Data design strategy:
+  - Total rows: 1,000,000 (1M rows for meaningful performance comparison)
+  - Token distribution:
+    * rare_XXX: appears in ~0.1% rows (sparse, short posting list ~1K entries)
+    * medium_XXX: appears in ~5% rows (medium density ~50K entries)
+    * frequent_XXX: appears in ~30% rows (dense, long posting list ~300K entries)
+    * common: appears in ~80% rows (very dense ~800K entries)
+  -->
+  <fill_query>
+    INSERT INTO text_index_lazy
+    SELECT
+        number AS id,
+        concat(
+            -- Rare tokens (0.1% each): sparse posting lists
+            if(rand(number) % 1000 = 0, 'rare_alpha ', ''),
+            if(rand(number + 1) % 1000 = 1, 'rare_beta ', ''),
+            if(rand(number + 2) % 1000 = 2, 'rare_gamma ', ''),
+            if(rand(number + 3) % 1000 = 3, 'rare_delta ', ''),
+            -- Medium tokens (5% each): medium posting lists
+            if(rand(number + 10) % 20 = 0, 'medium_one ', ''),
+            if(rand(number + 11) % 20 = 1, 'medium_two ', ''),
+            if(rand(number + 12) % 20 = 2, 'medium_three ', ''),
+            if(rand(number + 13) % 20 = 3, 'medium_four ', ''),
+            -- Frequent tokens (30% each): dense posting lists
+            if(rand(number + 20) % 10 &lt; 3, 'frequent_x ', ''),
+            if(rand(number + 21) % 10 &lt; 3, 'frequent_y ', ''),
+            if(rand(number + 22) % 10 &lt; 3, 'frequent_z ', ''),
+            -- Very common token (80%): very dense posting list
+            if(rand(number + 30) % 5 &lt; 4, 'common ', ''),
+            -- Base content
+            'text_content_', toString(number % 100)
+        ) AS text
+    FROM numbers(1000000);
+  </fill_query>
+
+  <fill_query>
+    INSERT INTO text_index_materialize SELECT * FROM text_index_lazy;
+  </fill_query>
+
+  <fill_query>
+    INSERT INTO text_index_uncompressed SELECT * FROM text_index_lazy;
+  </fill_query>
+
+  <!-- ==================== Benchmark Queries ==================== -->
+
+  <!-- ========== Group 1: Single Token Queries (hasToken) ========== -->
+  <!-- Tests basic posting list traversal performance -->
+
+  <!-- 1.1 Rare token (sparse, ~1K rows) -->
+  <query tag="single_rare_lazy">SELECT count() FROM text_index_lazy WHERE hasToken(text, 'rare_alpha') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_rare_materialize">SELECT count() FROM text_index_materialize WHERE hasToken(text, 'rare_alpha') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_rare_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'rare_alpha') SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 1.2 Medium frequency token (~50K rows) -->
+  <query tag="single_medium_lazy">SELECT count() FROM text_index_lazy WHERE hasToken(text, 'medium_one') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_medium_materialize">SELECT count() FROM text_index_materialize WHERE hasToken(text, 'medium_one') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_medium_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'medium_one') SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 1.3 Frequent token (dense, ~300K rows) -->
+  <query tag="single_frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasToken(text, 'frequent_x') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasToken(text, 'frequent_x') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'frequent_x') SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 1.4 Very common token (very dense, ~800K rows) -->
+  <query tag="single_common_lazy">SELECT count() FROM text_index_lazy WHERE hasToken(text, 'common') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_common_materialize">SELECT count() FROM text_index_materialize WHERE hasToken(text, 'common') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="single_common_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'common') SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- ========== Group 2: Union Queries (hasAnyTokens / OR) ========== -->
+  <!-- Tests lazyUnionPostingLists performance -->
+
+  <!-- 2.1 Union of 2 rare tokens (small union result) -->
+  <query tag="union_2rare_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_2rare_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_2rare_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 2.2 Union of 4 rare tokens -->
+  <query tag="union_4rare_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta', 'rare_gamma', 'rare_delta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_4rare_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta', 'rare_gamma', 'rare_delta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_4rare_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['rare_alpha', 'rare_beta', 'rare_gamma', 'rare_delta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 2.3 Union of 2 medium tokens -->
+  <query tag="union_2medium_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['medium_one', 'medium_two']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_2medium_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['medium_one', 'medium_two']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_2medium_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['medium_one', 'medium_two']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 2.4 Union of 4 medium tokens -->
+  <query tag="union_4medium_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_4medium_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_4medium_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 2.5 Union of 2 frequent tokens (large union result) -->
+  <query tag="union_2frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_2frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_2frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 2.6 Union of 3 frequent tokens -->
+  <query tag="union_3frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_3frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_3frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 2.7 Mixed union: rare + medium + frequent -->
+  <query tag="union_mixed_lazy">SELECT count() FROM text_index_lazy WHERE hasAnyTokens(text, ['rare_alpha', 'medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_mixed_materialize">SELECT count() FROM text_index_materialize WHERE hasAnyTokens(text, ['rare_alpha', 'medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="union_mixed_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAnyTokens(text, ['rare_alpha', 'medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- ========== Group 3: Intersection Queries (hasAllTokens / AND) ========== -->
+  <!-- Tests lazyIntersectPostingLists performance -->
+
+  <!-- 3.1 Intersection of 2 rare tokens (very small result) -->
+  <query tag="intersect_2rare_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['rare_alpha', 'rare_beta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_2rare_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['rare_alpha', 'rare_beta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_2rare_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['rare_alpha', 'rare_beta']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.2 Intersection of 2 medium tokens -->
+  <query tag="intersect_2medium_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['medium_one', 'medium_two']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_2medium_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['medium_one', 'medium_two']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_2medium_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['medium_one', 'medium_two']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.3 Intersection of 4 medium tokens (smaller result) -->
+  <query tag="intersect_4medium_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_4medium_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_4medium_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['medium_one', 'medium_two', 'medium_three', 'medium_four']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.4 Intersection of 2 frequent tokens (medium result) -->
+  <query tag="intersect_2frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['frequent_x', 'frequent_y']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_2frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['frequent_x', 'frequent_y']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_2frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['frequent_x', 'frequent_y']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.5 Intersection of 3 frequent tokens -->
+  <query tag="intersect_3frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_3frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_3frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['frequent_x', 'frequent_y', 'frequent_z']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.6 Mixed intersection: rare + frequent (result bounded by rare) -->
+  <query tag="intersect_rare_frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['rare_alpha', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_rare_frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['rare_alpha', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_rare_frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['rare_alpha', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.7 Mixed intersection: medium + frequent -->
+  <query tag="intersect_medium_frequent_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_medium_frequent_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_medium_frequent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- 3.8 Complex intersection: rare + medium + frequent -->
+  <query tag="intersect_mixed_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['rare_alpha', 'medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_mixed_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['rare_alpha', 'medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_mixed_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['rare_alpha', 'medium_one', 'frequent_x']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- ========== Group 4: Non-existent Token (Edge Case) ========== -->
+  <!-- Tests early termination behavior -->
+  <query tag="nonexistent_lazy">SELECT count() FROM text_index_lazy WHERE hasToken(text, 'nonexistent_xyz') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="nonexistent_materialize">SELECT count() FROM text_index_materialize WHERE hasToken(text, 'nonexistent_xyz') SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="nonexistent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasToken(text, 'nonexistent_xyz') SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- Intersection with non-existent token (should return 0 quickly) -->
+  <query tag="intersect_nonexistent_lazy">SELECT count() FROM text_index_lazy WHERE hasAllTokens(text, ['frequent_x', 'nonexistent_xyz']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_nonexistent_materialize">SELECT count() FROM text_index_materialize WHERE hasAllTokens(text, ['frequent_x', 'nonexistent_xyz']) SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="intersect_nonexistent_uncompressed">SELECT count() FROM text_index_uncompressed WHERE hasAllTokens(text, ['frequent_x', 'nonexistent_xyz']) SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- ========== Group 5: Result Retrieval (not just count) ========== -->
+  <!-- Tests full row retrieval performance with LIMIT -->
+  <query tag="select_rare_lazy">SELECT id FROM text_index_lazy WHERE hasToken(text, 'rare_alpha') ORDER BY id LIMIT 100 SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="select_rare_materialize">SELECT id FROM text_index_materialize WHERE hasToken(text, 'rare_alpha') ORDER BY id LIMIT 100 SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="select_rare_uncompressed">SELECT id FROM text_index_uncompressed WHERE hasToken(text, 'rare_alpha') ORDER BY id LIMIT 100 SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <query tag="select_frequent_lazy">SELECT id FROM text_index_lazy WHERE hasToken(text, 'frequent_x') ORDER BY id LIMIT 100 SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="select_frequent_materialize">SELECT id FROM text_index_materialize WHERE hasToken(text, 'frequent_x') ORDER BY id LIMIT 100 SETTINGS force_data_skipping_indices='idx_text'</query>
+  <query tag="select_frequent_uncompressed">SELECT id FROM text_index_uncompressed WHERE hasToken(text, 'frequent_x') ORDER BY id LIMIT 100 SETTINGS force_data_skipping_indices='idx_text'</query>
+
+  <!-- ========== Cleanup ========== -->
+  <drop_query>DROP TABLE IF EXISTS text_index_lazy</drop_query>
+  <drop_query>DROP TABLE IF EXISTS text_index_materialize</drop_query>
+  <drop_query>DROP TABLE IF EXISTS text_index_uncompressed</drop_query>
+</test>

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode.reference
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode.reference
@@ -1,0 +1,29 @@
+Test text_index_posting_list_apply_mode = materialize (default)
+101	Alick a01
+106	Alick a06
+111	Alick b01
+116	Alick b06
+101	Alick a01
+101	Alick a01
+111	Alick b01
+Test text_index_posting_list_apply_mode = lazy
+101	Alick a01
+106	Alick a06
+111	Alick b01
+116	Alick b06
+101	Alick a01
+101	Alick a01
+111	Alick b01
+Test lazy mode with multi-token AND (hasToken intersection)
+101	Alick a01
+101	Alick a01
+Test lazy mode with IN operator
+101	Alick a01
+106	Alick a06
+101	Alick a01
+106	Alick a06
+Test lazy mode with merged parts
+101	Alick a01
+201	rick c01
+101	Alick a01
+201	rick c01

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode.reference
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode.reference
@@ -27,3 +27,135 @@ Test lazy mode with merged parts
 201	rick c01
 101	Alick a01
 201	rick c01
+Test lazy mode with hasAnyTokens (OR union)
+101	Alick a01
+103	Click a03
+106	Alick a06
+108	Click a08
+111	Alick b01
+113	Click b03
+116	Alick b06
+118	Click b08
+101	Alick a01
+103	Click a03
+106	Alick a06
+108	Click a08
+111	Alick b01
+113	Click b03
+116	Alick b06
+118	Click b08
+Test lazy mode with hasAllTokens (AND intersection)
+101	Alick a01
+101	Alick a01
+Test lazy mode with hasAnyTokens string form
+102	Blick a02
+103	Click a03
+107	Blick a07
+108	Click a08
+112	Blick b02
+113	Click b03
+117	Blick b07
+118	Click b08
+102	Blick a02
+103	Click a03
+107	Blick a07
+108	Click a08
+112	Blick b02
+113	Click b03
+117	Blick b07
+118	Click b08
+Test lazy mode with hasAllTokens string form
+106	Alick a06
+106	Alick a06
+Test lazy mode with empty result
+Test lazy mode with large dataset (>128 rows, TurboPFor block boundary)
+50
+50
+50
+50
+1
+1
+3
+3
+Test lazy mode with multiple segments (multi-insert without merge)
+1	alpha beta
+3	alpha gamma
+5	alpha epsilon
+9	alpha iota
+1	alpha beta
+3	alpha gamma
+5	alpha epsilon
+9	alpha iota
+1	alpha beta
+1	alpha beta
+5	alpha epsilon
+6	beta zeta
+5	alpha epsilon
+6	beta zeta
+1	alpha beta
+3	alpha gamma
+5	alpha epsilon
+9	alpha iota
+1	alpha beta
+3	alpha gamma
+5	alpha epsilon
+9	alpha iota
+Test lazy mode with UTF-8 data and ngram tokenizer
+1	你好世界
+3	你好朋友
+1	你好世界
+3	你好朋友
+1	你好世界
+2	世界和平
+1	你好世界
+2	世界和平
+Test lazy mode with 3-way AND intersection
+101	Alick a01
+116	Alick b06
+116	Alick b06
+Test lazy mode with OR of hasToken
+101	Alick a01
+102	Blick a02
+106	Alick a06
+107	Blick a07
+111	Alick b01
+112	Blick b02
+116	Alick b06
+117	Blick b07
+101	Alick a01
+102	Blick a02
+106	Alick a06
+107	Blick a07
+111	Alick b01
+112	Blick b02
+116	Alick b06
+117	Blick b07
+Test lazy mode consistency with direct read
+1	hello world
+3	hello foo
+1	hello world
+3	hello foo
+1	hello world
+1	hello world
+1	hello world
+2	foo bar
+3	hello foo
+4	bar baz
+1	hello world
+2	foo bar
+3	hello foo
+4	bar baz
+Test lazy mode with large posting list and block-level index
+50
+50
+50
+50
+1
+1
+3
+3
+Test lazy mode with large posting list block-level index after merge
+50
+50
+50
+50

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode.sql
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode.sql
@@ -1,0 +1,296 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
+SET enable_full_text_index = 1;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+SET use_skip_indexes_on_data_read = 0;
+
+----------------------------------------------------
+SELECT 'Test text_index_posting_list_apply_mode = materialize (default)';
+
+DROP TABLE IF EXISTS tab_mode;
+
+CREATE TABLE tab_mode(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_mode VALUES (101, 'Alick a01'), (102, 'Blick a02'), (103, 'Click a03'), (104, 'Dlick a04'), (105, 'Elick a05'), (106, 'Alick a06'), (107, 'Blick a07'), (108, 'Click a08'), (109, 'Dlick a09'), (110, 'Elick a10'), (111, 'Alick b01'), (112, 'Blick b02'), (113, 'Click b03'), (114, 'Dlick b04'), (115, 'Elick b05'), (116, 'Alick b06'), (117, 'Blick b07'), (118, 'Click b08'), (119, 'Dlick b09'), (120, 'Elick b10');
+
+-- materialize mode: search with hasToken
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') ORDER BY k;
+
+-- materialize mode: search with ==
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE s == 'Alick a01';
+
+-- materialize mode: search with LIKE
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE s LIKE '%01%' ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test text_index_posting_list_apply_mode = lazy';
+
+-- lazy mode: search with hasToken
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') ORDER BY k;
+
+-- lazy mode: search with ==
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE s == 'Alick a01';
+
+-- lazy mode: search with LIKE
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE s LIKE '%01%' ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with multi-token AND (hasToken intersection)';
+
+-- lazy mode: multi-token AND search
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') AND hasToken(s, 'a01') ORDER BY k;
+
+-- materialize mode: same query for comparison
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') AND hasToken(s, 'a01') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with IN operator';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE s IN ('Alick a01', 'Alick a06') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE s IN ('Alick a01', 'Alick a06') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with merged parts';
+
+DROP TABLE IF EXISTS tab_merge;
+
+CREATE TABLE tab_merge(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = ngrams(2)))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_merge VALUES (101, 'Alick a01'), (102, 'Blick a02'), (103, 'Click a03'), (104, 'Dlick a04');
+INSERT INTO tab_merge VALUES (201, 'rick c01'), (202, 'mick c02'), (203, 'nick c03');
+
+OPTIMIZE TABLE tab_merge FINAL;
+
+-- lazy mode after merge
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_merge WHERE s LIKE '%01%' ORDER BY k;
+
+-- materialize mode after merge
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_merge WHERE s LIKE '%01%' ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with hasAnyTokens (OR union)';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasAnyTokens(s, ['Alick', 'Click']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasAnyTokens(s, ['Alick', 'Click']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with hasAllTokens (AND intersection)';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasAllTokens(s, ['Alick', 'a01']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasAllTokens(s, ['Alick', 'a01']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with hasAnyTokens string form';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasAnyTokens(s, 'Blick Click') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasAnyTokens(s, 'Blick Click') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with hasAllTokens string form';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasAllTokens(s, 'Alick a06') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasAllTokens(s, 'Alick a06') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with empty result';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasToken(s, 'nonexistent') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasAllTokens(s, ['Alick', 'nonexistent']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with large dataset (>128 rows, TurboPFor block boundary)';
+
+DROP TABLE IF EXISTS tab_large;
+
+CREATE TABLE tab_large(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_large SELECT number, concat('token_', toString(number % 10), ' word_', toString(number)) FROM numbers(500);
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_large WHERE hasToken(s, 'token_0');
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_large WHERE hasToken(s, 'token_0');
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_large WHERE hasToken(s, 'token_5');
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_large WHERE hasToken(s, 'token_5');
+
+-- lazy mode: AND intersection on large dataset
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_large WHERE hasAllTokens(s, ['token_3', 'word_3']);
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_large WHERE hasAllTokens(s, ['token_3', 'word_3']);
+
+-- lazy mode: OR union on large dataset
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_large WHERE hasAnyTokens(s, ['word_0', 'word_1', 'word_2']);
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_large WHERE hasAnyTokens(s, ['word_0', 'word_1', 'word_2']);
+
+----------------------------------------------------
+SELECT 'Test lazy mode with multiple segments (multi-insert without merge)';
+
+DROP TABLE IF EXISTS tab_multi;
+
+CREATE TABLE tab_multi(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_multi VALUES (1, 'alpha beta'), (2, 'gamma delta'), (3, 'alpha gamma'), (4, 'beta delta');
+INSERT INTO tab_multi VALUES (5, 'alpha epsilon'), (6, 'beta zeta'), (7, 'gamma eta'), (8, 'delta theta');
+INSERT INTO tab_multi VALUES (9, 'alpha iota'), (10, 'beta kappa');
+
+-- lazy mode: query across multiple parts
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_multi WHERE hasToken(s, 'alpha') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_multi WHERE hasToken(s, 'alpha') ORDER BY k;
+
+-- lazy mode: AND across parts
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_multi WHERE hasAllTokens(s, ['alpha', 'beta']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_multi WHERE hasAllTokens(s, ['alpha', 'beta']) ORDER BY k;
+
+-- lazy mode: OR across parts
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_multi WHERE hasAnyTokens(s, ['epsilon', 'zeta']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_multi WHERE hasAnyTokens(s, ['epsilon', 'zeta']) ORDER BY k;
+
+-- Now merge and test again
+OPTIMIZE TABLE tab_multi FINAL;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_multi WHERE hasToken(s, 'alpha') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_multi WHERE hasToken(s, 'alpha') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with UTF-8 data and ngram tokenizer';
+
+DROP TABLE IF EXISTS tab_utf8;
+
+CREATE TABLE tab_utf8(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = ngrams(2)))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_utf8 VALUES (1, '你好世界'), (2, '世界和平'), (3, '你好朋友'), (4, '天气很好');
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_utf8 WHERE s LIKE '%你好%' ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_utf8 WHERE s LIKE '%你好%' ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_utf8 WHERE s LIKE '%世界%' ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_utf8 WHERE s LIKE '%世界%' ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with 3-way AND intersection';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') AND hasToken(s, 'a01') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') AND hasToken(s, 'b06') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') AND hasToken(s, 'b06') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode with OR of hasToken';
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') OR hasToken(s, 'Blick') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_mode WHERE hasToken(s, 'Alick') OR hasToken(s, 'Blick') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test lazy mode consistency with direct read';
+
+DROP TABLE IF EXISTS tab_dr;
+
+CREATE TABLE tab_dr(k UInt64, text String, PROJECTION idx INDEX text TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_dr VALUES (1, 'hello world'), (2, 'foo bar'), (3, 'hello foo'), (4, 'bar baz');
+
+SET query_plan_direct_read_from_text_index = 1;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_dr WHERE hasToken(text, 'hello') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_dr WHERE hasToken(text, 'hello') ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_dr WHERE hasAllTokens(text, ['hello', 'world']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_dr WHERE hasAllTokens(text, ['hello', 'world']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT * FROM tab_dr WHERE hasAnyTokens(text, ['hello', 'bar']) ORDER BY k;
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT * FROM tab_dr WHERE hasAnyTokens(text, ['hello', 'bar']) ORDER BY k;
+
+SET query_plan_direct_read_from_text_index = 0;
+
+----------------------------------------------------
+DROP TABLE IF EXISTS tab_mode;
+DROP TABLE IF EXISTS tab_merge;
+DROP TABLE IF EXISTS tab_large;
+DROP TABLE IF EXISTS tab_multi;
+DROP TABLE IF EXISTS tab_utf8;
+DROP TABLE IF EXISTS tab_dr;

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode.sql
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode.sql
@@ -288,9 +288,76 @@ SELECT * FROM tab_dr WHERE hasAnyTokens(text, ['hello', 'bar']) ORDER BY k;
 SET query_plan_direct_read_from_text_index = 0;
 
 ----------------------------------------------------
+SELECT 'Test lazy mode with large posting list and block-level index';
+
+DROP TABLE IF EXISTS tab_block_idx;
+
+-- Use small posting_list_block_size (256) to trigger multiple large blocks with fewer rows.
+-- This exercises the v2 block-level index layout where each large block has a trailing index section.
+CREATE TABLE tab_block_idx(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 256))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_block_idx SELECT number, concat('token_', toString(number % 10), ' word_', toString(number)) FROM numbers(500);
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_block_idx WHERE hasToken(s, 'token_0');
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_block_idx WHERE hasToken(s, 'token_0');
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_block_idx WHERE hasToken(s, 'token_5');
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_block_idx WHERE hasToken(s, 'token_5');
+
+-- AND intersection with block-level index
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_block_idx WHERE hasAllTokens(s, ['token_3', 'word_3']);
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_block_idx WHERE hasAllTokens(s, ['token_3', 'word_3']);
+
+-- OR union with block-level index
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_block_idx WHERE hasAnyTokens(s, ['word_0', 'word_1', 'word_2']);
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_block_idx WHERE hasAnyTokens(s, ['word_0', 'word_1', 'word_2']);
+
+----------------------------------------------------
+SELECT 'Test lazy mode with large posting list block-level index after merge';
+
+DROP TABLE IF EXISTS tab_block_merge;
+
+CREATE TABLE tab_block_merge(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 256))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_block_merge SELECT number, concat('token_', toString(number % 10), ' word_', toString(number)) FROM numbers(250);
+INSERT INTO tab_block_merge SELECT number + 250, concat('token_', toString((number + 250) % 10), ' word_', toString(number + 250)) FROM numbers(250);
+
+OPTIMIZE TABLE tab_block_merge FINAL;
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_block_merge WHERE hasToken(s, 'token_0');
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_block_merge WHERE hasToken(s, 'token_0');
+
+SET text_index_posting_list_apply_mode = 'lazy';
+SELECT count() FROM tab_block_merge WHERE hasToken(s, 'token_5');
+
+SET text_index_posting_list_apply_mode = 'materialize';
+SELECT count() FROM tab_block_merge WHERE hasToken(s, 'token_5');
+
+----------------------------------------------------
 DROP TABLE IF EXISTS tab_mode;
 DROP TABLE IF EXISTS tab_merge;
 DROP TABLE IF EXISTS tab_large;
 DROP TABLE IF EXISTS tab_multi;
 DROP TABLE IF EXISTS tab_utf8;
 DROP TABLE IF EXISTS tab_dr;
+DROP TABLE IF EXISTS tab_block_idx;
+DROP TABLE IF EXISTS tab_block_merge;

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2.reference
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2.reference
@@ -1,0 +1,44 @@
+Test 1: Multiple large blocks with small posting_list_block_size=128
+1000
+1000
+0
+2000
+Test 2: Seek across packed block boundaries with ngrams
+0
+500
+2000
+Test 3: Exact TurboPFor boundary (128, 256, 384 docs)
+129
+257
+385
+130
+Test 4: Multi-way intersection (3, 4, 5 tokens)
+29
+3
+0
+1155
+2310
+1
+0
+Test 5: High-density posting lists (brute-force intersection path)
+250
+250
+0
+Test 6: first_doc_id prepend correctness
+0
+0	499
+500
+Test 7: Seek beyond all packed blocks (empty result)
+0
+0
+Test 8: Multiple large blocks after merge
+1000
+1000
+0
+Test 9: Seek within and across large blocks with ngrams
+750
+1499
+0
+Test 10: Direct read mode with v2 format and large posting list
+200
+0

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2.sql
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2.sql
@@ -1,0 +1,311 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
+-- Tests for v2 posting list format and lazy apply mode edge cases:
+-- 1. Multiple large blocks per token (small posting_list_block_size)
+-- 2. Seek across packed block boundaries (leapfrog intersection)
+-- 3. Exact TurboPFor boundary doc counts (128, 256, 384 docs)
+-- 4. Multi-way intersection (3, 4, 5+ tokens)
+-- 5. High-density posting lists (brute-force path)
+-- 6. first_doc_id prepend correctness
+-- 7. Seek beyond all packed blocks (empty result)
+
+SET enable_full_text_index = 1;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+SET use_skip_indexes_on_data_read = 0;
+
+----------------------------------------------------
+SELECT 'Test 1: Multiple large blocks with small posting_list_block_size=128';
+
+-- posting_list_block_size=128 -> aligned to 128, so each large block holds exactly 128 docs.
+-- A token appearing in 50% of 2000 rows -> 1000 docs -> ~8 large blocks.
+-- This exercises multiple Index Sections and the cross-large-block iteration in PostingListCursor.
+
+DROP TABLE IF EXISTS tab_multi_lb;
+
+CREATE TABLE tab_multi_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+-- 'common' appears in even rows (1000 times), 'uncommon' in odd rows (1000 times)
+INSERT INTO tab_multi_lb SELECT number, if(number % 2 = 0, 'common', 'uncommon') FROM numbers(2000);
+
+-- Verify count: 'common' should match exactly 1000 rows
+SELECT count() FROM tab_multi_lb WHERE hasToken(s, 'common');
+
+-- Verify count: 'uncommon' should also match exactly 1000 rows
+SELECT count() FROM tab_multi_lb WHERE hasToken(s, 'uncommon');
+
+-- AND: common + uncommon have zero overlap
+SELECT count() FROM tab_multi_lb WHERE hasToken(s, 'common') AND hasToken(s, 'uncommon');
+
+-- OR: common + uncommon = all rows
+SELECT count() FROM tab_multi_lb WHERE hasAnyTokens(s, ['common', 'uncommon']);
+
+----------------------------------------------------
+SELECT 'Test 2: Seek across packed block boundaries with ngrams';
+
+-- Use ngrams tokenizer so we can search with LIKE and arbitrary substrings.
+-- Each row has a group label (ga/gb/gc/gd) appearing every 4 rows, and a frequency label.
+
+DROP TABLE IF EXISTS tab_seek;
+
+CREATE TABLE tab_seek(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = ngrams(3), posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+-- 'aaa' appears in 50% of rows (1000), 'bbb' in the other 50%
+-- 'xxx' appears in 25% of rows (500), 'yyy' in another 25%
+INSERT INTO tab_seek SELECT number,
+    concat(if(number % 2 = 0, 'aaa', 'bbb'), ' ', if(number % 4 < 2, 'xxx', 'yyy'))
+    FROM numbers(2000);
+
+-- Two-way intersection: 'aaa' AND 'bbb' have no overlap
+SELECT count() FROM tab_seek WHERE s LIKE '%aaa%' AND s LIKE '%bbb%';
+
+-- Two-way intersection: 'aaa' AND 'xxx' -> even rows (aaa) AND rows 0,1,4,5,8,9,... (xxx)
+-- aaa rows: 0,2,4,6,8,10,...  xxx rows: 0,1,4,5,8,9,...  intersection: 0,4,8,12,... = every 4th row = 500
+SELECT count() FROM tab_seek WHERE s LIKE '%aaa%' AND s LIKE '%xxx%';
+
+-- OR across large blocks: 'aaa' + 'bbb' = all 2000 rows
+SELECT count() FROM tab_seek WHERE s LIKE '%aaa%' OR s LIKE '%bbb%';
+
+----------------------------------------------------
+SELECT 'Test 3: Exact TurboPFor boundary (128, 256, 384 docs)';
+
+-- Test that tail_size=0 (perfectly aligned) works correctly.
+-- With posting_list_block_size=128, insert exactly 129 rows (first_doc_id + 128 docs = 1 full packed block, no tail).
+
+DROP TABLE IF EXISTS tab_boundary;
+
+CREATE TABLE tab_boundary(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+-- All 129 rows have 'exact' token
+INSERT INTO tab_boundary SELECT number, 'exact' FROM numbers(129);
+
+SELECT count() FROM tab_boundary WHERE hasToken(s, 'exact');
+
+-- 257 rows: first_doc_id + 256 docs = 2 full packed blocks, tail_size=0, one large block
+DROP TABLE IF EXISTS tab_boundary2;
+
+CREATE TABLE tab_boundary2(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 512))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_boundary2 SELECT number, 'exact' FROM numbers(257);
+
+SELECT count() FROM tab_boundary2 WHERE hasToken(s, 'exact');
+
+-- 385 rows: first_doc_id + 384 docs = 3 full packed blocks, tail_size=0
+DROP TABLE IF EXISTS tab_boundary3;
+
+CREATE TABLE tab_boundary3(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 512))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_boundary3 SELECT number, 'exact' FROM numbers(385);
+
+SELECT count() FROM tab_boundary3 WHERE hasToken(s, 'exact');
+
+-- Off-by-one: 130 rows = first_doc_id + 129 docs = 1 full block + tail of 1 doc
+DROP TABLE IF EXISTS tab_boundary4;
+
+CREATE TABLE tab_boundary4(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_boundary4 SELECT number, 'exact' FROM numbers(130);
+
+SELECT count() FROM tab_boundary4 WHERE hasToken(s, 'exact');
+
+----------------------------------------------------
+SELECT 'Test 4: Multi-way intersection (3, 4, 5 tokens)';
+
+-- Use a dataset where each row has multiple overlapping tokens so we can
+-- construct 3/4/5-way AND intersections with non-empty results.
+-- Use purely alphabetic tokens: pa/pb/pc/pd/pe + suffix digit spelled as letter
+
+DROP TABLE IF EXISTS tab_multiway;
+
+CREATE TABLE tab_multiway(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+-- Each row has 5 tokens derived from modular arithmetic:
+-- pa{k%5} pb{k%7} pc{k%3} pd{k%11} pe{k%13}
+-- Using array of spelled-out names to keep tokens alphabetic
+INSERT INTO tab_multiway SELECT number,
+    concat(
+        arrayElement(['pazero','paone','patwo','pathree','pafour'], (number % 5) + 1), ' ',
+        arrayElement(['pbzero','pbone','pbtwo','pbthree','pbfour','pbfive','pbsix'], (number % 7) + 1), ' ',
+        arrayElement(['pczero','pcone','pctwo'], (number % 3) + 1), ' ',
+        arrayElement(['pdzero','pdone','pdtwo','pdthree','pdfour','pdfive','pdsix','pdseven','pdeight','pdnine','pdten'], (number % 11) + 1), ' ',
+        arrayElement(['pezero','peone','petwo','pethree','pefour','pefive','pesix','peseven','peeight','penine','peten','peeleven','petwelve'], (number % 13) + 1)
+    )
+    FROM numbers(3000);
+
+-- 3-way AND: pazero AND pbzero AND pczero -> k % lcm(5,7,3) = k % 105 = 0 -> rows 0,105,...,2940 = 29 rows
+SELECT count() FROM tab_multiway WHERE hasAllTokens(s, ['pazero', 'pbzero', 'pczero']);
+
+-- 4-way AND: + pdzero -> k % lcm(5,7,3,11) = k % 1155 = 0 -> rows 0,1155,2310 = 3 rows
+SELECT count() FROM tab_multiway WHERE hasAllTokens(s, ['pazero', 'pbzero', 'pczero', 'pdzero']);
+
+-- Verify the actual k values of 4-way intersection
+SELECT k FROM tab_multiway WHERE hasAllTokens(s, ['pazero', 'pbzero', 'pczero', 'pdzero']) ORDER BY k;
+
+-- 5-way AND: + pezero -> k % lcm(5,7,3,11,13) = k % 15015 = 0 -> only row 0
+SELECT count() FROM tab_multiway WHERE hasAllTokens(s, ['pazero', 'pbzero', 'pczero', 'pdzero', 'pezero']);
+
+-- 5-way AND: verify exact row
+SELECT k FROM tab_multiway WHERE hasAllTokens(s, ['pazero', 'pbzero', 'pczero', 'pdzero', 'pezero']);
+
+----------------------------------------------------
+SELECT 'Test 5: High-density posting lists (brute-force intersection path)';
+
+-- Every row contains 'dense', so density=1.0, which should trigger intersectBruteForce.
+-- Also add 'half' to 50% of rows, density~0.5 -> still above threshold.
+
+DROP TABLE IF EXISTS tab_dense;
+
+CREATE TABLE tab_dense(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_dense SELECT number,
+    concat('dense ', if(number % 2 = 0, 'half', 'other'))
+    FROM numbers(500);
+
+-- AND of two high-density tokens: dense(100%) AND half(50%) -> half = 250 rows
+SELECT count() FROM tab_dense WHERE hasAllTokens(s, ['dense', 'half']);
+
+-- AND of dense AND other -> 250 rows (odd numbers)
+SELECT count() FROM tab_dense WHERE hasAllTokens(s, ['dense', 'other']);
+
+-- Verify: half AND other = 0 (mutually exclusive)
+SELECT count() FROM tab_dense WHERE hasAllTokens(s, ['half', 'other']);
+
+----------------------------------------------------
+SELECT 'Test 6: first_doc_id prepend correctness';
+
+-- The first doc_id is stored inline in the dictionary, not in TurboPFor data.
+-- PostingListCursor must prepend it when decoding large block 0's packed block 0.
+-- Verify the exact first row is returned correctly.
+
+DROP TABLE IF EXISTS tab_first_doc;
+
+CREATE TABLE tab_first_doc(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_first_doc SELECT number, 'target' FROM numbers(500);
+
+-- 'target' appears in all 500 rows, first_doc_id=0
+-- Seek to value 0 (the very first doc_id): must find it via prepend
+SELECT min(k) FROM tab_first_doc WHERE hasToken(s, 'target');
+
+-- Verify first and last row are both returned in linearOr
+SELECT min(k), max(k) FROM tab_first_doc WHERE hasToken(s, 'target');
+
+-- Verify total count matches
+SELECT count() FROM tab_first_doc WHERE hasToken(s, 'target');
+
+----------------------------------------------------
+SELECT 'Test 7: Seek beyond all packed blocks (empty result)';
+
+DROP TABLE IF EXISTS tab_empty_seek;
+
+CREATE TABLE tab_empty_seek(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_empty_seek SELECT number, 'present' FROM numbers(500);
+
+-- Search for non-existent token
+SELECT count() FROM tab_empty_seek WHERE hasToken(s, 'nonexistent');
+
+-- AND with non-existent token
+SELECT count() FROM tab_empty_seek WHERE hasAllTokens(s, ['present', 'nonexistent']);
+
+----------------------------------------------------
+SELECT 'Test 8: Multiple large blocks after merge';
+
+-- Merge two parts, each generating large posting lists. After merge, the merged
+-- posting list should span even more large blocks with correct v2 Index Sections.
+
+DROP TABLE IF EXISTS tab_merge_lb;
+
+CREATE TABLE tab_merge_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_merge_lb SELECT number, if(number % 2 = 0, 'common', 'uncommon') FROM numbers(1000);
+INSERT INTO tab_merge_lb SELECT number + 1000, if((number + 1000) % 2 = 0, 'common', 'uncommon') FROM numbers(1000);
+
+OPTIMIZE TABLE tab_merge_lb FINAL;
+
+SELECT count() FROM tab_merge_lb WHERE hasToken(s, 'common');
+
+SELECT count() FROM tab_merge_lb WHERE hasToken(s, 'uncommon');
+
+-- AND after merge: common + uncommon = 0 overlap
+SELECT count() FROM tab_merge_lb WHERE hasToken(s, 'common') AND hasToken(s, 'uncommon');
+
+----------------------------------------------------
+SELECT 'Test 9: Seek within and across large blocks with ngrams';
+
+-- Use ngrams tokenizer for targeted seek via LIKE on per-row unique substrings.
+-- 'freq' appears in every row -> 1500 docs -> many large blocks of 128
+
+DROP TABLE IF EXISTS tab_seek_lb;
+
+CREATE TABLE tab_seek_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = ngrams(4), posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_seek_lb SELECT number, concat('freq zz', leftPad(toString(number), 5, '0')) FROM numbers(1500);
+
+-- Seek to a doc in the middle via LIKE
+SELECT k FROM tab_seek_lb WHERE s LIKE '%freq%' AND s LIKE '%zz00750%';
+
+-- Seek to last doc
+SELECT k FROM tab_seek_lb WHERE s LIKE '%freq%' AND s LIKE '%zz01499%';
+
+-- Seek to first doc
+SELECT k FROM tab_seek_lb WHERE s LIKE '%freq%' AND s LIKE '%zz00000%';
+
+----------------------------------------------------
+SELECT 'Test 10: Direct read mode with v2 format and large posting list';
+
+DROP TABLE IF EXISTS tab_dr_v2;
+
+CREATE TABLE tab_dr_v2(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_dr_v2 SELECT number, if(number % 3 = 0, 'common', 'other') FROM numbers(600);
+
+SET query_plan_direct_read_from_text_index = 1;
+
+SELECT count() FROM tab_dr_v2 WHERE hasToken(s, 'common');
+
+-- AND: common + other = 0 (disjoint)
+SELECT count() FROM tab_dr_v2 WHERE hasToken(s, 'common') AND hasToken(s, 'other');
+
+SET query_plan_direct_read_from_text_index = 0;
+
+----------------------------------------------------
+DROP TABLE IF EXISTS tab_multi_lb;
+DROP TABLE IF EXISTS tab_seek;
+DROP TABLE IF EXISTS tab_boundary;
+DROP TABLE IF EXISTS tab_boundary2;
+DROP TABLE IF EXISTS tab_boundary3;
+DROP TABLE IF EXISTS tab_boundary4;
+DROP TABLE IF EXISTS tab_multiway;
+DROP TABLE IF EXISTS tab_dense;
+DROP TABLE IF EXISTS tab_first_doc;
+DROP TABLE IF EXISTS tab_empty_seek;
+DROP TABLE IF EXISTS tab_merge_lb;
+DROP TABLE IF EXISTS tab_seek_lb;
+DROP TABLE IF EXISTS tab_dr_v2;

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2_large_block_advance.reference
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2_large_block_advance.reference
@@ -1,0 +1,73 @@
+Test 1: next() sequential scan across 3 large blocks via linearOr
+500
+0	499
+Test 2: next() in 2-way leapfrog across large blocks
+400
+0	399
+Test 3: seek() across large block boundary in leapfrog
+5
+0
+200
+400
+600
+800
+Test 4: Mixed next+seek alternation across large block boundaries
+80
+0	790
+Test 5: Exactly 1 packed block per large block (129 docs per LB)
+258
+127
+128
+129
+130
+Test 6: 3 large blocks with 2-way leapfrog spanning all
+400
+0	1197
+Test 7: 4-way intersection across multiple large blocks
+400
+0	1995
+Test 8: Sparse token seek across many large blocks of dense token
+6
+0
+500
+1000
+1500
+2000
+2500
+Test 9: next() exhausts all large blocks (cursor becomes invalid)
+300
+44850
+Test 10: hasAnyTokens (OR) across multiple large blocks
+400
+200
+200
+Test 11: Brute-force AND (linearAnd) across multiple large blocks
+300
+Test 12: Exactly at large block boundary - tail_size=0
+129
+258
+Test 13: Large block advance after merge with multiple parts
+1500
+500
+0	1497
+Test 14: 5-way leapfrog across multiple large blocks
+600
+0	599
+Test 15: Seek to exact large block boundary doc_id
+129
+Test 16: Seek to last doc of a large block
+128
+Test 17: Interleaved sparse tokens across different large blocks
+134
+0	1995
+Test 18: Very small posting list (embedded) mixed with large multi-LB posting list
+3
+100
+500
+900
+Test 19: next() across many large blocks - stress test
+5000
+12497500
+Test 20: 2-way intersection - one cursor finishes early across LBs
+150
+0	149

--- a/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2_large_block_advance.sql
+++ b/tests/queries/0_stateless/03801_projection_text_index_apply_mode_v2_large_block_advance.sql
@@ -1,0 +1,496 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
+-- Tests for large block advancement in V2 lazy apply mode.
+-- These tests specifically target the next()/seek() cross-large-block behavior
+-- that was fixed: next() must auto-advance to the next large block when the
+-- current one is exhausted, and seek() must skip already-failed large blocks.
+--
+-- Key scenarios:
+-- 1. next() crosses large block boundary (sequential scan via linearOr)
+-- 2. next() crosses large block boundary in leapfrog intersection
+-- 3. seek() crosses large block boundary in leapfrog intersection
+-- 4. Mixed next()+seek() alternation across large block boundaries
+-- 5. Single packed block per large block (block_size=128, exactly 129 docs per LB)
+-- 6. Multiple large blocks with tail-only blocks (block_size=128, 129+1=130 docs)
+-- 7. 3 large blocks with leapfrog 2-way intersection spanning all 3
+-- 8. 4-way intersection across multiple large blocks
+-- 9. Sparse token intersected with dense multi-LB token (leapfrog seek pattern)
+-- 10. next() exhausts all large blocks correctly (is_valid=false)
+-- 11. hasAnyTokens (OR) across multiple large blocks
+-- 12. linearAnd (brute-force AND) across multiple large blocks
+-- 13. Exact boundary: each large block has exactly 1 packed block (128 docs)
+-- 14. Interleaved tokens in alternating large blocks
+
+SET enable_full_text_index = 1;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+SET use_skip_indexes_on_data_read = 0;
+
+----------------------------------------------------
+SELECT 'Test 1: next() sequential scan across 3 large blocks via linearOr';
+
+-- posting_list_block_size=128 means each large block holds 128 docs (+ first_doc_id for LB0).
+-- Token 'alpha' in all 500 rows -> 500 docs -> ~4 large blocks.
+-- linearOr must traverse all large blocks to collect all doc IDs.
+
+DROP TABLE IF EXISTS tab_next_linear;
+
+CREATE TABLE tab_next_linear(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_next_linear SELECT number, 'alpha' FROM numbers(500);
+
+SELECT count() FROM tab_next_linear WHERE hasToken(s, 'alpha');
+
+-- Verify first and last doc_id are present
+SELECT min(k), max(k) FROM tab_next_linear WHERE hasToken(s, 'alpha');
+
+----------------------------------------------------
+SELECT 'Test 2: next() in 2-way leapfrog across large blocks';
+
+-- Two tokens both spanning multiple large blocks, with identical posting lists.
+-- intersectTwo: c0.value()==c1.value() -> both call next() repeatedly.
+-- next() must cross large block boundaries for both cursors.
+-- Token 'aa' and 'bb' both appear in every row -> all 400 rows match AND.
+
+DROP TABLE IF EXISTS tab_next_leapfrog;
+
+CREATE TABLE tab_next_leapfrog(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_next_leapfrog SELECT number, 'aa bb' FROM numbers(400);
+
+-- Both tokens in every row -> AND returns all 400
+SELECT count() FROM tab_next_leapfrog WHERE hasAllTokens(s, ['aa', 'bb']);
+
+-- Verify boundaries
+SELECT min(k), max(k) FROM tab_next_leapfrog WHERE hasAllTokens(s, ['aa', 'bb']);
+
+----------------------------------------------------
+SELECT 'Test 3: seek() across large block boundary in leapfrog';
+
+-- Token 'common' appears in every row (dense, multi-LB).
+-- Token 'sparse' appears only every 200th row (sparse, few docs).
+-- Leapfrog: sparse cursor leads, common cursor seeks to sparse values.
+-- seek() on 'common' cursor must jump across large block boundaries.
+
+DROP TABLE IF EXISTS tab_seek_cross_lb;
+
+CREATE TABLE tab_seek_cross_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_seek_cross_lb SELECT number,
+    concat('common', if(number % 200 = 0, ' sparse', ''))
+    FROM numbers(1000);
+
+-- sparse appears at rows 0, 200, 400, 600, 800 -> 5 rows match AND
+SELECT count() FROM tab_seek_cross_lb WHERE hasAllTokens(s, ['common', 'sparse']);
+
+-- Verify exact rows
+SELECT k FROM tab_seek_cross_lb WHERE hasAllTokens(s, ['common', 'sparse']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 4: Mixed next+seek alternation across large block boundaries';
+
+-- Token 'every' in all rows, token 'tenth' every 10th row.
+-- Leapfrog: 'tenth' leads (sparse), 'every' follows with seek.
+-- After match at 10k, both call next(); 'every' advances 1 by 1 while 'tenth' jumps 10.
+-- This tests rapid alternation of next()/seek() across LB boundaries.
+
+DROP TABLE IF EXISTS tab_mixed;
+
+CREATE TABLE tab_mixed(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_mixed SELECT number,
+    concat('every', if(number % 10 = 0, ' tenth', ''))
+    FROM numbers(800);
+
+-- AND: every row that has both -> every 10th row -> 80 rows
+SELECT count() FROM tab_mixed WHERE hasAllTokens(s, ['every', 'tenth']);
+
+SELECT min(k), max(k) FROM tab_mixed WHERE hasAllTokens(s, ['every', 'tenth']);
+
+----------------------------------------------------
+SELECT 'Test 5: Exactly 1 packed block per large block (129 docs per LB)';
+
+-- posting_list_block_size=128 -> each LB holds 128 delta-encoded docs.
+-- LB0: first_doc_id + 128 docs = 129 total.
+-- With 258 rows all having the token: LB0 has 129, LB1 has 129.
+-- Tests: LB boundary at row 129.
+
+DROP TABLE IF EXISTS tab_single_pb;
+
+CREATE TABLE tab_single_pb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_single_pb SELECT number, 'uniform' FROM numbers(258);
+
+SELECT count() FROM tab_single_pb WHERE hasToken(s, 'uniform');
+
+-- Verify values around the LB boundary
+-- Row 128 is in LB0, row 129 should be in LB1
+SELECT k FROM tab_single_pb WHERE hasToken(s, 'uniform') AND k >= 127 AND k <= 130 ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 6: 3 large blocks with 2-way leapfrog spanning all';
+
+-- 'both' appears in every 3rd row across 1200 rows -> 400 docs -> ~3 LBs.
+-- 'partner' appears in every 3rd row, offset by 0 -> same rows as 'both'.
+-- Leapfrog intersection must traverse all 3 LBs for both cursors.
+
+DROP TABLE IF EXISTS tab_three_lb;
+
+CREATE TABLE tab_three_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_three_lb SELECT number,
+    if(number % 3 = 0, 'both partner', 'filler')
+    FROM numbers(1200);
+
+-- both AND partner: same set of rows -> 400 match
+SELECT count() FROM tab_three_lb WHERE hasAllTokens(s, ['both', 'partner']);
+
+-- Verify boundaries across LBs
+SELECT min(k), max(k) FROM tab_three_lb WHERE hasAllTokens(s, ['both', 'partner']);
+
+----------------------------------------------------
+SELECT 'Test 7: 4-way intersection across multiple large blocks';
+
+-- All 4 tokens appear in every 5th row across 2000 rows -> 400 docs -> ~3 LBs.
+-- 4-way intersectFour must handle next() crossing LB boundaries for all 4 cursors.
+
+DROP TABLE IF EXISTS tab_fourway_lb;
+
+CREATE TABLE tab_fourway_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_fourway_lb SELECT number,
+    if(number % 5 = 0, 'wa wb wc wd', concat('x', toString(number % 5)))
+    FROM numbers(2000);
+
+-- 4-way AND: all 4 tokens present only in rows where k%5=0 -> 400 rows
+SELECT count() FROM tab_fourway_lb WHERE hasAllTokens(s, ['wa', 'wb', 'wc', 'wd']);
+
+SELECT min(k), max(k) FROM tab_fourway_lb WHERE hasAllTokens(s, ['wa', 'wb', 'wc', 'wd']);
+
+----------------------------------------------------
+SELECT 'Test 8: Sparse token seek across many large blocks of dense token';
+
+-- 'dense' in all 3000 rows -> ~24 large blocks of 128.
+-- 'rare' only at rows 0, 500, 1000, 1500, 2000, 2500 -> 6 rows.
+-- Leapfrog: rare leads, dense seeks. seek() must jump across many LBs.
+
+DROP TABLE IF EXISTS tab_sparse_dense;
+
+CREATE TABLE tab_sparse_dense(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_sparse_dense SELECT number,
+    concat('dense', if(number % 500 = 0, ' rare', ''))
+    FROM numbers(3000);
+
+SELECT count() FROM tab_sparse_dense WHERE hasAllTokens(s, ['dense', 'rare']);
+
+SELECT k FROM tab_sparse_dense WHERE hasAllTokens(s, ['dense', 'rare']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 9: next() exhausts all large blocks (cursor becomes invalid)';
+
+-- Verify that after all data is consumed, cursor correctly reports invalid.
+-- 'only' appears in 300 rows -> ~3 LBs.
+-- Query must return exactly 300, meaning cursor didn't terminate early.
+
+DROP TABLE IF EXISTS tab_exhaust;
+
+CREATE TABLE tab_exhaust(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_exhaust SELECT number, 'only' FROM numbers(300);
+
+SELECT count() FROM tab_exhaust WHERE hasToken(s, 'only');
+
+-- Verify every single row is found by checking sum
+SELECT sum(k) FROM tab_exhaust WHERE hasToken(s, 'only');
+
+----------------------------------------------------
+SELECT 'Test 10: hasAnyTokens (OR) across multiple large blocks';
+
+-- 'left' in first 200 rows, 'right' in rows 200-399. No overlap.
+-- Both span ~2 LBs each.
+-- OR should return all 400 rows.
+
+DROP TABLE IF EXISTS tab_or_multi_lb;
+
+CREATE TABLE tab_or_multi_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_or_multi_lb SELECT number,
+    if(number < 200, 'left', 'right')
+    FROM numbers(400);
+
+SELECT count() FROM tab_or_multi_lb WHERE hasAnyTokens(s, ['left', 'right']);
+
+-- Each individually
+SELECT count() FROM tab_or_multi_lb WHERE hasToken(s, 'left');
+
+SELECT count() FROM tab_or_multi_lb WHERE hasToken(s, 'right');
+
+----------------------------------------------------
+SELECT 'Test 11: Brute-force AND (linearAnd) across multiple large blocks';
+
+-- Force brute-force path by having very high density.
+-- 'da' in all rows, 'db' in even rows. All span multiple LBs.
+-- linearOr + linearAnd must traverse all LBs for both tokens.
+
+DROP TABLE IF EXISTS tab_bf_multi_lb;
+
+CREATE TABLE tab_bf_multi_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_bf_multi_lb SELECT number,
+    concat('da', if(number % 2 = 0, ' db', ''))
+    FROM numbers(600);
+
+-- brute-force AND: da(600) AND db(300) -> rows where k%2=0 -> 300
+SELECT count() FROM tab_bf_multi_lb WHERE hasAllTokens(s, ['da', 'db']);
+
+----------------------------------------------------
+SELECT 'Test 12: Exactly at large block boundary - tail_size=0';
+
+-- 128 docs per LB + first_doc_id = 129 rows in LB0.
+-- If we have exactly 129 rows, LB0 has 1 full packed block, 0 tail.
+-- No LB1 needed. Count must be 129.
+-- Then with 129*2=258 rows: LB0=129, LB1=129 (both perfectly aligned).
+
+DROP TABLE IF EXISTS tab_tail_zero;
+
+CREATE TABLE tab_tail_zero(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_tail_zero SELECT number, 'aligned' FROM numbers(129);
+
+SELECT count() FROM tab_tail_zero WHERE hasToken(s, 'aligned');
+
+DROP TABLE IF EXISTS tab_tail_zero2;
+
+CREATE TABLE tab_tail_zero2(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_tail_zero2 SELECT number, 'aligned' FROM numbers(258);
+
+SELECT count() FROM tab_tail_zero2 WHERE hasToken(s, 'aligned');
+
+----------------------------------------------------
+SELECT 'Test 13: Large block advance after merge with multiple parts';
+
+-- Insert 3 separate parts, each with the same token spanning multiple LBs.
+-- After OPTIMIZE FINAL, the merged posting list will be very large.
+-- Tests that merged multi-LB posting lists work correctly.
+
+DROP TABLE IF EXISTS tab_merge_advance;
+
+CREATE TABLE tab_merge_advance(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_merge_advance SELECT number, concat('merged', if(number % 3 = 0, ' extra', '')) FROM numbers(500);
+INSERT INTO tab_merge_advance SELECT number + 500, concat('merged', if((number + 500) % 3 = 0, ' extra', '')) FROM numbers(500);
+INSERT INTO tab_merge_advance SELECT number + 1000, concat('merged', if((number + 1000) % 3 = 0, ' extra', '')) FROM numbers(500);
+
+OPTIMIZE TABLE tab_merge_advance FINAL;
+
+-- 'merged' in all 1500 rows
+SELECT count() FROM tab_merge_advance WHERE hasToken(s, 'merged');
+
+-- AND: merged(1500) AND extra(500) -> rows where k%3=0 -> 500
+SELECT count() FROM tab_merge_advance WHERE hasAllTokens(s, ['merged', 'extra']);
+
+-- Verify exact first and last match of AND
+SELECT min(k), max(k) FROM tab_merge_advance WHERE hasAllTokens(s, ['merged', 'extra']);
+
+----------------------------------------------------
+SELECT 'Test 14: 5-way leapfrog across multiple large blocks';
+
+-- 5 tokens, each in every row. 5-way intersection uses intersectLeapfrogLinear (n=5).
+-- All 5 cursors must advance across LB boundaries via next().
+
+DROP TABLE IF EXISTS tab_fiveway_lb;
+
+CREATE TABLE tab_fiveway_lb(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_fiveway_lb SELECT number, 'fa fb fc fd fe' FROM numbers(600);
+
+-- All 5 in every row -> AND = 600
+SELECT count() FROM tab_fiveway_lb WHERE hasAllTokens(s, ['fa', 'fb', 'fc', 'fd', 'fe']);
+
+SELECT min(k), max(k) FROM tab_fiveway_lb WHERE hasAllTokens(s, ['fa', 'fb', 'fc', 'fd', 'fe']);
+
+----------------------------------------------------
+SELECT 'Test 15: Seek to exact large block boundary doc_id';
+
+-- Token in every row, seek to the exact first doc of LB1 (row 129).
+-- This tests that seek() lands precisely at the LB boundary.
+
+DROP TABLE IF EXISTS tab_seek_boundary;
+
+CREATE TABLE tab_seek_boundary(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+-- 'full' in all 400 rows, 'pin' only at row 129 (exact LB1 start)
+INSERT INTO tab_seek_boundary SELECT number,
+    concat('full', if(number = 129, ' pin', ''))
+    FROM numbers(400);
+
+-- AND: full(400) AND pin(1) -> only row 129
+SELECT k FROM tab_seek_boundary WHERE hasAllTokens(s, ['full', 'pin']);
+
+----------------------------------------------------
+SELECT 'Test 16: Seek to last doc of a large block';
+
+-- 'fill' in all 400 rows, 'last' only at row 128 (last doc of LB0).
+-- LB0: rows 0-128 (129 docs), so row 128 is the last in LB0.
+
+DROP TABLE IF EXISTS tab_seek_last;
+
+CREATE TABLE tab_seek_last(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_seek_last SELECT number,
+    concat('fill', if(number = 128, ' last', ''))
+    FROM numbers(400);
+
+SELECT k FROM tab_seek_last WHERE hasAllTokens(s, ['fill', 'last']);
+
+----------------------------------------------------
+SELECT 'Test 17: Interleaved sparse tokens across different large blocks';
+
+-- 'tokena' at rows 0,3,6,... (every 3rd row)
+-- 'tokenb' at rows 0,5,10,... (every 5th row)
+-- AND -> rows where k%15=0: 0,15,30,...
+-- Both tokens span multiple LBs. Leapfrog must seek across LB boundaries.
+
+DROP TABLE IF EXISTS tab_interleave;
+
+CREATE TABLE tab_interleave(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_interleave SELECT number,
+    concat(
+        if(number % 3 = 0, 'tokena ', ''),
+        if(number % 5 = 0, 'tokenb ', ''),
+        'base'
+    )
+    FROM numbers(2000);
+
+-- AND: tokena(667) AND tokenb(400) -> lcm(3,5)=15 -> rows where k%15=0 -> 134 rows (0,15,...,1995)
+SELECT count() FROM tab_interleave WHERE hasAllTokens(s, ['tokena', 'tokenb']);
+
+-- Verify first and last
+SELECT min(k), max(k) FROM tab_interleave WHERE hasAllTokens(s, ['tokena', 'tokenb']);
+
+----------------------------------------------------
+SELECT 'Test 18: Very small posting list (embedded) mixed with large multi-LB posting list';
+
+-- 'huge' in all 1000 rows (multi-LB), 'tiny' in only 3 rows (embedded posting).
+-- The embedded cursor doesn't use large blocks at all.
+-- Leapfrog must handle one embedded cursor + one multi-LB cursor correctly.
+
+DROP TABLE IF EXISTS tab_embed_mix;
+
+CREATE TABLE tab_embed_mix(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_embed_mix SELECT number,
+    concat('huge', if(number IN (100, 500, 900), ' tiny', ''))
+    FROM numbers(1000);
+
+-- AND: huge(1000) AND tiny(3) -> rows 100, 500, 900
+SELECT count() FROM tab_embed_mix WHERE hasAllTokens(s, ['huge', 'tiny']);
+
+SELECT k FROM tab_embed_mix WHERE hasAllTokens(s, ['huge', 'tiny']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 19: next() across many large blocks - stress test';
+
+-- 'stress' in all 5000 rows -> ~39 large blocks of 128.
+-- Full sequential scan via hasToken must read all of them.
+
+DROP TABLE IF EXISTS tab_stress;
+
+CREATE TABLE tab_stress(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_stress SELECT number, 'stress' FROM numbers(5000);
+
+SELECT count() FROM tab_stress WHERE hasToken(s, 'stress');
+
+-- Verify sum to ensure no data loss
+SELECT sum(k) FROM tab_stress WHERE hasToken(s, 'stress');
+
+----------------------------------------------------
+SELECT 'Test 20: 2-way intersection - one cursor finishes early across LBs';
+
+-- 'short' in first 150 rows (just over 1 LB).
+-- 'long' in all 500 rows (4 LBs).
+-- AND: intersection stops when 'short' cursor becomes invalid after LB1.
+-- Must still find all 150 matches correctly.
+
+DROP TABLE IF EXISTS tab_early_finish;
+
+CREATE TABLE tab_early_finish(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_early_finish SELECT number,
+    concat('long', if(number < 150, ' short', ''))
+    FROM numbers(500);
+
+-- AND: long(500) AND short(150) -> first 150 rows
+SELECT count() FROM tab_early_finish WHERE hasAllTokens(s, ['long', 'short']);
+
+SELECT min(k), max(k) FROM tab_early_finish WHERE hasAllTokens(s, ['long', 'short']);
+
+----------------------------------------------------
+-- Cleanup
+DROP TABLE IF EXISTS tab_next_linear;
+DROP TABLE IF EXISTS tab_next_leapfrog;
+DROP TABLE IF EXISTS tab_seek_cross_lb;
+DROP TABLE IF EXISTS tab_mixed;
+DROP TABLE IF EXISTS tab_single_pb;
+DROP TABLE IF EXISTS tab_three_lb;
+DROP TABLE IF EXISTS tab_fourway_lb;
+DROP TABLE IF EXISTS tab_sparse_dense;
+DROP TABLE IF EXISTS tab_exhaust;
+DROP TABLE IF EXISTS tab_or_multi_lb;
+DROP TABLE IF EXISTS tab_bf_multi_lb;
+DROP TABLE IF EXISTS tab_tail_zero;
+DROP TABLE IF EXISTS tab_tail_zero2;
+DROP TABLE IF EXISTS tab_merge_advance;
+DROP TABLE IF EXISTS tab_fiveway_lb;
+DROP TABLE IF EXISTS tab_seek_boundary;
+DROP TABLE IF EXISTS tab_seek_last;
+DROP TABLE IF EXISTS tab_interleave;
+DROP TABLE IF EXISTS tab_embed_mix;
+DROP TABLE IF EXISTS tab_stress;
+DROP TABLE IF EXISTS tab_early_finish;

--- a/tests/queries/0_stateless/03802_projection_text_index_posting_list_version.reference
+++ b/tests/queries/0_stateless/03802_projection_text_index_posting_list_version.reference
@@ -1,0 +1,23 @@
+Test 1: posting_list_version=1 (auto materialize mode)
+100
+100
+0
+Test 2: posting_list_version=2 (auto lazy mode)
+100
+100
+0
+Test 3: Default posting_list_version (v2, auto lazy)
+100
+200
+Test 4: Large data with posting_list_version=1 (materialize, triggers large posting list)
+1000
+1000
+0
+Test 5: Large data with posting_list_version=2 (lazy)
+1000
+1000
+0
+Test 6: Large data with posting_list_version=2 after merge
+1000
+1000
+Test 7: Invalid posting_list_version

--- a/tests/queries/0_stateless/03802_projection_text_index_posting_list_version.sql
+++ b/tests/queries/0_stateless/03802_projection_text_index_posting_list_version.sql
@@ -1,0 +1,123 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
+-- Tests for posting_list_version DDL parameter:
+-- 1. posting_list_version=1 + materialize mode (auto) -> normal query
+-- 2. posting_list_version=2 + lazy mode (auto) -> normal query
+-- 3. Default (not specified) -> uses v2, lazy works
+-- 4. Large data test with v1 (triggers large posting list path, materialize)
+-- 5. Large data test with v2 (triggers large posting list path, lazy)
+-- 6. Large data with v2 after merge
+-- 7. Invalid posting_list_version
+
+SET enable_full_text_index = 1;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+SET use_skip_indexes_on_data_read = 0;
+
+----------------------------------------------------
+SELECT 'Test 1: posting_list_version=1 (auto materialize mode)';
+
+DROP TABLE IF EXISTS tab_v1;
+
+CREATE TABLE tab_v1(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_version = 1))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_v1 SELECT number, if(number % 2 = 0, 'alpha', 'beta') FROM numbers(200);
+
+SELECT count() FROM tab_v1 WHERE hasToken(s, 'alpha');
+SELECT count() FROM tab_v1 WHERE hasToken(s, 'beta');
+SELECT count() FROM tab_v1 WHERE hasToken(s, 'alpha') AND hasToken(s, 'beta');
+
+----------------------------------------------------
+SELECT 'Test 2: posting_list_version=2 (auto lazy mode)';
+
+DROP TABLE IF EXISTS tab_v2;
+
+CREATE TABLE tab_v2(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_version = 2))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_v2 SELECT number, if(number % 2 = 0, 'alpha', 'beta') FROM numbers(200);
+
+SELECT count() FROM tab_v2 WHERE hasToken(s, 'alpha');
+SELECT count() FROM tab_v2 WHERE hasToken(s, 'beta');
+SELECT count() FROM tab_v2 WHERE hasToken(s, 'alpha') AND hasToken(s, 'beta');
+
+----------------------------------------------------
+SELECT 'Test 3: Default posting_list_version (v2, auto lazy)';
+
+DROP TABLE IF EXISTS tab_default;
+
+CREATE TABLE tab_default(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha'))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_default SELECT number, if(number % 3 = 0, 'gamma', 'delta') FROM numbers(300);
+
+SELECT count() FROM tab_default WHERE hasToken(s, 'gamma');
+SELECT count() FROM tab_default WHERE hasToken(s, 'delta');
+
+----------------------------------------------------
+SELECT 'Test 4: Large data with posting_list_version=1 (materialize, triggers large posting list)';
+
+DROP TABLE IF EXISTS tab_v1_large;
+
+CREATE TABLE tab_v1_large(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128, posting_list_version = 1))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_v1_large SELECT number, if(number % 2 = 0, 'common', 'rare') FROM numbers(2000);
+
+SELECT count() FROM tab_v1_large WHERE hasToken(s, 'common');
+SELECT count() FROM tab_v1_large WHERE hasToken(s, 'rare');
+SELECT count() FROM tab_v1_large WHERE hasToken(s, 'common') AND hasToken(s, 'rare');
+
+----------------------------------------------------
+SELECT 'Test 5: Large data with posting_list_version=2 (lazy)';
+
+DROP TABLE IF EXISTS tab_v2_large;
+
+CREATE TABLE tab_v2_large(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128, posting_list_version = 2))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_v2_large SELECT number, if(number % 2 = 0, 'common', 'rare') FROM numbers(2000);
+
+SELECT count() FROM tab_v2_large WHERE hasToken(s, 'common');
+SELECT count() FROM tab_v2_large WHERE hasToken(s, 'rare');
+SELECT count() FROM tab_v2_large WHERE hasToken(s, 'common') AND hasToken(s, 'rare');
+
+----------------------------------------------------
+SELECT 'Test 6: Large data with posting_list_version=2 after merge';
+
+DROP TABLE IF EXISTS tab_v2_merge;
+
+CREATE TABLE tab_v2_merge(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128, posting_list_version = 2))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_v2_merge SELECT number, if(number % 2 = 0, 'common', 'rare') FROM numbers(1000);
+INSERT INTO tab_v2_merge SELECT number + 1000, if((number + 1000) % 2 = 0, 'common', 'rare') FROM numbers(1000);
+
+OPTIMIZE TABLE tab_v2_merge FINAL;
+
+SELECT count() FROM tab_v2_merge WHERE hasToken(s, 'common');
+SELECT count() FROM tab_v2_merge WHERE hasToken(s, 'rare');
+
+----------------------------------------------------
+SELECT 'Test 7: Invalid posting_list_version';
+
+DROP TABLE IF EXISTS tab_invalid;
+CREATE TABLE tab_invalid(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_version = 3))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi'; -- { serverError BAD_ARGUMENTS }
+
+----------------------------------------------------
+DROP TABLE IF EXISTS tab_v1;
+DROP TABLE IF EXISTS tab_v2;
+DROP TABLE IF EXISTS tab_default;
+DROP TABLE IF EXISTS tab_v1_large;
+DROP TABLE IF EXISTS tab_v2_large;
+DROP TABLE IF EXISTS tab_v2_merge;
+DROP TABLE IF EXISTS tab_invalid;

--- a/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.reference
+++ b/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.reference
@@ -1,0 +1,71 @@
+Part 1: Small data
+hasToken apple
+100
+100
+hasToken cherry
+100
+100
+hasToken elderberry
+100
+100
+AND intersection (empty)
+0
+0
+AND same group
+100
+100
+OR union
+200
+200
+non-existent token
+0
+0
+row values
+0	apple banana
+3	apple banana
+6	apple banana
+9	apple banana
+12	apple banana
+0	apple banana
+3	apple banana
+6	apple banana
+9	apple banana
+12	apple banana
+Part 2: Large data (triggers large posting list path)
+large: hasToken common
+2000
+2000
+large: hasToken rare
+1000
+1000
+large: hasToken frequent
+1000
+1000
+large: AND common AND frequent
+1000
+1000
+large: AND common AND rare (empty)
+0
+0
+large: OR rare OR unique
+3000
+3000
+large: 3-way AND common AND medium (not frequent)
+1000
+1000
+Part 3: After merge
+after merge: hasToken alpha
+2000
+2000
+after merge: hasToken beta
+2000
+2000
+after merge: AND alpha AND beta (empty)
+0
+0
+after merge: AND merge AND alpha
+2000
+2000
+after merge: OR alpha OR beta
+4000
+4000

--- a/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.reference
+++ b/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.reference
@@ -31,6 +31,45 @@ row values
 6	apple banana
 9	apple banana
 12	apple banana
+hasAnyTokens array: apple or cherry
+200
+200
+hasAnyTokens array: elderberry or grape
+100
+100
+hasAnyTokens array: all three
+300
+300
+hasAnyTokens array: none exist
+0
+0
+hasAnyTokens string: apple cherry
+200
+200
+hasAnyTokens string: grape mango
+0
+0
+hasAllTokens array: apple and banana
+100
+100
+hasAllTokens array: apple and cherry (empty)
+0
+0
+hasAllTokens array: cherry and date
+100
+100
+hasAllTokens array: single token apple
+100
+100
+hasAllTokens array: non-existent grape
+0
+0
+hasAllTokens string: apple banana
+100
+100
+hasAllTokens string: apple cherry
+0
+0
 Part 2: Large data (triggers large posting list path)
 large: hasToken common
 2000
@@ -53,6 +92,57 @@ large: OR rare OR unique
 large: 3-way AND common AND medium (not frequent)
 1000
 1000
+large: hasAnyTokens array: common or rare
+3000
+3000
+large: hasAnyTokens array: frequent or special or odd
+3000
+3000
+large: hasAnyTokens array: nonexistent
+0
+0
+large: hasAnyTokens array: one exists one not
+2000
+2000
+large: hasAnyTokens string: common rare
+3000
+3000
+large: hasAnyTokens string: frequent special odd
+3000
+3000
+large: hasAllTokens array: common and frequent
+1000
+1000
+large: hasAllTokens array: common and medium
+1000
+1000
+large: hasAllTokens array: common and rare (empty)
+0
+0
+large: hasAllTokens array: rare and special
+1000
+1000
+large: hasAllTokens array: unique and even
+1000
+1000
+large: hasAllTokens array: common and nonexistent
+0
+0
+large: hasAllTokens string: common frequent
+1000
+1000
+large: hasAllTokens string: rare special
+1000
+1000
+large: hasAllTokens string: common rare
+0
+0
+large: hasAnyTokens AND hasToken
+2000
+2000
+large: hasAllTokens OR hasToken
+2000
+2000
 Part 3: After merge
 after merge: hasToken alpha
 2000
@@ -67,5 +157,38 @@ after merge: AND merge AND alpha
 2000
 2000
 after merge: OR alpha OR beta
+4000
+4000
+after merge: hasAnyTokens array: alpha or beta
+4000
+4000
+after merge: hasAnyTokens array: alpha or nonexistent
+2000
+2000
+after merge: hasAnyTokens array: nonexistent only
+0
+0
+after merge: hasAnyTokens string: alpha beta
+4000
+4000
+after merge: hasAllTokens array: merge and alpha
+2000
+2000
+after merge: hasAllTokens array: merge and beta
+2000
+2000
+after merge: hasAllTokens array: alpha and beta (empty)
+0
+0
+after merge: hasAllTokens array: merge and nonexistent
+0
+0
+after merge: hasAllTokens string: merge alpha
+2000
+2000
+after merge: hasAllTokens string: alpha beta
+0
+0
+after merge: hasAnyTokens AND hasAllTokens
 4000
 4000

--- a/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.sql
+++ b/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.sql
@@ -4,6 +4,7 @@
 -- Equivalence test: v1 and v2 posting list formats must produce identical query results.
 -- Two tables with the same schema (only posting_list_version differs) receive the same data.
 -- Every query is run against both tables and the results must match.
+-- Covers hasToken, hasAnyTokens (array + string), hasAllTokens (array + string).
 
 SET enable_full_text_index = 1;
 SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
@@ -31,14 +32,14 @@ CREATE TABLE tab_eq_v2(
   SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 ----------------------------------------------------
--- Insert identical data (small posting lists)
+-- Part 1: Small data
 ----------------------------------------------------
 SELECT 'Part 1: Small data';
 
 INSERT INTO tab_eq_v1 SELECT number, if(number % 3 = 0, 'apple banana', if(number % 3 = 1, 'cherry date', 'elderberry fig')) FROM numbers(300);
 INSERT INTO tab_eq_v2 SELECT number, if(number % 3 = 0, 'apple banana', if(number % 3 = 1, 'cherry date', 'elderberry fig')) FROM numbers(300);
 
--- Single token queries
+-- hasToken: single token queries
 SELECT 'hasToken apple';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple');
@@ -51,33 +52,89 @@ SELECT 'hasToken elderberry';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'elderberry');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'elderberry');
 
--- AND (intersection) — tokens from different groups, expect 0
+-- hasToken: AND (intersection) — tokens from different groups, expect 0
 SELECT 'AND intersection (empty)';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple') AND hasToken(s, 'cherry');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple') AND hasToken(s, 'cherry');
 
--- AND — tokens from the same group, expect 100
+-- hasToken: AND — tokens from the same group, expect 100
 SELECT 'AND same group';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple') AND hasToken(s, 'banana');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple') AND hasToken(s, 'banana');
 
--- OR (union)
+-- hasToken: OR (union)
 SELECT 'OR union';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple') OR hasToken(s, 'cherry');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple') OR hasToken(s, 'cherry');
 
--- Non-existent token
+-- hasToken: non-existent token
 SELECT 'non-existent token';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'grape');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'grape');
 
--- Actual row values
+-- hasToken: row values
 SELECT 'row values';
 SELECT k, s FROM tab_eq_v1 WHERE hasToken(s, 'apple') ORDER BY k LIMIT 5;
 SELECT k, s FROM tab_eq_v2 WHERE hasToken(s, 'apple') ORDER BY k LIMIT 5;
 
+-- hasAnyTokens: array form — match any of the listed tokens
+SELECT 'hasAnyTokens array: apple or cherry';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['apple', 'cherry']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['apple', 'cherry']);
+
+SELECT 'hasAnyTokens array: elderberry or grape';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['elderberry', 'grape']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['elderberry', 'grape']);
+
+SELECT 'hasAnyTokens array: all three';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['apple', 'cherry', 'elderberry']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['apple', 'cherry', 'elderberry']);
+
+SELECT 'hasAnyTokens array: none exist';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['grape', 'mango']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['grape', 'mango']);
+
+-- hasAnyTokens: string form
+SELECT 'hasAnyTokens string: apple cherry';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, 'apple cherry');
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, 'apple cherry');
+
+SELECT 'hasAnyTokens string: grape mango';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, 'grape mango');
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, 'grape mango');
+
+-- hasAllTokens: array form — match all listed tokens
+SELECT 'hasAllTokens array: apple and banana';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['apple', 'banana']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['apple', 'banana']);
+
+SELECT 'hasAllTokens array: apple and cherry (empty)';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['apple', 'cherry']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['apple', 'cherry']);
+
+SELECT 'hasAllTokens array: cherry and date';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['cherry', 'date']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['cherry', 'date']);
+
+SELECT 'hasAllTokens array: single token apple';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['apple']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['apple']);
+
+SELECT 'hasAllTokens array: non-existent grape';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['apple', 'grape']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['apple', 'grape']);
+
+-- hasAllTokens: string form
+SELECT 'hasAllTokens string: apple banana';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'apple banana');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'apple banana');
+
+SELECT 'hasAllTokens string: apple cherry';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'apple cherry');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'apple cherry');
+
 ----------------------------------------------------
--- Insert more data to trigger large posting lists
+-- Part 2: Large data (triggers large posting list path)
 ----------------------------------------------------
 SELECT 'Part 2: Large data (triggers large posting list path)';
 
@@ -87,6 +144,7 @@ TRUNCATE TABLE tab_eq_v2;
 INSERT INTO tab_eq_v1 SELECT number, if(number % 5 = 0, 'common frequent', if(number % 5 = 1, 'common medium', if(number % 5 = 2, 'rare special', if(number % 5 = 3, 'unique odd', 'unique even')))) FROM numbers(5000);
 INSERT INTO tab_eq_v2 SELECT number, if(number % 5 = 0, 'common frequent', if(number % 5 = 1, 'common medium', if(number % 5 = 2, 'rare special', if(number % 5 = 3, 'unique odd', 'unique even')))) FROM numbers(5000);
 
+-- hasToken
 SELECT 'large: hasToken common';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'common');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'common');
@@ -115,8 +173,81 @@ SELECT 'large: 3-way AND common AND medium (not frequent)';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'common') AND hasToken(s, 'medium');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'common') AND hasToken(s, 'medium');
 
+-- hasAnyTokens: array form
+SELECT 'large: hasAnyTokens array: common or rare';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['common', 'rare']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['common', 'rare']);
+
+SELECT 'large: hasAnyTokens array: frequent or special or odd';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['frequent', 'special', 'odd']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['frequent', 'special', 'odd']);
+
+SELECT 'large: hasAnyTokens array: nonexistent';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['nonexistent', 'missing']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['nonexistent', 'missing']);
+
+SELECT 'large: hasAnyTokens array: one exists one not';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['common', 'nonexistent']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['common', 'nonexistent']);
+
+-- hasAnyTokens: string form
+SELECT 'large: hasAnyTokens string: common rare';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, 'common rare');
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, 'common rare');
+
+SELECT 'large: hasAnyTokens string: frequent special odd';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, 'frequent special odd');
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, 'frequent special odd');
+
+-- hasAllTokens: array form
+SELECT 'large: hasAllTokens array: common and frequent';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['common', 'frequent']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['common', 'frequent']);
+
+SELECT 'large: hasAllTokens array: common and medium';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['common', 'medium']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['common', 'medium']);
+
+SELECT 'large: hasAllTokens array: common and rare (empty)';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['common', 'rare']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['common', 'rare']);
+
+SELECT 'large: hasAllTokens array: rare and special';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['rare', 'special']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['rare', 'special']);
+
+SELECT 'large: hasAllTokens array: unique and even';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['unique', 'even']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['unique', 'even']);
+
+SELECT 'large: hasAllTokens array: common and nonexistent';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['common', 'nonexistent']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['common', 'nonexistent']);
+
+-- hasAllTokens: string form
+SELECT 'large: hasAllTokens string: common frequent';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'common frequent');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'common frequent');
+
+SELECT 'large: hasAllTokens string: rare special';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'rare special');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'rare special');
+
+SELECT 'large: hasAllTokens string: common rare';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'common rare');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'common rare');
+
+-- Mixed: hasAnyTokens combined with hasToken via AND/OR
+SELECT 'large: hasAnyTokens AND hasToken';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['frequent', 'medium']) AND hasToken(s, 'common');
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['frequent', 'medium']) AND hasToken(s, 'common');
+
+SELECT 'large: hasAllTokens OR hasToken';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['rare', 'special']) OR hasToken(s, 'even');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['rare', 'special']) OR hasToken(s, 'even');
+
 ----------------------------------------------------
--- Multi-part merge test
+-- Part 3: After merge
 ----------------------------------------------------
 SELECT 'Part 3: After merge';
 
@@ -132,6 +263,7 @@ INSERT INTO tab_eq_v2 SELECT number + 2000, if((number + 2000) % 2 = 0, 'merge a
 OPTIMIZE TABLE tab_eq_v1 FINAL;
 OPTIMIZE TABLE tab_eq_v2 FINAL;
 
+-- hasToken
 SELECT 'after merge: hasToken alpha';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'alpha');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'alpha');
@@ -151,6 +283,55 @@ SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'merge') AND hasToken(s, 'alpha'
 SELECT 'after merge: OR alpha OR beta';
 SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'alpha') OR hasToken(s, 'beta');
 SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'alpha') OR hasToken(s, 'beta');
+
+-- hasAnyTokens: array form
+SELECT 'after merge: hasAnyTokens array: alpha or beta';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['alpha', 'beta']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['alpha', 'beta']);
+
+SELECT 'after merge: hasAnyTokens array: alpha or nonexistent';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['alpha', 'nonexistent']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['alpha', 'nonexistent']);
+
+SELECT 'after merge: hasAnyTokens array: nonexistent only';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['nonexistent', 'missing']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['nonexistent', 'missing']);
+
+-- hasAnyTokens: string form
+SELECT 'after merge: hasAnyTokens string: alpha beta';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, 'alpha beta');
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, 'alpha beta');
+
+-- hasAllTokens: array form
+SELECT 'after merge: hasAllTokens array: merge and alpha';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['merge', 'alpha']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['merge', 'alpha']);
+
+SELECT 'after merge: hasAllTokens array: merge and beta';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['merge', 'beta']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['merge', 'beta']);
+
+SELECT 'after merge: hasAllTokens array: alpha and beta (empty)';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['alpha', 'beta']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['alpha', 'beta']);
+
+SELECT 'after merge: hasAllTokens array: merge and nonexistent';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, ['merge', 'nonexistent']);
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, ['merge', 'nonexistent']);
+
+-- hasAllTokens: string form
+SELECT 'after merge: hasAllTokens string: merge alpha';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'merge alpha');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'merge alpha');
+
+SELECT 'after merge: hasAllTokens string: alpha beta';
+SELECT count() FROM tab_eq_v1 WHERE hasAllTokens(s, 'alpha beta');
+SELECT count() FROM tab_eq_v2 WHERE hasAllTokens(s, 'alpha beta');
+
+-- Mixed after merge
+SELECT 'after merge: hasAnyTokens AND hasAllTokens';
+SELECT count() FROM tab_eq_v1 WHERE hasAnyTokens(s, ['alpha', 'beta']) AND hasAllTokens(s, ['merge']);
+SELECT count() FROM tab_eq_v2 WHERE hasAnyTokens(s, ['alpha', 'beta']) AND hasAllTokens(s, ['merge']);
 
 ----------------------------------------------------
 -- Cleanup

--- a/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.sql
+++ b/tests/queries/0_stateless/03802_projection_text_index_v1_v2_equivalence.sql
@@ -1,0 +1,159 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
+-- Equivalence test: v1 and v2 posting list formats must produce identical query results.
+-- Two tables with the same schema (only posting_list_version differs) receive the same data.
+-- Every query is run against both tables and the results must match.
+
+SET enable_full_text_index = 1;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+SET use_skip_indexes_on_data_read = 0;
+
+DROP TABLE IF EXISTS tab_eq_v1;
+DROP TABLE IF EXISTS tab_eq_v2;
+
+----------------------------------------------------
+-- Schema: identical except posting_list_version
+----------------------------------------------------
+
+CREATE TABLE tab_eq_v1(
+    k UInt64,
+    s String,
+    PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128, posting_list_version = 1)
+) ENGINE = MergeTree() ORDER BY k
+  SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+CREATE TABLE tab_eq_v2(
+    k UInt64,
+    s String,
+    PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128, posting_list_version = 2)
+) ENGINE = MergeTree() ORDER BY k
+  SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+----------------------------------------------------
+-- Insert identical data (small posting lists)
+----------------------------------------------------
+SELECT 'Part 1: Small data';
+
+INSERT INTO tab_eq_v1 SELECT number, if(number % 3 = 0, 'apple banana', if(number % 3 = 1, 'cherry date', 'elderberry fig')) FROM numbers(300);
+INSERT INTO tab_eq_v2 SELECT number, if(number % 3 = 0, 'apple banana', if(number % 3 = 1, 'cherry date', 'elderberry fig')) FROM numbers(300);
+
+-- Single token queries
+SELECT 'hasToken apple';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple');
+
+SELECT 'hasToken cherry';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'cherry');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'cherry');
+
+SELECT 'hasToken elderberry';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'elderberry');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'elderberry');
+
+-- AND (intersection) — tokens from different groups, expect 0
+SELECT 'AND intersection (empty)';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple') AND hasToken(s, 'cherry');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple') AND hasToken(s, 'cherry');
+
+-- AND — tokens from the same group, expect 100
+SELECT 'AND same group';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple') AND hasToken(s, 'banana');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple') AND hasToken(s, 'banana');
+
+-- OR (union)
+SELECT 'OR union';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'apple') OR hasToken(s, 'cherry');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'apple') OR hasToken(s, 'cherry');
+
+-- Non-existent token
+SELECT 'non-existent token';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'grape');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'grape');
+
+-- Actual row values
+SELECT 'row values';
+SELECT k, s FROM tab_eq_v1 WHERE hasToken(s, 'apple') ORDER BY k LIMIT 5;
+SELECT k, s FROM tab_eq_v2 WHERE hasToken(s, 'apple') ORDER BY k LIMIT 5;
+
+----------------------------------------------------
+-- Insert more data to trigger large posting lists
+----------------------------------------------------
+SELECT 'Part 2: Large data (triggers large posting list path)';
+
+TRUNCATE TABLE tab_eq_v1;
+TRUNCATE TABLE tab_eq_v2;
+
+INSERT INTO tab_eq_v1 SELECT number, if(number % 5 = 0, 'common frequent', if(number % 5 = 1, 'common medium', if(number % 5 = 2, 'rare special', if(number % 5 = 3, 'unique odd', 'unique even')))) FROM numbers(5000);
+INSERT INTO tab_eq_v2 SELECT number, if(number % 5 = 0, 'common frequent', if(number % 5 = 1, 'common medium', if(number % 5 = 2, 'rare special', if(number % 5 = 3, 'unique odd', 'unique even')))) FROM numbers(5000);
+
+SELECT 'large: hasToken common';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'common');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'common');
+
+SELECT 'large: hasToken rare';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'rare');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'rare');
+
+SELECT 'large: hasToken frequent';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'frequent');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'frequent');
+
+SELECT 'large: AND common AND frequent';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'common') AND hasToken(s, 'frequent');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'common') AND hasToken(s, 'frequent');
+
+SELECT 'large: AND common AND rare (empty)';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'common') AND hasToken(s, 'rare');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'common') AND hasToken(s, 'rare');
+
+SELECT 'large: OR rare OR unique';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'rare') OR hasToken(s, 'unique');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'rare') OR hasToken(s, 'unique');
+
+SELECT 'large: 3-way AND common AND medium (not frequent)';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'common') AND hasToken(s, 'medium');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'common') AND hasToken(s, 'medium');
+
+----------------------------------------------------
+-- Multi-part merge test
+----------------------------------------------------
+SELECT 'Part 3: After merge';
+
+TRUNCATE TABLE tab_eq_v1;
+TRUNCATE TABLE tab_eq_v2;
+
+INSERT INTO tab_eq_v1 SELECT number, if(number % 2 = 0, 'merge alpha', 'merge beta') FROM numbers(2000);
+INSERT INTO tab_eq_v1 SELECT number + 2000, if((number + 2000) % 2 = 0, 'merge alpha', 'merge beta') FROM numbers(2000);
+
+INSERT INTO tab_eq_v2 SELECT number, if(number % 2 = 0, 'merge alpha', 'merge beta') FROM numbers(2000);
+INSERT INTO tab_eq_v2 SELECT number + 2000, if((number + 2000) % 2 = 0, 'merge alpha', 'merge beta') FROM numbers(2000);
+
+OPTIMIZE TABLE tab_eq_v1 FINAL;
+OPTIMIZE TABLE tab_eq_v2 FINAL;
+
+SELECT 'after merge: hasToken alpha';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'alpha');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'alpha');
+
+SELECT 'after merge: hasToken beta';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'beta');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'beta');
+
+SELECT 'after merge: AND alpha AND beta (empty)';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'alpha') AND hasToken(s, 'beta');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'alpha') AND hasToken(s, 'beta');
+
+SELECT 'after merge: AND merge AND alpha';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'merge') AND hasToken(s, 'alpha');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'merge') AND hasToken(s, 'alpha');
+
+SELECT 'after merge: OR alpha OR beta';
+SELECT count() FROM tab_eq_v1 WHERE hasToken(s, 'alpha') OR hasToken(s, 'beta');
+SELECT count() FROM tab_eq_v2 WHERE hasToken(s, 'alpha') OR hasToken(s, 'beta');
+
+----------------------------------------------------
+-- Cleanup
+----------------------------------------------------
+DROP TABLE tab_eq_v1;
+DROP TABLE tab_eq_v2;

--- a/tests/queries/0_stateless/03803_projection_text_index_linear_scan_block_skip.reference
+++ b/tests/queries/0_stateless/03803_projection_text_index_linear_scan_block_skip.reference
@@ -1,0 +1,37 @@
+Test 1: Dense token, narrow query range — block skip effectiveness
+1
+2500
+Test 2: Brute-force AND with two dense multi-block tokens
+1000
+0	1998
+Test 3: linearOr across multiple large blocks with partial overlap
+3000
+4498500
+Test 4: Query range aligned to packed block boundaries
+4
+0
+128
+256
+384
+Test 5: Query range spanning single packed block
+2
+65
+66
+Test 6: Query range covering all packed blocks (no skip)
+600
+0	599
+Test 7: Brute-force AND with narrow-range second token
+3
+1999
+2000
+2001
+Test 8: Mixed embedded + large posting list in OR
+2000
+500
+1500
+Test 9: Three-way AND with different densities across many blocks
+750
+0	2996
+Test 10: Large posting list after merge — block skip still works
+30
+0	2900

--- a/tests/queries/0_stateless/03803_projection_text_index_linear_scan_block_skip.sql
+++ b/tests/queries/0_stateless/03803_projection_text_index_linear_scan_block_skip.sql
@@ -1,0 +1,232 @@
+-- Tags: no-fasttest
+-- no-fasttest: It can be slow
+
+-- Tests for the linearOr/linearAnd block-level skip optimization.
+-- These verify that using packed_block_last_doc_ids[] to skip packed blocks
+-- during linear scans produces correct results, and that middle blocks
+-- (fully within the query range) skip binary search clipping without error.
+--
+-- Key scenarios:
+-- 1. Dense token spanning many packed blocks, narrow query range (block skip)
+-- 2. Brute-force AND with high-density tokens spanning many blocks
+-- 3. linearOr across multiple large blocks with partial range overlap
+-- 4. Query range exactly aligned to packed block boundaries
+-- 5. Query range spanning only a single packed block
+-- 6. Query range covering all packed blocks (no skip, all middle blocks)
+-- 7. Brute-force AND where one token is narrow-range (partial block overlap)
+-- 8. linearOr with embedded + large posting list mix
+
+SET enable_full_text_index = 1;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
+SET use_skip_indexes_on_data_read = 0;
+
+----------------------------------------------------
+SELECT 'Test 1: Dense token, narrow query range — block skip effectiveness';
+
+-- 'freq' in all 5000 rows -> ~39 large blocks of 128 -> many packed blocks.
+-- 'pin' only at row 2500. AND forces leapfrog/brute-force to process 'freq'
+-- only in the packed block(s) near row 2500.
+-- This tests that linearOr/linearAnd skip blocks far from the query range.
+
+DROP TABLE IF EXISTS tab_skip1;
+
+CREATE TABLE tab_skip1(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip1 SELECT number, concat('freq', if(number = 2500, ' pin', '')) FROM numbers(5000);
+
+SELECT count() FROM tab_skip1 WHERE hasAllTokens(s, ['freq', 'pin']);
+SELECT k FROM tab_skip1 WHERE hasAllTokens(s, ['freq', 'pin']);
+
+----------------------------------------------------
+SELECT 'Test 2: Brute-force AND with two dense multi-block tokens';
+
+-- 'da' in all 2000 rows (many blocks), 'db' in even rows (1000 docs, also many blocks).
+-- Both are high density -> brute-force path (linearOr + linearAnd).
+-- Tests that linearAndImpl correctly skips blocks and clips first/last blocks.
+
+DROP TABLE IF EXISTS tab_skip2;
+
+CREATE TABLE tab_skip2(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip2 SELECT number, concat('da', if(number % 2 = 0, ' db', '')) FROM numbers(2000);
+
+SELECT count() FROM tab_skip2 WHERE hasAllTokens(s, ['da', 'db']);
+
+-- Verify first and last
+SELECT min(k), max(k) FROM tab_skip2 WHERE hasAllTokens(s, ['da', 'db']);
+
+----------------------------------------------------
+SELECT 'Test 3: linearOr across multiple large blocks with partial overlap';
+
+-- 'wide' in all 3000 rows -> ~24 large blocks. Query all rows via hasToken.
+-- linearOr must traverse all large blocks, each invoking linearOrImpl which
+-- uses the block-skip optimization. Full coverage: all blocks overlap.
+
+DROP TABLE IF EXISTS tab_skip3;
+
+CREATE TABLE tab_skip3(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip3 SELECT number, 'wide' FROM numbers(3000);
+
+SELECT count() FROM tab_skip3 WHERE hasToken(s, 'wide');
+SELECT sum(k) FROM tab_skip3 WHERE hasToken(s, 'wide');
+
+----------------------------------------------------
+SELECT 'Test 4: Query range aligned to packed block boundaries';
+
+-- 'aligned' in all 512 rows -> 4 full packed blocks (128 each) in one large block.
+-- (first_doc_id = 0, then 511 delta-encoded docs = 3 full blocks + 1 block of 127 + first_doc_id)
+-- Actually: 512 rows = first_doc_id + 511 docs = 3 full blocks (384) + tail of 127 = 4 blocks.
+-- Intersect with 'mark' at rows 0, 128, 256, 384 — exactly at block boundaries.
+
+DROP TABLE IF EXISTS tab_skip4;
+
+CREATE TABLE tab_skip4(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 4096))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip4 SELECT number, concat('aligned', if(number % 128 = 0, ' mark', '')) FROM numbers(512);
+
+SELECT count() FROM tab_skip4 WHERE hasAllTokens(s, ['aligned', 'mark']);
+SELECT k FROM tab_skip4 WHERE hasAllTokens(s, ['aligned', 'mark']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 5: Query range spanning single packed block';
+
+-- 'full' in all 1000 rows. 'narrow' only at rows 65 and 66 — within packed block 0
+-- (which covers doc_ids 0..128 for large block 0).
+-- linearOr/linearAnd for 'full' should decode only the block containing rows 65-66.
+
+DROP TABLE IF EXISTS tab_skip5;
+
+CREATE TABLE tab_skip5(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip5 SELECT number, concat('full', if(number IN (65, 66), ' narrow', '')) FROM numbers(1000);
+
+SELECT count() FROM tab_skip5 WHERE hasAllTokens(s, ['full', 'narrow']);
+SELECT k FROM tab_skip5 WHERE hasAllTokens(s, ['full', 'narrow']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 6: Query range covering all packed blocks (no skip)';
+
+-- 'every' in all 600 rows. Single token query -> linearOr with full range.
+-- All packed blocks overlap the query range. Middle blocks should skip clipping.
+-- Verify every row is found.
+
+DROP TABLE IF EXISTS tab_skip6;
+
+CREATE TABLE tab_skip6(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip6 SELECT number, 'every' FROM numbers(600);
+
+SELECT count() FROM tab_skip6 WHERE hasToken(s, 'every');
+SELECT min(k), max(k) FROM tab_skip6 WHERE hasToken(s, 'every');
+
+----------------------------------------------------
+SELECT 'Test 7: Brute-force AND with narrow-range second token';
+
+-- 'broad' in all 4000 rows (many packed blocks).
+-- 'spot' at rows 1999, 2000, 2001 (3 rows in a narrow range, likely embedded).
+-- Brute-force: broad.linearOr fills bitmap, spot.linearAnd increments.
+-- linearAndImpl for 'broad' processes only blocks near rows 1999-2001.
+
+DROP TABLE IF EXISTS tab_skip7;
+
+CREATE TABLE tab_skip7(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip7 SELECT number, concat('broad', if(number IN (1999, 2000, 2001), ' spot', '')) FROM numbers(4000);
+
+SELECT count() FROM tab_skip7 WHERE hasAllTokens(s, ['broad', 'spot']);
+SELECT k FROM tab_skip7 WHERE hasAllTokens(s, ['broad', 'spot']) ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 8: Mixed embedded + large posting list in OR';
+
+-- 'big' in all 2000 rows (large posting list, many blocks).
+-- 'tiny' in only 2 rows (embedded posting list).
+-- OR: should return 2000 rows (all of them, since 'big' covers everything).
+-- This tests that linearOrImpl handles the case where it's called after
+-- another cursor's linearOr has already set some bits.
+
+DROP TABLE IF EXISTS tab_skip8;
+
+CREATE TABLE tab_skip8(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip8 SELECT number, if(number IN (500, 1500), 'tiny', 'big') FROM numbers(2000);
+
+-- OR: big(1998) + tiny(2) = 2000 total rows
+SELECT count() FROM tab_skip8 WHERE hasAnyTokens(s, ['big', 'tiny']);
+
+-- Verify tiny rows are found
+SELECT k FROM tab_skip8 WHERE hasToken(s, 'tiny') ORDER BY k;
+
+----------------------------------------------------
+SELECT 'Test 9: Three-way AND with different densities across many blocks';
+
+-- 'all' in all 3000 rows, 'half' in even rows (1500), 'quarter' in rows % 4 == 0 (750).
+-- Three-way AND -> rows where all three match -> rows % 4 == 0 AND even -> rows % 4 == 0 -> 750.
+-- All three tokens span many packed blocks.
+-- Tests linearAnd block-skip with multiple tokens of different density.
+
+DROP TABLE IF EXISTS tab_skip9;
+
+CREATE TABLE tab_skip9(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip9 SELECT number,
+    concat('all',
+        if(number % 2 = 0, ' half', ''),
+        if(number % 4 = 0, ' quarter', ''))
+    FROM numbers(3000);
+
+SELECT count() FROM tab_skip9 WHERE hasAllTokens(s, ['all', 'half', 'quarter']);
+SELECT min(k), max(k) FROM tab_skip9 WHERE hasAllTokens(s, ['all', 'half', 'quarter']);
+
+----------------------------------------------------
+SELECT 'Test 10: Large posting list after merge — block skip still works';
+
+-- Insert into 3 parts, merge, then query. Verifies that after merge the
+-- Index Section is rebuilt correctly and block-skip optimization works.
+
+DROP TABLE IF EXISTS tab_skip10;
+
+CREATE TABLE tab_skip10(k UInt64, s String, PROJECTION af INDEX s TYPE text(tokenizer = 'splitByNonAlpha', posting_list_block_size = 128))
+    ENGINE = MergeTree() ORDER BY k
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+INSERT INTO tab_skip10 SELECT number, concat('merged', if(number % 100 = 0, ' century', '')) FROM numbers(1000);
+INSERT INTO tab_skip10 SELECT number + 1000, concat('merged', if((number + 1000) % 100 = 0, ' century', '')) FROM numbers(1000);
+INSERT INTO tab_skip10 SELECT number + 2000, concat('merged', if((number + 2000) % 100 = 0, ' century', '')) FROM numbers(1000);
+
+OPTIMIZE TABLE tab_skip10 FINAL;
+
+SELECT count() FROM tab_skip10 WHERE hasAllTokens(s, ['merged', 'century']);
+SELECT min(k), max(k) FROM tab_skip10 WHERE hasAllTokens(s, ['merged', 'century']);
+
+----------------------------------------------------
+-- Cleanup
+DROP TABLE IF EXISTS tab_skip1;
+DROP TABLE IF EXISTS tab_skip2;
+DROP TABLE IF EXISTS tab_skip3;
+DROP TABLE IF EXISTS tab_skip4;
+DROP TABLE IF EXISTS tab_skip5;
+DROP TABLE IF EXISTS tab_skip6;
+DROP TABLE IF EXISTS tab_skip7;
+DROP TABLE IF EXISTS tab_skip8;
+DROP TABLE IF EXISTS tab_skip9;
+DROP TABLE IF EXISTS tab_skip10;


### PR DESCRIPTION
Changelog category (leave one):

- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add a new text_index_posting_list_apply_mode setting that introduces a lazy cursor-based posting list evaluation path for ProjectionIndex queries. The existing materialize mode eagerly decodes entire posting lists into Roaring Bitmaps; the new lazy mode decodes TurboPFor-compressed blocks on-demand, reducing memory usage and improving performance for selective queries.

Detailed description / Documentation draft:

In the current materialize mode, every posting list is fully decompressed into a Roaring Bitmap before set operations. For large posting lists or highly selective queries, this is wasteful — most decoded doc IDs are never examined. A lazy cursor can skip entire 128-doc blocks and stop early once the result is determined.