### PR TITLE
feat(text-index): add linearOr block-skip optimizations with AVX2 has…

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -127,6 +127,9 @@
     M(TextIndexLazyLargeBlocksPrepared, "Number of large block Index Sections loaded by lazy posting list cursors.", ValueType::Number) \
     M(TextIndexLazyBruteForceIntersections, "Number of times the brute-force intersection algorithm was chosen for lazy posting list cursors.", ValueType::Number) \
     M(TextIndexLazyLeapfrogIntersections, "Number of times the leapfrog intersection algorithm was chosen for lazy posting list cursors.", ValueType::Number) \
+    M(TextIndexLazyLargeBlocksSkippedDense, "Number of large blocks skipped via dense-memset optimization in lazy posting list linearOr.", ValueType::Number) \
+    M(TextIndexLazyLargeBlocksSkippedCovered, "Number of large blocks skipped because the output region was already all-ones in lazy posting list linearOr.", ValueType::Number) \
+    M(TextIndexLazyPackedBlocksSkippedCovered, "Number of packed blocks skipped because the output region was already all-ones in lazy posting list linearOrImpl.", ValueType::Number) \
     M(QueryConditionCacheHits, "Number of times an entry has been found in the query condition cache (and reading of marks can be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
     M(QueryConditionCacheMisses, "Number of times an entry has not been found in the query condition cache (and reading of mark cannot be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
     M(QueryCacheHits, "Number of times a query result has been found in the query cache (and query computation was avoided). Only updated for SELECT queries with SETTING use_query_cache = 1.", ValueType::Number) \

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -3,8 +3,13 @@
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Storages/MergeTree/ProjectionIndex/LengthPrefixedInt.h>
 #include <Common/ProfileEvents.h>
+#include <Common/TargetSpecific.h>
 #include <algorithm>
 #include <cstring>
+
+#if USE_MULTITARGET_CODE
+#include <immintrin.h>
+#endif
 
 #include <turbopfor.h>
 
@@ -16,6 +21,9 @@ namespace ProfileEvents
     extern const Event TextIndexLazyLargeBlocksPrepared;
     extern const Event TextIndexLazyBruteForceIntersections;
     extern const Event TextIndexLazyLeapfrogIntersections;
+    extern const Event TextIndexLazyLargeBlocksSkippedDense;
+    extern const Event TextIndexLazyLargeBlocksSkippedCovered;
+    extern const Event TextIndexLazyPackedBlocksSkippedCovered;
 }
 
 namespace DB
@@ -342,7 +350,7 @@ void PostingListCursor::seek(uint32_t target)
 
 bool PostingListCursor::seekImpl(uint32_t target)
 {
-    if (is_embedded)
+    if (unlikely(is_embedded))
     {
         /// Embedded: all doc_ids are in decoded_values, use binary search.
         auto it = std::lower_bound(decoded_values, decoded_values + decoded_count, target);
@@ -582,6 +590,74 @@ inline void padArithmeticBlock(UInt8 * __restrict out, uint32_t first_doc_id, ui
     }
 }
 
+/// Check whether a byte buffer contains no zero bytes.
+/// In the `linearOr` path, buffer values are only 0 or 1, so "no zeros"
+/// is equivalent to "all ones" but avoids the more expensive broadcast of 1.
+///
+/// Called from two sites with different typical sizes:
+///   - Packed block check (Level 2b): 128 bytes (TURBOPFOR_BLOCK_SIZE), or 1–127 for tail blocks.
+///   - Large block check (Level 2a): variable, up to ~500 KB.
+///
+/// Uses the ClickHouse multi-target dispatch pattern:
+///   - AVX2 path with 4x loop unrolling (128 bytes/iteration) when available.
+///   - Scalar fallback via `memchr` on all other platforms (ARM, macOS, non-AVX2 x86).
+
+#if USE_MULTITARGET_CODE
+DECLARE_AVX2_SPECIFIC_CODE(
+inline bool hasNoZeros(const UInt8 * data, size_t count)
+{
+    const UInt8 * p = data;
+    const UInt8 * end = data + count;
+    const __m256i zero = _mm256_setzero_si256();
+
+    /// Phase 1: Process 128 bytes (4 x 32) per iteration.
+    /// OR-accumulate zero-match masks and check once per 128-byte chunk.
+    while (end - p >= 128)
+    {
+        __m256i v0 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(p));
+        __m256i v1 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(p + 32));
+        __m256i v2 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(p + 64));
+        __m256i v3 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(p + 96));
+
+        __m256i eq0 = _mm256_cmpeq_epi8(v0, zero);
+        __m256i eq1 = _mm256_cmpeq_epi8(v1, zero);
+        __m256i eq2 = _mm256_cmpeq_epi8(v2, zero);
+        __m256i eq3 = _mm256_cmpeq_epi8(v3, zero);
+
+        __m256i any_zero = _mm256_or_si256(_mm256_or_si256(eq0, eq1),
+                                           _mm256_or_si256(eq2, eq3));
+        if (_mm256_movemask_epi8(any_zero))
+            return false;
+        p += 128;
+    }
+
+    /// Phase 2: Handle remaining 32–127 bytes one vector at a time.
+    while (end - p >= 32)
+    {
+        __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(p));
+        if (_mm256_movemask_epi8(_mm256_cmpeq_epi8(v, zero)))
+            return false;
+        p += 32;
+    }
+
+    /// Phase 3: Tail (< 32 bytes) — delegate to `memchr`.
+    return memchr(p, 0, static_cast<size_t>(end - p)) == nullptr;
+}
+) /// DECLARE_AVX2_SPECIFIC_CODE
+#endif
+
+inline bool hasNoZeros(const UInt8 * data, size_t count)
+{
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX2))
+        return TargetSpecific::AVX2::hasNoZeros(data, count);
+#endif
+
+    /// Scalar fallback: `memchr` uses platform-optimized SIMD internally
+    /// (SSE/AVX on x86_64, NEON on aarch64 via glibc/bionic).
+    return memchr(data, 0, count) == nullptr;
+}
+
 void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out, size_t row_begin, size_t row_end)
 {
     chassert(large_block < info.ranges.size());
@@ -625,6 +701,28 @@ void PostingListCursor::linearOrImpl(size_t large_block, UInt8 * __restrict out,
 
     for (size_t blk = blk_start; blk < blk_end; ++blk)
     {
+        /// Level 2b — Already-covered packed block skip: if the output region
+        /// for this packed block is already all-1, skip seek + probe + decode.
+        {
+            uint32_t pb_first = (blk == 0)
+                ? static_cast<uint32_t>(info.ranges[large_block].begin)
+                : packed_block_last_doc_ids[blk - 1] + 1;
+            uint32_t pb_last = packed_block_last_doc_ids[blk];
+
+            uint32_t check_begin = std::max(pb_first, static_cast<uint32_t>(row_begin));
+            uint32_t check_end = std::min(pb_last, static_cast<uint32_t>(row_end));
+            if (check_begin <= check_end)
+            {
+                size_t off = check_begin - row_begin;
+                size_t cnt = check_end - check_begin + 1;
+                if (hasNoZeros(out + off, cnt))
+                {
+                    ProfileEvents::increment(ProfileEvents::TextIndexLazyPackedBlocksSkippedCovered);
+                    continue;
+                }
+            }
+        }
+
         /// Probe the header; if non-arithmetic, decode in one pass.
         if (probeAndDecodePackedBlock(blk))
         {
@@ -681,16 +779,53 @@ void PostingListCursor::linearOr(UInt8 * data, size_t row_offset, size_t num_row
     for (size_t i = current_large_block_idx; i < total_large_blocks; ++i)
     {
         auto large_block = i;
-        size_t begin = info.ranges[large_block].begin;
-        size_t end = info.ranges[large_block].end;
+        size_t lb_begin = info.ranges[large_block].begin;
+        size_t lb_end = info.ranges[large_block].end;
 
-        if (row_offset > end)
+        if (row_offset > lb_end)
             continue;
 
-        if ((row_offset + num_rows) < begin)
+        if ((row_offset + num_rows) < lb_begin)
             break;
 
-        end = std::min(end, row_offset + num_rows - 1);
+        size_t end = std::min(lb_end, row_offset + num_rows - 1);
+
+        /// Compute the clipped region that overlaps [row_offset, row_offset+num_rows)
+        /// and [lb_begin, lb_end].  Used by both skip checks below.
+        size_t clip_begin = std::max(lb_begin, row_offset);
+        size_t clip_end = end;  /// already min'd above
+        size_t clip_off = clip_begin - row_offset;
+        size_t clip_count = clip_end - clip_begin + 1;
+
+        /// Level 1 — Dense large block memset: if every row in the large block's
+        /// range has a posting, we can memset the overlapping region directly,
+        /// skipping `prepare` (Index Section I/O) and all packed block processing.
+        {
+            size_t actual_doc_count = info.offsets[large_block].block_doc_count;
+            /// For large block 0 (non-embedded), `block_doc_count` excludes the
+            /// first_doc_id which is stored inline in the dictionary.  The range
+            /// however covers [first_doc_id, last_doc_id], so add 1.
+            if (large_block == 0 && !is_embedded)
+                actual_doc_count += 1;
+
+            size_t range_span = lb_end - lb_begin + 1;
+            if (actual_doc_count == range_span)
+            {
+                memset(data + clip_off, 1, clip_count);
+                ProfileEvents::increment(ProfileEvents::TextIndexLazyLargeBlocksSkippedDense);
+                continue;
+            }
+        }
+
+        /// Level 2a — Already-covered large block skip: if a previous cursor
+        /// already set the entire overlapping region to 1, skip this large block
+        /// entirely (including Index Section I/O from `prepare`).
+        if (hasNoZeros(data + clip_off, clip_count))
+        {
+            ProfileEvents::increment(ProfileEvents::TextIndexLazyLargeBlocksSkippedCovered);
+            continue;
+        }
+
         prepare(large_block);
         linearOrImpl(large_block, data, row_offset, end);
     }
@@ -1118,6 +1253,14 @@ void lazyUnionPostingLists(IColumn & column, const PostingListCursorMap & postin
         if (it != postings.end())
             cursors.emplace_back(it->second);
     }
+
+    /// Sort by descending density so the densest cursor fills the output buffer
+    /// first.  Subsequent cursors benefit from `hasNoZeros` short-circuiting:
+    /// already-covered regions are skipped without I/O or decoding.
+    std::stable_sort(cursors.begin(), cursors.end(),
+        [](const PostingListCursorPtr & a, const PostingListCursorPtr & b)
+        { return a->density() > b->density(); });
+
     for (const auto & cursor : cursors)
         cursor->linearOr(out, row_offset, num_rows);
 }

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3450,3 +3450,117 @@ TEST(PostingListCursorTest, ArithmeticRepeatedSeekSameBlock)
     ASSERT_TRUE(cursor->valid());
     EXPECT_EQ(cursor->value(), 256u);
 }
+
+
+// ===========================================================================================
+// Section: linearOr block-level coverage skip optimizations
+// ===========================================================================================
+
+TEST(PostingListCursorTest, DenseLargeBlockFullCoverage)
+{
+    /// Single dense large block (step=1) should trigger Level 1 memset path.
+    /// 300 docs: 0..299, all consecutive.
+    auto docs = generateRange(0, 300);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 300);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, DenseLargeBlockWithRowClipping)
+{
+    /// Dense block 0..299, but only query rows 50..249.
+    auto docs = generateRange(0, 300);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 50, 200);
+    auto expected = generateRange(50, 200);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, DenseTwoLargeBlocks)
+{
+    /// Two dense large blocks: block 0 = 0..299, block 1 = 300..599.
+    auto block0 = generateRange(0, 300);
+    auto block1 = generateRange(300, 300);
+    auto data = makeMultiBlockData({block0, block1});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 600);
+    auto expected = generateRange(0, 600);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, SparseLargeBlockNoFalseSkip)
+{
+    /// Sparse block (step=2): 0,2,4,...,598.  300 docs spanning range [0,598].
+    /// range_span=599, doc_count=300 (or 299+1) != 599, so Level 1 must NOT trigger.
+    auto docs = generateRange(0, 300, 2);
+    auto data = makeMultiBlockData({docs});
+    auto cursor = makeMultiBlockCursor(data);
+
+    auto result = linearOrToDocIds(cursor, 0, 599);
+    EXPECT_EQ(result, docs);
+}
+
+TEST(PostingListCursorTest, MultiCursorUnionIdenticalDense)
+{
+    /// Two cursors with the same dense range.  The second cursor should hit
+    /// the Level 2 (already-covered) skip path at either the large block or
+    /// packed block level.
+    auto docs = generateRange(0, 300);
+    auto data1 = makeMultiBlockData({docs});
+    auto data2 = makeMultiBlockData({docs});
+    auto cursor1 = makeMultiBlockCursor(data1);
+    auto cursor2 = makeMultiBlockCursor(data2);
+
+    PostingListCursorMap postings;
+    postings["t1"] = cursor1;
+    postings["t2"] = cursor2;
+
+    auto result = unionAndCollect(postings, {"t1", "t2"}, 0, 300);
+    auto expected = generateRange(0, 300);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiCursorUnionFirstCoversAll)
+{
+    /// First cursor is dense (0..299), second is sparse (0,2,4,...).
+    /// The second cursor should skip everything via Level 2 coverage checks.
+    auto dense_docs = generateRange(0, 300);
+    auto sparse_docs = generateRange(0, 150, 2);  /// 0,2,4,...,298
+    auto data1 = makeMultiBlockData({dense_docs});
+    auto data2 = makeMultiBlockData({sparse_docs});
+    auto cursor1 = makeMultiBlockCursor(data1);
+    auto cursor2 = makeMultiBlockCursor(data2);
+
+    PostingListCursorMap postings;
+    postings["dense"] = cursor1;
+    postings["sparse"] = cursor2;
+
+    auto result = unionAndCollect(postings, {"dense", "sparse"}, 0, 300);
+    auto expected = generateRange(0, 300);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(PostingListCursorTest, MultiCursorPartialOverlap)
+{
+    /// First cursor covers 0..199 (dense), second covers 100..399 (dense).
+    /// Packed-block-level skip should handle the overlapping region 100..199.
+    auto docs1 = generateRange(0, 200);
+    auto docs2 = generateRange(100, 300);
+    auto data1 = makeMultiBlockData({docs1});
+    auto data2 = makeMultiBlockData({docs2});
+    auto cursor1 = makeMultiBlockCursor(data1);
+    auto cursor2 = makeMultiBlockCursor(data2);
+
+    PostingListCursorMap postings;
+    postings["t1"] = cursor1;
+    postings["t2"] = cursor2;
+
+    auto result = unionAndCollect(postings, {"t1", "t2"}, 0, 400);
+    auto expected = generateRange(0, 400);
+    EXPECT_EQ(result, expected);
+}


### PR DESCRIPTION
Changelog category (leave one):

Performance Improvement
Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Optimize linearOr with block-level coverage skip

Detailed description / Documentation draft:

Add three levels of skip optimization to linearOr that exploit existing
metadata (no format change required):

Level 1 — Dense large block memset: if block_doc_count equals the
range span, skip prepare (Index Section I/O) and all packed block
processing, replacing them with a single memset. For block 0,
block_doc_count is adjusted +1 because first_doc_id is stored
inline in the dictionary.

Level 2a — Already-covered large block skip: before prepare, check
if the output region is already all-ones via isAllOnes; if so, skip
the entire large block. This benefits multi-cursor OR (hasAnyTokens)
where a previous cursor already covered the region.

Level 2b — Already-covered packed block skip: inside linearOrImpl,
before probeAndDecodePackedBlock, check if the packed block's output
region is already all-ones; if so, skip seek + probe + decode.